### PR TITLE
docs(versioning): list files that must mirror package.json version

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,15 @@ convention (currently `0.x.y`):
 
 Bump the version in the same PR that ships the change.
 
+**Files to update together with `package.json` `version`:**
+
+- `pyproject.toml` `version` field
+- `uv.lock` (run `UV_NO_CONFIG=1 uv lock`)
+- `package-lock.json` (npm syncs this on `npm install`; commit if it drifted)
+
+**When bumping `engines.node` in `package.json`** (Node major version),
+also update `railpack.json` `packages.node` to the same major.
+
 ---
 
 ## Licensing


### PR DESCRIPTION
## Summary
The 2026-04-30 audit found that \`pyproject.toml\` had drifted to \`0.1.0\` while \`package.json\` was \`0.2.3\` (~10 patch releases stale), and \`railpack.json\` Node was \`23\` while \`engines.node\` required \`>=24\`. Both drifts were caused by the version-bump checklist in CLAUDE.md not naming the mirror files.

This PR adds a short checklist to the Versioning section so the same drift doesn't happen again on the next bump.

## Test plan
- [x] No code changes — doc-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)