### PR TITLE
fix(ingest): atomic UTF-8 writes in yaml_helpers

### DIFF
--- a/scripts/add_circuit/yaml_helpers.py
+++ b/scripts/add_circuit/yaml_helpers.py
@@ -1,5 +1,7 @@
 """YAML formatting helpers for code and circuit data."""
 
+import os
+import tempfile
 from pathlib import Path
 
 import yaml
@@ -102,10 +104,27 @@ def _convert_matrices(data):
 
 
 def write_file(fpath, content, quiet=False):
-    """Write a file, creating parent directories as needed."""
+    """Write a file atomically as UTF-8, creating parent directories as needed.
+
+    Writes to a temp file in the same directory and renames on success, so a
+    crash mid-write leaves the destination untouched.
+    """
     fpath = Path(fpath)
     fpath.parent.mkdir(parents=True, exist_ok=True)
     if not quiet:
         action = "Overwriting" if fpath.exists() else "Creating"
         print(f"  {action}: {fpath}")
-    fpath.write_text(content)
+
+    tmp_fd, tmp_name = tempfile.mkstemp(prefix=f".{fpath.name}.", suffix=".tmp", dir=fpath.parent)
+    try:
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_name, fpath)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise

--- a/scripts/add_circuit/yaml_helpers.py
+++ b/scripts/add_circuit/yaml_helpers.py
@@ -116,8 +116,9 @@ def write_file(fpath, content, quiet=False):
         print(f"  {action}: {fpath}")
 
     tmp_fd, tmp_name = tempfile.mkstemp(prefix=f".{fpath.name}.", suffix=".tmp", dir=fpath.parent)
+    os.close(tmp_fd)
     try:
-        with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
+        with open(tmp_name, "w", encoding="utf-8") as f:
             f.write(content)
             f.flush()
             os.fsync(f.fileno())

--- a/scripts/tests/test_yaml_helpers.py
+++ b/scripts/tests/test_yaml_helpers.py
@@ -1,0 +1,37 @@
+"""Tests for yaml_helpers.write_file atomicity and encoding."""
+
+from pathlib import Path
+
+from scripts.add_circuit.yaml_helpers import write_file
+
+
+def test_write_file_explicit_utf8(tmp_path: Path) -> None:
+    """write_file must write UTF-8 regardless of platform default encoding."""
+    target = tmp_path / "ünïcödé.yaml"
+    write_file(target, "name: étoilé\n", quiet=True)
+    assert target.read_bytes() == b"name: \xc3\xa9toil\xc3\xa9\n"
+
+
+def test_write_file_atomic_no_partial(tmp_path: Path, monkeypatch) -> None:
+    """If the write fails mid-way, the destination must be untouched."""
+    target = tmp_path / "out.yaml"
+    target.write_text("original\n", encoding="utf-8")
+
+    import os
+
+    original_replace = os.replace
+
+    def boom(src, dst):
+        raise RuntimeError("simulated mid-write crash")
+
+    monkeypatch.setattr(os, "replace", boom)
+
+    try:
+        write_file(target, "new content\n", quiet=True)
+    except RuntimeError:
+        pass
+
+    monkeypatch.setattr(os, "replace", original_replace)
+
+    # Original content preserved; no partial write
+    assert target.read_text(encoding="utf-8") == "original\n"

--- a/scripts/tests/test_yaml_helpers.py
+++ b/scripts/tests/test_yaml_helpers.py
@@ -9,7 +9,10 @@ def test_write_file_explicit_utf8(tmp_path: Path) -> None:
     """write_file must write UTF-8 regardless of platform default encoding."""
     target = tmp_path / "ünïcödé.yaml"
     write_file(target, "name: étoilé\n", quiet=True)
-    assert target.read_bytes() == b"name: \xc3\xa9toil\xc3\xa9\n"
+    # Substring check (rather than exact-bytes) avoids platform newline
+    # translation differences while still proving UTF-8 encoding of "étoilé".
+    raw = target.read_bytes()
+    assert b"\xc3\xa9toil\xc3\xa9" in raw, f"Expected UTF-8 'étoilé' in: {raw!r}"
 
 
 def test_write_file_atomic_no_partial(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- `write_file()` now writes to a temp file (in the same directory) and atomically renames on success — a crash mid-write no longer leaves half-written YAML in `data_yaml/`.
- Always writes UTF-8 explicitly (no reliance on platform default).
- Adds two regression tests in `scripts/tests/test_yaml_helpers.py` covering both behaviours.

## Test plan
- [x] `uv run pytest scripts/tests/test_yaml_helpers.py` — 2/2 green
- [x] Full suite: 133 → 135 (+2)
- [x] `uv run ruff check scripts/` — clean

## Audit reference
PR2 of five from the 2026-04-30 project audit. Plan: `docs/superpowers/plans/2026-04-30-audit-fixes.md`. Independent of PR1 (#29).

🤖 Generated with [Claude Code](https://claude.com/claude-code)