### PR TITLE
fix: critical audit follow-ups (qec_id, Node 24, version sync)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qecirc-website"
-version = "0.1.0"
+version = "0.2.3"
 description = "QECirc — quantum error correction circuit library"
 license = "MIT"
 requires-python = ">=3.13"

--- a/railpack.json
+++ b/railpack.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.railpack.com",
   "provider": "node",
   "packages": {
-    "node": "23"
+    "node": "24"
   },
   "deploy": {
     "startCommand": "node dist/server/entry.mjs"

--- a/scripts/add_circuit/__init__.py
+++ b/scripts/add_circuit/__init__.py
@@ -34,6 +34,7 @@ from .circuit_validate import (  # noqa: F401
 )
 from .compute import compute_code_data, compute_code_data_h
 from .compute_circuit import compute_circuit_data
+from .ids import next_qec_id
 from .helpers import (  # noqa: F401
     ExistingCodeMatch,
     check_code,
@@ -178,6 +179,7 @@ def add_circuit(
         tool=tool,
         notes=notes,
     )
+    circ_data["qec_id"] = next_qec_id(data_dir)
 
     # Collect files to write
     code_slug = code["slug"]

--- a/scripts/add_circuit/__init__.py
+++ b/scripts/add_circuit/__init__.py
@@ -34,7 +34,6 @@ from .circuit_validate import (  # noqa: F401
 )
 from .compute import compute_code_data, compute_code_data_h
 from .compute_circuit import compute_circuit_data
-from .ids import next_qec_id
 from .helpers import (  # noqa: F401
     ExistingCodeMatch,
     check_code,
@@ -45,6 +44,7 @@ from .helpers import (  # noqa: F401
     preview_circuit,
     summarize_circuit,
 )
+from .ids import next_qec_id
 from .models import ExtractedCode  # noqa: F401
 from .yaml_helpers import (
     build_circuit_yaml,

--- a/scripts/add_circuit/generate.py
+++ b/scripts/add_circuit/generate.py
@@ -18,10 +18,10 @@ import json
 from pathlib import Path
 
 import numpy as np
-import yaml
 
 from .compute import compute_code_data
 from .compute_circuit import compute_circuit_data
+from .ids import next_qec_id
 from .yaml_helpers import (
     build_circuit_yaml,
     build_code_yaml,
@@ -29,18 +29,6 @@ from .yaml_helpers import (
     dump_yaml,
     write_file,
 )
-
-
-def _next_qec_id(data_dir: Path) -> int:
-    """Return the next available qec_id by scanning existing circuit YAMLs."""
-    circuits_dir = data_dir / "circuits"
-    max_id = 0
-    if circuits_dir.exists():
-        for f in circuits_dir.glob("*.yaml"):
-            data = yaml.safe_load(f.read_text(encoding="utf-8"))
-            if data and isinstance(data.get("qec_id"), int):
-                max_id = max(max_id, data["qec_id"])
-    return max_id + 1
 
 
 def main():
@@ -96,7 +84,7 @@ def main():
         )
 
     # Compute circuit data for each STIM file
-    next_id = _next_qec_id(data_dir)
+    next_id = next_qec_id(data_dir)
     circuits = []
     for i, stim_path in enumerate(args.stim):
         circuit_text = Path(stim_path).read_text(encoding="utf-8")

--- a/scripts/add_circuit/ids.py
+++ b/scripts/add_circuit/ids.py
@@ -1,0 +1,21 @@
+"""Shared helpers for assigning permanent identifiers."""
+
+from pathlib import Path
+
+import yaml
+
+
+def next_qec_id(data_dir: Path) -> int:
+    """Return the next available qec_id by scanning existing circuit YAMLs.
+
+    qec_ids are permanent and never reused; this scans data_yaml/circuits/*.yaml
+    to find max(qec_id) and returns max + 1. Returns 1 if no circuits exist.
+    """
+    circuits_dir = Path(data_dir) / "circuits"
+    max_id = 0
+    if circuits_dir.exists():
+        for f in circuits_dir.glob("*.yaml"):
+            data = yaml.safe_load(f.read_text(encoding="utf-8"))
+            if data and isinstance(data.get("qec_id"), int):
+                max_id = max(max_id, data["qec_id"])
+    return max_id + 1

--- a/scripts/add_circuit/ids.py
+++ b/scripts/add_circuit/ids.py
@@ -8,8 +8,10 @@ import yaml
 def next_qec_id(data_dir: Path) -> int:
     """Return the next available qec_id by scanning existing circuit YAMLs.
 
-    qec_ids are permanent and never reused; this scans data_yaml/circuits/*.yaml
-    to find max(qec_id) and returns max + 1. Returns 1 if no circuits exist.
+    Scans data_yaml/circuits/*.yaml to find max(qec_id) and returns max + 1.
+    Returns 1 if no circuits exist. This avoids reusing IDs only while the
+    previously assigned circuit YAML files remain present on disk; deleting
+    the highest-id YAML would cause the next allocation to reuse that id.
     """
     circuits_dir = Path(data_dir) / "circuits"
     max_id = 0

--- a/scripts/tests/test_add_circuit_api.py
+++ b/scripts/tests/test_add_circuit_api.py
@@ -1,0 +1,70 @@
+"""Regression tests for the add_circuit() public Python API."""
+
+from pathlib import Path
+
+import numpy as np
+import yaml
+
+from scripts.add_circuit import add_circuit
+
+
+# Steane [[7,1,3]] CSS code — minimal valid input
+_STEANE_HX = np.array(
+    [
+        [1, 0, 0, 1, 0, 1, 1],
+        [0, 1, 0, 1, 1, 0, 1],
+        [0, 0, 1, 0, 1, 1, 1],
+    ],
+    dtype=int,
+)
+_STEANE_HZ = _STEANE_HX.copy()
+
+_TRIVIAL_STIM = "QUBIT_COORDS(0, 0) 0\nH 0\nTICK\n"
+
+
+def test_add_circuit_allocates_qec_id(tmp_path: Path) -> None:
+    """add_circuit must populate qec_id in the circuit YAML."""
+    result = add_circuit(
+        circuit=_TRIVIAL_STIM,
+        circuit_name="Trivial",
+        d=3,
+        Hx=_STEANE_HX,
+        Hz=_STEANE_HZ,
+        code_name="Steane Code",
+        data_dir=tmp_path,
+    )
+
+    circ_yaml_path = next(
+        p for p in result.files_written
+        if p.endswith(".yaml") and "/circuits/" in p and "originals" not in p
+    )
+    data = yaml.safe_load(Path(circ_yaml_path).read_text(encoding="utf-8"))
+
+    assert "qec_id" in data, f"qec_id missing from circuit YAML: {data}"
+    assert isinstance(data["qec_id"], int)
+    assert data["qec_id"] >= 1
+
+
+def test_add_circuit_qec_id_increments(tmp_path: Path) -> None:
+    """Adding two circuits must assign distinct, increasing qec_ids."""
+    r1 = add_circuit(
+        circuit=_TRIVIAL_STIM, circuit_name="First", d=3,
+        Hx=_STEANE_HX, Hz=_STEANE_HZ, code_name="Steane Code",
+        data_dir=tmp_path,
+    )
+    r2 = add_circuit(
+        circuit=_TRIVIAL_STIM + "X 0\n", circuit_name="Second", d=3,
+        Hx=_STEANE_HX, Hz=_STEANE_HZ, code_name="Steane Code",
+        data_dir=tmp_path,
+    )
+    p1 = next(
+        p for p in r1.files_written
+        if p.endswith(".yaml") and "/circuits/" in p and "originals" not in p
+    )
+    p2 = next(
+        p for p in r2.files_written
+        if p.endswith(".yaml") and "/circuits/" in p and "originals" not in p
+    )
+    id1 = yaml.safe_load(Path(p1).read_text(encoding="utf-8"))["qec_id"]
+    id2 = yaml.safe_load(Path(p2).read_text(encoding="utf-8"))["qec_id"]
+    assert id2 == id1 + 1

--- a/scripts/tests/test_add_circuit_api.py
+++ b/scripts/tests/test_add_circuit_api.py
@@ -36,7 +36,7 @@ def test_add_circuit_allocates_qec_id(tmp_path: Path) -> None:
     circ_yaml_path = next(
         p
         for p in result.files_written
-        if p.endswith(".yaml") and "/circuits/" in p and "originals" not in p
+        if p.endswith(".yaml") and "circuits" in Path(p).parts and "originals" not in Path(p).parts
     )
     data = yaml.safe_load(Path(circ_yaml_path).read_text(encoding="utf-8"))
 
@@ -68,12 +68,12 @@ def test_add_circuit_qec_id_increments(tmp_path: Path) -> None:
     p1 = next(
         p
         for p in r1.files_written
-        if p.endswith(".yaml") and "/circuits/" in p and "originals" not in p
+        if p.endswith(".yaml") and "circuits" in Path(p).parts and "originals" not in Path(p).parts
     )
     p2 = next(
         p
         for p in r2.files_written
-        if p.endswith(".yaml") and "/circuits/" in p and "originals" not in p
+        if p.endswith(".yaml") and "circuits" in Path(p).parts and "originals" not in Path(p).parts
     )
     id1 = yaml.safe_load(Path(p1).read_text(encoding="utf-8"))["qec_id"]
     id2 = yaml.safe_load(Path(p2).read_text(encoding="utf-8"))["qec_id"]

--- a/scripts/tests/test_add_circuit_api.py
+++ b/scripts/tests/test_add_circuit_api.py
@@ -7,7 +7,6 @@ import yaml
 
 from scripts.add_circuit import add_circuit
 
-
 # Steane [[7,1,3]] CSS code — minimal valid input
 _STEANE_HX = np.array(
     [
@@ -35,7 +34,8 @@ def test_add_circuit_allocates_qec_id(tmp_path: Path) -> None:
     )
 
     circ_yaml_path = next(
-        p for p in result.files_written
+        p
+        for p in result.files_written
         if p.endswith(".yaml") and "/circuits/" in p and "originals" not in p
     )
     data = yaml.safe_load(Path(circ_yaml_path).read_text(encoding="utf-8"))
@@ -48,21 +48,31 @@ def test_add_circuit_allocates_qec_id(tmp_path: Path) -> None:
 def test_add_circuit_qec_id_increments(tmp_path: Path) -> None:
     """Adding two circuits must assign distinct, increasing qec_ids."""
     r1 = add_circuit(
-        circuit=_TRIVIAL_STIM, circuit_name="First", d=3,
-        Hx=_STEANE_HX, Hz=_STEANE_HZ, code_name="Steane Code",
+        circuit=_TRIVIAL_STIM,
+        circuit_name="First",
+        d=3,
+        Hx=_STEANE_HX,
+        Hz=_STEANE_HZ,
+        code_name="Steane Code",
         data_dir=tmp_path,
     )
     r2 = add_circuit(
-        circuit=_TRIVIAL_STIM + "X 0\n", circuit_name="Second", d=3,
-        Hx=_STEANE_HX, Hz=_STEANE_HZ, code_name="Steane Code",
+        circuit=_TRIVIAL_STIM + "X 0\n",
+        circuit_name="Second",
+        d=3,
+        Hx=_STEANE_HX,
+        Hz=_STEANE_HZ,
+        code_name="Steane Code",
         data_dir=tmp_path,
     )
     p1 = next(
-        p for p in r1.files_written
+        p
+        for p in r1.files_written
         if p.endswith(".yaml") and "/circuits/" in p and "originals" not in p
     )
     p2 = next(
-        p for p in r2.files_written
+        p
+        for p in r2.files_written
         if p.endswith(".yaml") and "/circuits/" in p and "originals" not in p
     )
     id1 = yaml.safe_load(Path(p1).read_text(encoding="utf-8"))["qec_id"]

--- a/uv.lock
+++ b/uv.lock
@@ -874,7 +874,7 @@ wheels = [
 
 [[package]]
 name = "qecirc-website"
-version = "0.1.0"
+version = "0.2.3"
 source = { virtual = "." }
 dependencies = [
     { name = "mqt-qecc" },


### PR DESCRIPTION
## Summary
- **Fix `add_circuit()` Python API**: it never allocated a `qec_id`, so the resulting circuit YAML failed `npm run db:create` validation. Extracted `next_qec_id` from `generate.py` into a new shared module `scripts/add_circuit/ids.py` so both the CLI and the public Python API use the same allocator.
- **Bump `railpack.json` Node to 24** to match the `engines` field in `package.json` (`>=24.0.0`). Was `23`, would block Railway deploys.
- **Sync `pyproject.toml` version to 0.2.3** to match `package.json` (was `0.1.0`, ~10 patch releases stale).

## Test plan
- [x] `uv run pytest scripts/tests/` — 133/133 green
- [x] New regression tests `test_add_circuit_api.py::{test_add_circuit_allocates_qec_id, test_add_circuit_qec_id_increments}` pass
- [x] `uv run ruff check scripts/` — clean
- [x] `uv lock --check` — passes (project version updated to 0.2.3)
- [ ] Full Node build verified by CI

## Audit reference
First of five PRs from the 2026-04-30 project audit. Plan: \`docs/superpowers/plans/2026-04-30-audit-fixes.md\` (saved on a separate branch). PR1 contains the only deploy- and API-blocking findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)