### PR TITLE
feat: add HTTP Basic Auth for temporary access control

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,38 @@
+import { defineMiddleware } from "astro:middleware";
+import { timingSafeEqual } from "node:crypto";
+
+const SITE_PASSWORD = import.meta.env.SITE_PASSWORD || "";
+
+function safeEqual(a: string, b: string): boolean {
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) return false;
+  return timingSafeEqual(bufA, bufB);
+}
+
+const UNAUTHORIZED = new Response("Unauthorized", {
+  status: 401,
+  headers: { "WWW-Authenticate": 'Basic realm="QECirc"' },
+});
+
+export const onRequest = defineMiddleware((context, next) => {
+  if (!SITE_PASSWORD) return next();
+
+  const auth = context.request.headers.get("authorization");
+  if (auth) {
+    const [scheme, encoded] = auth.split(" ");
+    if (scheme?.toLowerCase() === "basic" && encoded) {
+      let decoded: string;
+      try {
+        decoded = atob(encoded);
+      } catch {
+        return UNAUTHORIZED;
+      }
+      const colonIndex = decoded.indexOf(":");
+      const password = decoded.substring(colonIndex + 1);
+      if (safeEqual(password, SITE_PASSWORD)) return next();
+    }
+  }
+
+  return UNAUTHORIZED;
+});


### PR DESCRIPTION
## Summary

- Adds Astro middleware (`src/middleware.ts`) that gates all requests behind HTTP Basic Auth
- Enabled by setting `SITE_PASSWORD` env var (e.g. on Railway); disabled when unset
- Temporary measure until legal pages (Impressum etc.) are in place
- To remove: delete `src/middleware.ts` and unset the env var

## Details

- Timing-safe password comparison via `node:crypto.timingSafeEqual`
- Handles colons in passwords, malformed base64, case-insensitive scheme matching
- Username can be anything — only the password is checked
- Changing the env var requires a server restart

## Test plan

- [ ] Set `SITE_PASSWORD=test` locally, run `npm run dev` — browser prompts for credentials
- [ ] Enter wrong password — stays on 401
- [ ] Enter correct password — site loads normally
- [ ] Unset `SITE_PASSWORD` — site loads without prompt
- [ ] `npm run build` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)