### PR TITLE
chore: gitignore .coverage and .mypy_cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ __pycache__/
 *.pyc
 *.pyo
 .pytest_cache/
+.coverage
+.coverage.*
+.mypy_cache/
 
 # Node
 node_modules/


### PR DESCRIPTION
## Summary
Audit follow-up: pytest coverage artifacts and mypy cache were untracked-but-present in working trees and at risk of accidental commit. Added matching `.gitignore` entries.

## Test plan
- [x] `git check-ignore -v .coverage` matches the new rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)