### PR TITLE
Add hamburger menu for mobile navigation

### DIFF
--- a/src/components/Layout.astro
+++ b/src/components/Layout.astro
@@ -26,25 +26,64 @@ const { title } = Astro.props;
   </head>
   <body class="min-h-screen bg-white dark:bg-gray-950 text-gray-900 dark:text-gray-100 antialiased">
     <header class="border-b border-gray-200 dark:border-gray-800">
-      <nav class="mx-auto max-w-4xl px-4 py-4 flex items-center gap-6">
-        <a href="/" class="text-lg font-semibold">QECirc</a>
-        <a href="/codes" class="text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100">Codes</a>
-        <a href="/tools" class="text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100">Tools</a>
-        <a href="/contribute" class="text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100">Contribute</a>
-        <div class="ml-auto flex items-center gap-3">
-          <button
-            id="theme-toggle"
-            class="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 cursor-pointer"
-            aria-label="Toggle dark mode"
-          >
-            <svg class="w-4 h-4 dark:hidden" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
-            </svg>
-            <svg class="w-4 h-4 hidden dark:block" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <circle cx="12" cy="12" r="5" /><line x1="12" y1="1" x2="12" y2="3" /><line x1="12" y1="21" x2="12" y2="23" /><line x1="4.22" y1="4.22" x2="5.64" y2="5.64" /><line x1="18.36" y1="18.36" x2="19.78" y2="19.78" /><line x1="1" y1="12" x2="3" y2="12" /><line x1="21" y1="12" x2="23" y2="12" /><line x1="4.22" y1="19.78" x2="5.64" y2="18.36" /><line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
-            </svg>
-          </button>
-          <SearchBar />
+      <nav class="mx-auto max-w-4xl px-4 py-4">
+        <div class="flex items-center gap-6">
+          <a href="/" class="text-lg font-semibold">QECirc</a>
+          <a href="/codes" class="hidden sm:block text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100">Codes</a>
+          <a href="/tools" class="hidden sm:block text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100">Tools</a>
+          <a href="/contribute" class="hidden sm:block text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100">Contribute</a>
+          <div class="hidden sm:flex ml-auto items-center gap-3">
+            <button
+              id="theme-toggle"
+              class="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 cursor-pointer"
+              aria-label="Toggle dark mode"
+            >
+              <svg class="w-4 h-4 dark:hidden" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+              </svg>
+              <svg class="w-4 h-4 hidden dark:block" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="12" cy="12" r="5" /><line x1="12" y1="1" x2="12" y2="3" /><line x1="12" y1="21" x2="12" y2="23" /><line x1="4.22" y1="4.22" x2="5.64" y2="5.64" /><line x1="18.36" y1="18.36" x2="19.78" y2="19.78" /><line x1="1" y1="12" x2="3" y2="12" /><line x1="21" y1="12" x2="23" y2="12" /><line x1="4.22" y1="19.78" x2="5.64" y2="18.36" /><line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+              </svg>
+            </button>
+            <SearchBar />
+          </div>
+          <div class="sm:hidden ml-auto flex items-center gap-3">
+            <SearchBar />
+            <button
+              id="nav-toggle"
+              class="text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100"
+              aria-label="Toggle menu"
+              aria-expanded="false"
+            >
+              <svg class="nav-icon-open w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M4 6h16M4 12h16M4 18h16" />
+              </svg>
+              <svg class="nav-icon-close w-5 h-5 hidden" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div id="nav-menu" class="sm:hidden overflow-hidden transition-[max-height] duration-300 ease-in-out" style="max-height: 0px;">
+          <div class="pt-3 pb-1 flex flex-col gap-3">
+            <a href="/codes" class="text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100">Codes</a>
+            <a href="/tools" class="text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100">Tools</a>
+            <a href="/contribute" class="text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100">Contribute</a>
+            <div class="flex items-center">
+              <button
+                id="theme-toggle-mobile"
+                class="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 cursor-pointer"
+                aria-label="Toggle dark mode"
+              >
+                <svg class="w-4 h-4 dark:hidden" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+                </svg>
+                <svg class="w-4 h-4 hidden dark:block" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <circle cx="12" cy="12" r="5" /><line x1="12" y1="1" x2="12" y2="3" /><line x1="12" y1="21" x2="12" y2="23" /><line x1="4.22" y1="4.22" x2="5.64" y2="5.64" /><line x1="18.36" y1="18.36" x2="19.78" y2="19.78" /><line x1="1" y1="12" x2="3" y2="12" /><line x1="21" y1="12" x2="23" y2="12" /><line x1="4.22" y1="19.78" x2="5.64" y2="18.36" /><line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+                </svg>
+              </button>
+            </div>
+          </div>
         </div>
       </nav>
     </header>
@@ -57,10 +96,32 @@ const { title } = Astro.props;
       </div>
     </footer>
     <script is:inline>
-      document.getElementById("theme-toggle").addEventListener("click", function () {
+      function toggleTheme() {
         var dark = document.documentElement.classList.toggle("dark");
         localStorage.setItem("theme", dark ? "dark" : "light");
-      });
+      }
+      document.getElementById("theme-toggle").addEventListener("click", toggleTheme);
+      var mobileTheme = document.getElementById("theme-toggle-mobile");
+      if (mobileTheme) mobileTheme.addEventListener("click", toggleTheme);
+
+      var navToggle = document.getElementById("nav-toggle");
+      var navMenu = document.getElementById("nav-menu");
+      if (navToggle && navMenu) {
+        navToggle.addEventListener("click", function () {
+          var isOpen = navMenu.style.maxHeight !== "0px";
+          if (isOpen) {
+            navMenu.style.maxHeight = "0px";
+            navToggle.setAttribute("aria-expanded", "false");
+            navToggle.querySelector(".nav-icon-open").classList.remove("hidden");
+            navToggle.querySelector(".nav-icon-close").classList.add("hidden");
+          } else {
+            navMenu.style.maxHeight = navMenu.scrollHeight + "px";
+            navToggle.setAttribute("aria-expanded", "true");
+            navToggle.querySelector(".nav-icon-open").classList.add("hidden");
+            navToggle.querySelector(".nav-icon-close").classList.remove("hidden");
+          }
+        });
+      }
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- On narrow screens (<640px), nav links (Codes, Tools, Contribute) and theme toggle collapse into a hamburger menu
- Search bar stays visible in the header next to the hamburger button
- Slide-down panel with smooth max-height animation (same pattern as circuit rows)
- Desktop layout unchanged

## Test plan
- [ ] Resize browser to <640px: hamburger icon appears, nav links hidden
- [ ] Click hamburger: menu slides down with links and theme toggle
- [ ] Click X: menu closes
- [ ] Resize to desktop: hamburger gone, normal nav restored
- [ ] Theme toggle works in both mobile menu and desktop
- [ ] Search bar works on mobile
- [ ] Navigation links work from mobile menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)