### PR TITLE
fix(utils): validate matrix shape in safeParseMatrix

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,10 +1,32 @@
-export function safeParseMatrix(json: string | null): number[][] | null {
+/**
+ * Parse a JSON-encoded 2D integer matrix.
+ *
+ * Optional `expectedRows` / `expectedCols` enforce shape. Values are also
+ * checked to be finite numbers; symplectic matrices should additionally pass
+ * 0/1 — caller can verify post-parse.
+ */
+export function safeParseMatrix(
+  json: string | null | undefined,
+  expectedRows?: number,
+  expectedCols?: number,
+): number[][] | null {
   if (!json) return null;
+  let parsed: unknown;
   try {
-    return JSON.parse(json);
+    parsed = JSON.parse(json);
   } catch {
     return null;
   }
+  if (!Array.isArray(parsed)) return null;
+  if (expectedRows !== undefined && parsed.length !== expectedRows) return null;
+  for (const row of parsed) {
+    if (!Array.isArray(row)) return null;
+    if (expectedCols !== undefined && row.length !== expectedCols) return null;
+    for (const v of row) {
+      if (typeof v !== "number" || !Number.isFinite(v)) return null;
+    }
+  }
+  return parsed as number[][];
 }
 
 // Convert a symplectic stabilizer matrix (rows × 2n) to Pauli strings.

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,9 +1,9 @@
 /**
- * Parse a JSON-encoded 2D integer matrix.
+ * Parse a JSON-encoded 2D numeric matrix.
  *
  * Optional `expectedRows` / `expectedCols` enforce shape. Values are also
- * checked to be finite numbers; symplectic matrices should additionally pass
- * 0/1 — caller can verify post-parse.
+ * checked to be finite numbers; callers that require integers or symplectic
+ * 0/1 entries should verify those constraints post-parse.
  */
 export function safeParseMatrix(
   json: string | null | undefined,

--- a/src/pages/circuits/[qec_id].astro
+++ b/src/pages/circuits/[qec_id].astro
@@ -45,8 +45,12 @@ const stimFilename = buildStimFilename({
   qubitCount: circuit.qubit_count,
 });
 
-const origH = original ? safeParseMatrix(original.original_h) : null;
-const origLogical = original ? safeParseMatrix(original.original_logical) : null;
+const origH = original
+  ? safeParseMatrix(original.original_h, circuit.code_n - circuit.code_k, 2 * circuit.code_n)
+  : null;
+const origLogical = original
+  ? safeParseMatrix(original.original_logical, 2 * circuit.code_k, 2 * circuit.code_n)
+  : null;
 const hasOriginalMatrices = !!(origH && origLogical);
 ---
 

--- a/src/pages/codes/[code].astro
+++ b/src/pages/codes/[code].astro
@@ -31,8 +31,8 @@ if (!code) {
 const tags = getTagsFor("code", code.id);
 const params = formatCodeParams(code);
 
-const h = safeParseMatrix(code.h);
-const logical = safeParseMatrix(code.logical);
+const h = safeParseMatrix(code.h, code.n - code.k, 2 * code.n);
+const logical = safeParseMatrix(code.logical, 2 * code.k, 2 * code.n);
 const hasMatrices = !!(h && logical);
 
 // Parse circuit filter and sort params


### PR DESCRIPTION
## Summary
- `safeParseMatrix` now optionally enforces row/column counts and that all values are finite numbers. Without dimension args, behaviour is unchanged for valid input but malformed JSON / non-arrays / non-numeric values are now rejected (was silently passed through).
- Callsites that know `n` and `k` from the surrounding code/circuit pass them so schema drift is caught early. Two callsites updated:
  - `src/pages/codes/[code].astro` — `code.h` and `code.logical`
  - `src/pages/circuits/[qec_id].astro` — `original_h` and `original_logical`

## Test plan
- [x] `npx tsc --noEmit` — no new errors in changed files (5 unrelated pre-existing errors confirmed against `main`)
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean

## Audit reference
PR5 of five from the 2026-04-30 project audit. Plan: `docs/superpowers/plans/2026-04-30-audit-fixes.md`. Independent of PR1 (#29).

🤖 Generated with [Claude Code](https://claude.com/claude-code)