### PR TITLE
refactor(frontend): consolidate helpers, fix clipboard race, a11y

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qecirc-website",
-  "version": "0.2.0",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qecirc-website",
-      "version": "0.2.0",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "@astrojs/node": "^10.0.3",

--- a/src/components/CircuitRow.astro
+++ b/src/components/CircuitRow.astro
@@ -289,10 +289,7 @@ const stimFilename = buildStimFilename({
         const qecId = btn.dataset.qecId;
         const url = location.origin + location.pathname + "#" + qecId;
         const ok = await copyToClipboard(url);
-        if (!ok) {
-          console.warn("Clipboard write failed");
-          return;
-        }
+        if (!ok) return;
         showCopyCheck(btn, ".permalink-label", ".permalink-check");
       });
     });
@@ -306,10 +303,7 @@ const stimFilename = buildStimFilename({
       btn.addEventListener("click", async function () {
         const qecId = btn.dataset.qecId;
         const ok = await copyToClipboard("#" + qecId);
-        if (!ok) {
-          console.warn("Clipboard write failed");
-          return;
-        }
+        if (!ok) return;
         showCopyCheck(btn, ".id-label", ".id-check");
       });
     });

--- a/src/components/CircuitRow.astro
+++ b/src/components/CircuitRow.astro
@@ -189,6 +189,8 @@ const stimFilename = buildStimFilename({
 </div>
 
 <script>
+  import { setFavState } from "../lib/dom-helpers";
+
   function initCircuitRows() {
     document.querySelectorAll(".circuit-toggle").forEach(function (btn) {
       if ((btn as HTMLElement).dataset.initialized) return;
@@ -321,24 +323,13 @@ const stimFilename = buildStimFilename({
         btn.dataset.favInit = "1";
 
         const qecId = Number(btn.dataset.qecId);
-        const outline = btn.querySelector(".fav-outline") as HTMLElement;
-        const filled = btn.querySelector(".fav-filled") as HTMLElement;
-
-        function setFavState(isFav: boolean) {
-          outline.classList.toggle("hidden", isFav);
-          filled.classList.toggle("hidden", !isFav);
-          btn.classList.toggle("text-red-400", isFav);
-          btn.classList.toggle("dark:text-red-400", isFav);
-          btn.classList.toggle("text-gray-300", !isFav);
-          btn.classList.toggle("dark:text-gray-600", !isFav);
-        }
 
         if (favSet.has(qecId)) {
-          setFavState(true);
+          setFavState(btn, true);
         }
 
         btn.addEventListener("click", function () {
-          setFavState(toggleFavorite(qecId));
+          setFavState(btn, toggleFavorite(qecId));
         });
       });
     });

--- a/src/components/CircuitRow.astro
+++ b/src/components/CircuitRow.astro
@@ -189,7 +189,7 @@ const stimFilename = buildStimFilename({
 </div>
 
 <script>
-  import { setFavState } from "../lib/dom-helpers";
+  import { copyToClipboard, setFavState } from "../lib/dom-helpers";
 
   function initCircuitRows() {
     document.querySelectorAll(".circuit-toggle").forEach(function (btn) {
@@ -288,9 +288,9 @@ const stimFilename = buildStimFilename({
       btn.addEventListener("click", async function () {
         const qecId = btn.dataset.qecId;
         const url = location.origin + location.pathname + "#" + qecId;
-        try {
-          await navigator.clipboard.writeText(url);
-        } catch {
+        const ok = await copyToClipboard(url);
+        if (!ok) {
+          console.warn("Clipboard write failed");
           return;
         }
         showCopyCheck(btn, ".permalink-label", ".permalink-check");
@@ -305,9 +305,9 @@ const stimFilename = buildStimFilename({
 
       btn.addEventListener("click", async function () {
         const qecId = btn.dataset.qecId;
-        try {
-          await navigator.clipboard.writeText("#" + qecId);
-        } catch {
+        const ok = await copyToClipboard("#" + qecId);
+        if (!ok) {
+          console.warn("Clipboard write failed");
           return;
         }
         showCopyCheck(btn, ".id-label", ".id-check");

--- a/src/components/CodeBlock.astro
+++ b/src/components/CodeBlock.astro
@@ -83,10 +83,7 @@ const formatted = lines
       btn.addEventListener("click", async function () {
         const code = (btn as HTMLElement).dataset.code || "";
         const ok = await copyToClipboard(code);
-        if (!ok) {
-          console.warn("Clipboard write failed");
-          return;
-        }
+        if (!ok) return;
         const label = btn.querySelector(".copy-label") as HTMLElement | null;
         if (label) {
           const original = label.textContent;

--- a/src/components/CodeBlock.astro
+++ b/src/components/CodeBlock.astro
@@ -60,6 +60,8 @@ const formatted = lines
 </div>
 
 <script>
+  import { copyToClipboard } from "../lib/dom-helpers";
+
   document.querySelectorAll<HTMLElement>("[data-code-block]:not([data-initialized])").forEach(function (block) {
     block.setAttribute("data-initialized", "");
 
@@ -78,9 +80,13 @@ const formatted = lines
     }
 
     block.querySelectorAll(".copy-btn").forEach(function (btn) {
-      btn.addEventListener("click", function () {
+      btn.addEventListener("click", async function () {
         const code = (btn as HTMLElement).dataset.code || "";
-        navigator.clipboard.writeText(code);
+        const ok = await copyToClipboard(code);
+        if (!ok) {
+          console.warn("Clipboard write failed");
+          return;
+        }
         const label = btn.querySelector(".copy-label") as HTMLElement | null;
         if (label) {
           const original = label.textContent;

--- a/src/components/KeyboardHelp.astro
+++ b/src/components/KeyboardHelp.astro
@@ -75,6 +75,8 @@ const SHORTCUTS: { keys: string[]; action: string }[] = [
 </div>
 
 <script>
+  import { isInputFocused } from "../lib/dom-helpers";
+
   const overlay = document.getElementById("keyboard-help");
   if (overlay) {
     const backdrop = overlay.querySelector(".kbd-help-backdrop");
@@ -102,16 +104,6 @@ const SHORTCUTS: { keys: string[]; action: string }[] = [
         previouslyFocused.focus();
       }
       previouslyFocused = null;
-    }
-
-    function isInputFocused(): boolean {
-      const a = document.activeElement;
-      return (
-        a instanceof HTMLInputElement ||
-        a instanceof HTMLTextAreaElement ||
-        a instanceof HTMLSelectElement ||
-        (a instanceof HTMLElement && a.isContentEditable)
-      );
     }
 
     document.addEventListener(

--- a/src/components/Layout.astro
+++ b/src/components/Layout.astro
@@ -182,8 +182,8 @@ const sunIconSvg = `<svg class="w-4 h-4 hidden dark:block" viewBox="0 0 24 24" f
       const navMenu = document.getElementById("nav-menu");
       if (navToggle && navMenu) {
         navToggle.addEventListener("click", function () {
-          const isOpen = navMenu.style.maxHeight !== "0px";
-          if (isOpen) {
+          const expanded = navToggle.getAttribute("aria-expanded") === "true";
+          if (expanded) {
             navMenu.style.maxHeight = "0px";
             navToggle.setAttribute("aria-expanded", "false");
             navToggle.querySelector(".nav-icon-open").classList.remove("hidden");

--- a/src/components/SearchBar.astro
+++ b/src/components/SearchBar.astro
@@ -37,17 +37,25 @@
   function hide() {
     resultsList.classList.add("hidden");
     activeIndex = -1;
+    input.removeAttribute("aria-activedescendant");
   }
 
   function updateActive() {
     const items = resultsList.querySelectorAll("li");
     items.forEach(function (item, i) {
-      if (i === activeIndex) {
+      const active = i === activeIndex;
+      item.setAttribute("aria-selected", active ? "true" : "false");
+      if (active) {
         item.classList.add("bg-gray-100", "dark:bg-gray-800");
       } else {
         item.classList.remove("bg-gray-100", "dark:bg-gray-800");
       }
     });
+    if (activeIndex >= 0 && items[activeIndex]) {
+      input.setAttribute("aria-activedescendant", (items[activeIndex] as HTMLElement).id);
+    } else {
+      input.removeAttribute("aria-activedescendant");
+    }
   }
 
   function navigateTo(href: string) {
@@ -73,9 +81,12 @@
       return;
     }
 
-    results.forEach(function (item) {
+    results.forEach(function (item, i) {
       const li = document.createElement("li");
       li.className = "px-3 py-2 text-sm cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800";
+      li.id = `search-result-${i}`;
+      li.setAttribute("role", "option");
+      li.setAttribute("aria-selected", "false");
       li.dataset.slug = item.slug;
       li.dataset.href = item.href;
 

--- a/src/components/SearchBar.astro
+++ b/src/components/SearchBar.astro
@@ -15,6 +15,8 @@
 </div>
 
 <script>
+  import { isInputFocused } from "../lib/dom-helpers";
+
   const container = document.getElementById("search-bar") as HTMLElement;
   const input = container.querySelector("input") as HTMLInputElement;
   const resultsList = container.querySelector("ul") as HTMLUListElement;
@@ -155,8 +157,7 @@
     w.__searchShortcutBound = true;
     document.addEventListener("keydown", function (e) {
       if (e.key !== "/") return;
-      const active = document.activeElement;
-      if (active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement || active instanceof HTMLSelectElement || (active instanceof HTMLElement && active.isContentEditable)) return;
+      if (isInputFocused()) return;
       e.preventDefault();
       const allInputs = document.querySelectorAll<HTMLInputElement>(".search-input");
       const visible = Array.from(allInputs).find(function (inp) { return inp.offsetParent !== null; });

--- a/src/components/SearchBar.astro
+++ b/src/components/SearchBar.astro
@@ -10,7 +10,12 @@
     autocomplete="off"
   />
   <kbd aria-hidden="true" class="search-hint pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-1.5 py-0.5 text-[10px] text-gray-400 dark:text-gray-500 font-sans">/</kbd>
-  <ul class="search-results absolute right-0 top-full mt-1 w-96 rounded border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-lg hidden z-50 max-h-80 overflow-y-auto">
+  <ul
+    class="search-results absolute right-0 top-full mt-1 w-96 rounded border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-lg hidden z-50 max-h-80 overflow-y-auto"
+    role="listbox"
+    aria-live="polite"
+    aria-label="Search results"
+  >
   </ul>
 </div>
 
@@ -23,6 +28,7 @@
 
   let debounceTimer: ReturnType<typeof setTimeout>;
   let activeIndex = -1;
+  let cachedItems: NodeListOf<HTMLLIElement> | HTMLLIElement[] = [];
 
   function show() {
     resultsList.classList.remove("hidden");
@@ -59,6 +65,7 @@
 
     resultsList.innerHTML = "";
     activeIndex = -1;
+    cachedItems = [];
 
     if (results.length === 0) {
       resultsList.innerHTML = '<li class="px-3 py-2 text-sm text-gray-400">No results</li>';
@@ -105,6 +112,7 @@
       resultsList.appendChild(li);
     });
 
+    cachedItems = resultsList.querySelectorAll<HTMLLIElement>("li[data-href]");
     show();
   }
 
@@ -117,7 +125,7 @@
   });
 
   input.addEventListener("keydown", function (e) {
-    const items = resultsList.querySelectorAll("li[data-href]");
+    const items = cachedItems;
     if (items.length === 0) return;
 
     if (e.key === "ArrowDown") {

--- a/src/lib/back-key-client.ts
+++ b/src/lib/back-key-client.ts
@@ -5,15 +5,7 @@
 // history.back() keeps the destination predictable when a user landed
 // on the page via a direct URL.
 
-function isInputFocused(): boolean {
-  const a = document.activeElement;
-  return (
-    a instanceof HTMLInputElement ||
-    a instanceof HTMLTextAreaElement ||
-    a instanceof HTMLSelectElement ||
-    (a instanceof HTMLElement && a.isContentEditable)
-  );
-}
+import { isInputFocused } from "./dom-helpers";
 
 export function initBackKey(backHref: string): () => void {
   function onKeydown(e: KeyboardEvent) {

--- a/src/lib/circuit-actions-client.ts
+++ b/src/lib/circuit-actions-client.ts
@@ -12,6 +12,8 @@
 // All bindings reuse the existing click handlers on the underlying buttons,
 // so no copy/download/format logic is duplicated here.
 
+import { isInputFocused } from "./dom-helpers";
+
 export interface CircuitActionsConfig {
   // Container selector in which to find the active code-block. Omit to
   // disable 1/2/3 + c/y + d (e.g. on `/favorites`, where rows aren't expanded).
@@ -21,16 +23,6 @@ export interface CircuitActionsConfig {
   // Page-level "favorite this circuit" button selector — bound to `f`. Used
   // on the circuit detail page where there is no list-keynav handling f.
   favoriteSelector?: string;
-}
-
-function isInputFocused(): boolean {
-  const a = document.activeElement;
-  return (
-    a instanceof HTMLInputElement ||
-    a instanceof HTMLTextAreaElement ||
-    a instanceof HTMLSelectElement ||
-    (a instanceof HTMLElement && a.isContentEditable)
-  );
 }
 
 export function initCircuitActions(config: CircuitActionsConfig): () => void {

--- a/src/lib/dom-helpers.ts
+++ b/src/lib/dom-helpers.ts
@@ -32,7 +32,8 @@ export async function copyToClipboard(text: string): Promise<boolean> {
   try {
     await navigator.clipboard.writeText(text);
     return true;
-  } catch {
+  } catch (err) {
+    console.warn("Failed to copy text to clipboard:", err);
     return false;
   }
 }

--- a/src/lib/dom-helpers.ts
+++ b/src/lib/dom-helpers.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared DOM utilities for client-side scripts.
+ */
+
+/** True if focus is on a text-input-like element where keyboard shortcuts should not fire. */
+export function isInputFocused(): boolean {
+  const el = document.activeElement;
+  if (!el) return false;
+  const tag = el.tagName;
+  if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+  return (el as HTMLElement).isContentEditable === true;
+}
+
+/** Apply the visual "favourite" state to a heart-icon toggle button. */
+export function setFavState(btn: HTMLElement, isFav: boolean): void {
+  const outline = btn.querySelector<HTMLElement>(".fav-outline");
+  const filled = btn.querySelector<HTMLElement>(".fav-filled");
+  if (outline) outline.classList.toggle("hidden", isFav);
+  if (filled) filled.classList.toggle("hidden", !isFav);
+  btn.classList.toggle("text-red-400", isFav);
+  btn.classList.toggle("dark:text-red-400", isFav);
+  btn.classList.toggle("text-gray-300", !isFav);
+  btn.classList.toggle("dark:text-gray-600", !isFav);
+}
+
+/**
+ * Copy `text` to clipboard. Returns boolean indicating success.
+ * Awaits the clipboard write so callers can drive UI off the actual outcome.
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  if (!navigator.clipboard) return false;
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/list-keynav-client.ts
+++ b/src/lib/list-keynav-client.ts
@@ -7,6 +7,8 @@
 // expand/collapse, favorite, and link navigation all behave exactly as they
 // do for mouse users. No logic is duplicated.
 
+import { isInputFocused } from "./dom-helpers";
+
 export interface ListKeynavConfig {
   // CSS selector for the focusable rows in the list.
   rowSelector: string;
@@ -31,16 +33,6 @@ export interface ListKeynavConfig {
   // (so /codes/foo#42 focuses the row whose [hashAttr] === "42").
   // Default: "id".
   hashAttr?: string;
-}
-
-function isInputFocused(): boolean {
-  const a = document.activeElement;
-  return (
-    a instanceof HTMLInputElement ||
-    a instanceof HTMLTextAreaElement ||
-    a instanceof HTMLSelectElement ||
-    (a instanceof HTMLElement && a.isContentEditable)
-  );
 }
 
 export function initListKeynav(config: ListKeynavConfig): () => void {

--- a/src/pages/circuits/[qec_id].astro
+++ b/src/pages/circuits/[qec_id].astro
@@ -176,6 +176,7 @@ const hasOriginalMatrices = !!(origH && origLogical);
 <script>
   import { initCircuitActions } from "../../lib/circuit-actions-client";
   import { initBackKey } from "../../lib/back-key-client";
+  import { setFavState } from "../../lib/dom-helpers";
 
   // The page contains exactly one circuit body; main is the natural container.
   // `f` toggles this circuit's favorite (the heart in the title row).
@@ -192,22 +193,11 @@ const hasOriginalMatrices = !!(origH && origLogical);
   if (favBtn) {
     import("../../lib/favorites-client").then(function ({ isFavorite, toggleFavorite }) {
       const qecId = Number(favBtn.dataset.qecId);
-      const outline = favBtn.querySelector(".fav-outline") as HTMLElement;
-      const filled = favBtn.querySelector(".fav-filled") as HTMLElement;
 
-      function setFavState(isFav: boolean) {
-        outline.classList.toggle("hidden", isFav);
-        filled.classList.toggle("hidden", !isFav);
-        favBtn.classList.toggle("text-red-400", isFav);
-        favBtn.classList.toggle("dark:text-red-400", isFav);
-        favBtn.classList.toggle("text-gray-300", !isFav);
-        favBtn.classList.toggle("dark:text-gray-600", !isFav);
-      }
-
-      setFavState(isFavorite(qecId));
+      setFavState(favBtn, isFavorite(qecId));
 
       favBtn.addEventListener("click", function () {
-        setFavState(toggleFavorite(qecId));
+        setFavState(favBtn, toggleFavorite(qecId));
       });
     });
   }


### PR DESCRIPTION
## Summary
- New `src/lib/dom-helpers.ts` consolidates `isInputFocused` (was duplicated 5×) and `setFavState` (was duplicated 2×). Adds an awaited `copyToClipboard` helper.
- **Real UX bug fix**: `CodeBlock.astro` no longer claims "Copied!" before/regardless of the clipboard write resolving — now awaits and only shows success on actual success. Same pattern applied to the two `CircuitRow.astro` copy buttons (which already awaited but had silent empty catch blocks; now `console.warn` on failure).
- **Mobile nav** (`Layout.astro`): use `aria-expanded` as state truth instead of an inline-style string check.
- **Search a11y**: `<ul role="listbox" aria-live="polite" aria-label="Search results">` so screen readers announce new results. Cache item NodeList once per render instead of re-querying on every keystroke.

## Notable deviations from the plan (intentional)
- `setFavState` uses the existing stable JS-hook classes `.fav-outline` / `.fav-filled` rather than introducing parallel `[data-fav-*]` attributes — less markup churn.
- `isInputFocused` uses `tagName === "INPUT"` checks instead of `instanceof HTMLInputElement` — functionally equivalent, marginally more robust across iframes.

## Lockfile note
Commit `66b4bf9` includes a 4-line `package-lock.json` sync (0.2.0 → 0.2.3) — pre-existing drift from earlier `package.json` patch bumps that npm install corrected during worktree setup. Benign, just landed in the wrong commit.

## Test plan
- [x] `npx tsc --noEmit` — only the 5 unrelated pre-existing errors (verified vs `main`)
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [ ] Manual smoke (recommended): copy buttons (CodeBlock, permalink, qec_id), mobile hamburger toggle, search keyboard nav (arrow + Enter), favourites toggle/sync between row and detail page

## Audit reference
PR4 of five from the 2026-04-30 project audit. Plan: `docs/superpowers/plans/2026-04-30-audit-fixes.md`. Independent of PR1 (#29).

🤖 Generated with [Claude Code](https://claude.com/claude-code)