### PR TITLE
perf(codes): skip & lazy-load h/logical matrices to cut SSR memory

### DIFF
--- a/src/components/CodeMatrices.astro
+++ b/src/components/CodeMatrices.astro
@@ -1,159 +1,94 @@
 ---
 import { TAB_ACTIVE_CLASS, TAB_INACTIVE_CLASS } from "../lib/constants";
-import { formatMatrixRows, splitHToCss, splitLogicalToCss, symplecticToPauli } from "../lib/utils";
 
 interface Props {
-  n: number;
-  k: number;
-  h: number[][];
-  logical: number[][];
+  /**
+   * URL of the JSON endpoint returning `{ n, k, h, logical }` for this
+   * matrices block. Matrices are loaded lazily on first expand of the
+   * wrapping CollapsibleSection so the multi-MB JSON for large codes
+   * (e.g. [[144,12,12]]) never ships in the initial page HTML.
+   */
+  dataUrl: string;
   // Prefix applied to "Stabilizers" / "Logical operators" headings.
   prefix?: string;
   // Stable id for the toggle group; required when more than one CodeMatrices
   // renders on the same page.
   id?: string;
-  defaultView?: "pauli" | "symplectic" | "hxhz";
 }
 
-const { n, k, h, logical, prefix = "", id = "code-matrices", defaultView = "pauli" } = Astro.props;
-
-// Derive the CSS view from the symplectic h/logical at render time. Both
-// splits must succeed for the Hx/Hz tab to be offered — for a row-CSS h paired
-// with mixed-support logicals we conservatively hide CSS rather than show
-// inconsistent halves.
-const splitH = splitHToCss(h, n);
-const splitLogical = splitLogicalToCss(logical, n, k);
-const isCss = splitH !== null && splitLogical !== null;
-const hx = splitH?.hx ?? null;
-const hz = splitH?.hz ?? null;
-const logicalX = splitLogical?.logicalX ?? null;
-const logicalZ = splitLogical?.logicalZ ?? null;
-const view = !isCss && defaultView === "hxhz" ? "pauli" : defaultView;
-
-// ---------------------------------------------------------------------------
-// Render helpers
-// ---------------------------------------------------------------------------
-
-function paulisJoined(matrix: number[][]): string {
-  return symplecticToPauli(matrix, n).join("\n");
-}
-
-function symplecticJoined(matrix: number[][]): string {
-  const flat = matrix.flat();
-  const colWidth = flat.length > 0 ? Math.max(...flat.map((v) => String(v).length)) : 1;
-  const padCells = (cells: number[]) =>
-    cells.map((v) => String(v).padStart(colWidth, " ")).join("  ");
-  return matrix
-    .map((row) => `[ ${padCells(row.slice(0, n))} │ ${padCells(row.slice(n, 2 * n))} ]`)
-    .join("\n");
-}
-
-// CSS Hx/Hz view: two labelled matrix groups inside a single <pre>, sharing
-// the same styling as the other views. Sub-labels keep "[ row ]" formatting
-// consistent and the two groups are separated by a blank line.
-function hxhzJoined(blocks: { label: string; matrix: number[][] }[]): string {
-  return blocks
-    .map(({ label, matrix }) => `${label}\n${formatMatrixRows(matrix).join("\n")}`)
-    .join("\n\n");
-}
-
-// Paste-ready np.array(...) literal.
-function numpyArray(matrix: number[][]): string {
-  if (matrix.length === 0) return "np.array([])";
-  const rows = matrix.map((row) => `    [${row.join(", ")}],`).join("\n");
-  return `np.array([\n${rows}\n])`;
-}
-
-function numpyAssign(blocks: { name: string; matrix: number[][] }[]): string {
-  return blocks.map(({ name, matrix }) => `${name} = ${numpyArray(matrix)}`).join("\n\n");
-}
-
-// ---------------------------------------------------------------------------
-// Pre-computed pane strings
-// ---------------------------------------------------------------------------
-
-const stabPauli = paulisJoined(h);
-const stabSymplecticHuman = symplecticJoined(h);
-const stabSymplecticNumpy = numpyAssign([{ name: "H", matrix: h }]);
-const stabHxHzHuman = isCss
-  ? hxhzJoined([
-      { label: "Hx (X-checks)", matrix: hx! },
-      { label: "Hz (Z-checks)", matrix: hz! },
-    ])
-  : "";
-const stabHxHzNumpy = isCss
-  ? numpyAssign([
-      { name: "Hx", matrix: hx! },
-      { name: "Hz", matrix: hz! },
-    ])
-  : "";
-
-const logicalPauli = paulisJoined(logical);
-const logicalSymplecticHuman = symplecticJoined(logical);
-const logicalSymplecticNumpy = numpyAssign([{ name: "L", matrix: logical }]);
-const logicalHxHzHuman = isCss
-  ? hxhzJoined([
-      { label: "Logical X", matrix: logicalX! },
-      { label: "Logical Z", matrix: logicalZ! },
-    ])
-  : "";
-const logicalHxHzNumpy = isCss
-  ? numpyAssign([
-      { name: "Lx", matrix: logicalX! },
-      { name: "Lz", matrix: logicalZ! },
-    ])
-  : "";
+const { dataUrl, prefix = "", id = "code-matrices" } = Astro.props;
 
 const stabLabel = `${prefix}Stabilizers`;
 const logicalLabel = `${prefix}Logical operators`;
 
-// Tab descriptors so the template stays uniform across views.
-const tabs: { view: "pauli" | "symplectic" | "hxhz"; label: string; show: boolean }[] = [
-  { view: "pauli", label: "Pauli", show: true },
-  { view: "symplectic", label: "Symplectic", show: true },
-  { view: "hxhz", label: "Hx/Hz", show: isCss },
+// Tab descriptors. The Hx/Hz tab is always rendered server-side because we
+// don't know is-CSS without parsing the matrices; the client hides it after
+// fetch if the code isn't CSS-decomposable.
+const tabs: { view: "pauli" | "symplectic" | "hxhz"; label: string }[] = [
+  { view: "pauli", label: "Pauli" },
+  { view: "symplectic", label: "Symplectic" },
+  { view: "hxhz", label: "Hx/Hz" },
 ];
+
+// Server-side initial view is always "pauli" (works for any code, CSS or
+// not). Client takes over for subsequent tab interactions.
+const initialView: "pauli" | "symplectic" | "hxhz" = "pauli";
+const initialFormat: "human" | "numpy" = "human";
+const isPauliInitial = initialView === ("pauli" as typeof initialView);
 
 const paneClass =
   "code-matrix-pane text-sm leading-relaxed font-mono bg-gray-50 dark:bg-gray-900 rounded border border-gray-200 dark:border-gray-800 px-3 py-2 overflow-x-auto";
 
-// Initial format is "human"; NumPy button starts inactive.
-const format: "human" | "numpy" = "human";
-const isPauli = (v: typeof view) => v === "pauli";
+// All pane combinations (stab × {pauli, symplectic.human, symplectic.numpy,
+// hxhz.human, hxhz.numpy} × {stab, logical}). The Pauli view has no NUMPY
+// variant — the toolbar hides the NUMPY button when Pauli is active.
+const panes: { pane: "stab" | "logical"; view: string; format: "human" | "numpy" }[] = [];
+for (const pane of ["stab", "logical"] as const) {
+  panes.push({ pane, view: "pauli", format: "human" });
+  panes.push({ pane, view: "symplectic", format: "human" });
+  panes.push({ pane, view: "symplectic", format: "numpy" });
+  panes.push({ pane, view: "hxhz", format: "human" });
+  panes.push({ pane, view: "hxhz", format: "numpy" });
+}
+
+const stabPanes = panes.filter((p) => p.pane === "stab");
+const logicalPanes = panes.filter((p) => p.pane === "logical");
+
+function isPaneActive(view: string, format: "human" | "numpy"): boolean {
+  if (view !== initialView) return false;
+  if (view === "pauli") return format === "human";
+  return format === initialFormat;
+}
 ---
 
-<div data-code-matrices={id}>
+<div data-code-matrices={id} data-data-url={dataUrl}>
   <div class="flex items-center justify-between gap-2 mb-3">
     <div class="flex gap-0.5" role="tablist" aria-label="Matrix display format">
-      {
-        tabs
-          .filter((t) => t.show)
-          .map((tab) => (
-            <button
-              type="button"
-              class:list={[
-                "code-matrix-toggle px-3 py-1.5 text-xs font-semibold rounded-md cursor-pointer transition-colors focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500",
-                view === tab.view ? TAB_ACTIVE_CLASS : TAB_INACTIVE_CLASS,
-              ]}
-              data-target={id}
-              data-view={tab.view}
-              aria-pressed={view === tab.view}
-            >
-              {tab.label.toUpperCase()}
-            </button>
-          ))
-      }
+      {tabs.map((tab) => (
+        <button
+          type="button"
+          class:list={[
+            "code-matrix-toggle px-3 py-1.5 text-xs font-semibold rounded-md cursor-pointer transition-colors focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500",
+            initialView === tab.view ? TAB_ACTIVE_CLASS : TAB_INACTIVE_CLASS,
+          ]}
+          data-target={id}
+          data-view={tab.view}
+          aria-pressed={initialView === tab.view}
+        >
+          {tab.label.toUpperCase()}
+        </button>
+      ))}
     </div>
     <button
       type="button"
       class:list={[
         "code-matrix-numpy px-3 py-1.5 text-xs font-semibold rounded-md cursor-pointer transition-colors focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500",
-        format === "numpy" ? TAB_ACTIVE_CLASS : TAB_INACTIVE_CLASS,
+        TAB_INACTIVE_CLASS,
       ]}
       data-target={id}
-      aria-pressed={format === "numpy"}
+      aria-pressed="false"
       title="Show as np.array(...) for direct paste into Python"
-      hidden={isPauli(view)}
+      hidden={isPauliInitial}
     >
       NUMPY
     </button>
@@ -161,108 +96,46 @@ const isPauli = (v: typeof view) => v === "pauli";
 
   <div class="mb-4">
     <p class="text-xs text-gray-500 dark:text-gray-400 mb-1 font-medium">{stabLabel}</p>
-    <pre
-      class={paneClass}
-      data-target={id}
-      data-pane="stab"
-      data-view="pauli"
-      data-format="human"
-      hidden={view !== "pauli"}
-    ><code set:text={stabPauli} /></pre>
-    <pre
-      class={paneClass}
-      data-target={id}
-      data-pane="stab"
-      data-view="symplectic"
-      data-format="human"
-      hidden={view !== "symplectic" || format !== "human"}
-    ><code set:text={stabSymplecticHuman} /></pre>
-    <pre
-      class={paneClass}
-      data-target={id}
-      data-pane="stab"
-      data-view="symplectic"
-      data-format="numpy"
-      hidden={view !== "symplectic" || format !== "numpy"}
-    ><code set:text={stabSymplecticNumpy} /></pre>
-    {isCss && (
+    {stabPanes.map(({ pane, view, format }) => (
       <pre
-        class={paneClass}
+        class={`${paneClass} code-matrix-pending`}
         data-target={id}
-        data-pane="stab"
-        data-view="hxhz"
-        data-format="human"
-        hidden={view !== "hxhz" || format !== "human"}
-      ><code set:text={stabHxHzHuman} /></pre>
-    )}
-    {isCss && (
-      <pre
-        class={paneClass}
-        data-target={id}
-        data-pane="stab"
-        data-view="hxhz"
-        data-format="numpy"
-        hidden={view !== "hxhz" || format !== "numpy"}
-      ><code set:text={stabHxHzNumpy} /></pre>
-    )}
+        data-pane={pane}
+        data-view={view}
+        data-format={format}
+        hidden={!isPaneActive(view, format)}
+      ><code>Loading matrices&hellip;</code></pre>
+    ))}
   </div>
 
   <div>
     <p class="text-xs text-gray-500 dark:text-gray-400 mb-1 font-medium">{logicalLabel}</p>
-    <pre
-      class={paneClass}
-      data-target={id}
-      data-pane="logical"
-      data-view="pauli"
-      data-format="human"
-      hidden={view !== "pauli"}
-    ><code set:text={logicalPauli} /></pre>
-    <pre
-      class={paneClass}
-      data-target={id}
-      data-pane="logical"
-      data-view="symplectic"
-      data-format="human"
-      hidden={view !== "symplectic" || format !== "human"}
-    ><code set:text={logicalSymplecticHuman} /></pre>
-    <pre
-      class={paneClass}
-      data-target={id}
-      data-pane="logical"
-      data-view="symplectic"
-      data-format="numpy"
-      hidden={view !== "symplectic" || format !== "numpy"}
-    ><code set:text={logicalSymplecticNumpy} /></pre>
-    {isCss && (
+    {logicalPanes.map(({ pane, view, format }) => (
       <pre
-        class={paneClass}
+        class={`${paneClass} code-matrix-pending`}
         data-target={id}
-        data-pane="logical"
-        data-view="hxhz"
-        data-format="human"
-        hidden={view !== "hxhz" || format !== "human"}
-      ><code set:text={logicalHxHzHuman} /></pre>
-    )}
-    {isCss && (
-      <pre
-        class={paneClass}
-        data-target={id}
-        data-pane="logical"
-        data-view="hxhz"
-        data-format="numpy"
-        hidden={view !== "hxhz" || format !== "numpy"}
-      ><code set:text={logicalHxHzNumpy} /></pre>
-    )}
+        data-pane={pane}
+        data-view={view}
+        data-format={format}
+        hidden={!isPaneActive(view, format)}
+      ><code>Loading matrices&hellip;</code></pre>
+    ))}
   </div>
 </div>
 
 <script>
   import { TAB_ACTIVE_CLASS, TAB_INACTIVE_CLASS } from "../lib/constants";
+  import { splitHToCss, splitLogicalToCss } from "../lib/utils";
+  import {
+    paulisJoined,
+    symplecticJoined,
+    hxhzJoined,
+    numpyAssign,
+  } from "../lib/code-matrices-format";
 
-  // Component-specific class names (`code-matrix-toggle`, `code-matrix-numpy`)
-  // are appended in setClass() at the call site; only the shared tab styling
-  // lives here so it stays in lockstep with FormatSwitcher.
-  const BASE_TAB_CLASS = "px-3 py-1.5 text-xs font-semibold rounded-md cursor-pointer transition-colors focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500";
+  // Shared tab styling — keep in lockstep with the Astro template above.
+  const BASE_TAB_CLASS =
+    "px-3 py-1.5 text-xs font-semibold rounded-md cursor-pointer transition-colors focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500";
   const ACTIVE_CLASS = `${BASE_TAB_CLASS} ${TAB_ACTIVE_CLASS}`;
   const INACTIVE_CLASS = `${BASE_TAB_CLASS} ${TAB_INACTIVE_CLASS}`;
 
@@ -302,7 +175,140 @@ const isPauli = (v: typeof view) => v === "pauli";
     }
   }
 
-  // View tabs (Pauli / Symplectic / Hx-Hz).
+  // ---------------------------------------------------------------------------
+  // Lazy fetch + populate panes on first expand of the wrapping collapsible.
+  // ---------------------------------------------------------------------------
+
+  type MatricesResponse = { n: number; k: number; h: number[][]; logical: number[][] };
+
+  const loaded = new WeakSet<HTMLElement>();
+
+  function populatePanes(root: HTMLElement, data: MatricesResponse): void {
+    const { n, k, h, logical } = data;
+    const splitH = splitHToCss(h, n);
+    const splitLogical = splitLogicalToCss(logical, n, k);
+    const isCss = splitH !== null && splitLogical !== null;
+    const id = root.dataset.codeMatrices ?? "";
+    const sel = `[data-target="${CSS.escape(id)}"]`;
+
+    // Hide the Hx/Hz tab and remove its panes for non-CSS codes.
+    if (!isCss) {
+      const hxhzTab = root.querySelector<HTMLButtonElement>(
+        `.code-matrix-toggle[data-view="hxhz"]`,
+      );
+      if (hxhzTab) hxhzTab.hidden = true;
+      for (const pane of root.querySelectorAll<HTMLElement>(
+        `.code-matrix-pane[data-view="hxhz"]`,
+      )) {
+        pane.remove();
+      }
+    }
+
+    // Fill the panes.
+    const writePane = (pane: "stab" | "logical", view: string, format: string, text: string) => {
+      const el = root.querySelector<HTMLElement>(
+        `.code-matrix-pane[data-pane="${pane}"][data-view="${view}"][data-format="${format}"]`,
+      );
+      if (!el) return;
+      const code = el.querySelector("code") ?? el;
+      code.textContent = text;
+      el.classList.remove("code-matrix-pending");
+    };
+
+    writePane("stab", "pauli", "human", paulisJoined(h, n));
+    writePane("stab", "symplectic", "human", symplecticJoined(h, n));
+    writePane("stab", "symplectic", "numpy", numpyAssign([{ name: "H", matrix: h }]));
+    writePane("logical", "pauli", "human", paulisJoined(logical, n));
+    writePane("logical", "symplectic", "human", symplecticJoined(logical, n));
+    writePane("logical", "symplectic", "numpy", numpyAssign([{ name: "L", matrix: logical }]));
+
+    if (isCss && splitH && splitLogical) {
+      writePane(
+        "stab",
+        "hxhz",
+        "human",
+        hxhzJoined([
+          { label: "Hx (X-checks)", matrix: splitH.hx },
+          { label: "Hz (Z-checks)", matrix: splitH.hz },
+        ]),
+      );
+      writePane(
+        "stab",
+        "hxhz",
+        "numpy",
+        numpyAssign([
+          { name: "Hx", matrix: splitH.hx },
+          { name: "Hz", matrix: splitH.hz },
+        ]),
+      );
+      writePane(
+        "logical",
+        "hxhz",
+        "human",
+        hxhzJoined([
+          { label: "Logical X", matrix: splitLogical.logicalX },
+          { label: "Logical Z", matrix: splitLogical.logicalZ },
+        ]),
+      );
+      writePane(
+        "logical",
+        "hxhz",
+        "numpy",
+        numpyAssign([
+          { name: "Lx", matrix: splitLogical.logicalX },
+          { name: "Lz", matrix: splitLogical.logicalZ },
+        ]),
+      );
+    }
+
+    syncPanes(sel);
+    syncCollapsible(root.parentElement);
+  }
+
+  function showError(root: HTMLElement, message: string): void {
+    for (const pane of root.querySelectorAll<HTMLElement>(".code-matrix-pane.code-matrix-pending")) {
+      const code = pane.querySelector("code") ?? pane;
+      code.textContent = message;
+    }
+  }
+
+  async function loadMatrices(root: HTMLElement): Promise<void> {
+    if (loaded.has(root)) return;
+    loaded.add(root);
+    const url = root.dataset.dataUrl;
+    if (!url) return;
+    try {
+      const res = await fetch(url);
+      if (!res.ok) {
+        loaded.delete(root); // allow a fresh expand to retry
+        showError(root, "Failed to load matrices — refresh to retry.");
+        return;
+      }
+      const data = (await res.json()) as MatricesResponse;
+      populatePanes(root, data);
+    } catch {
+      loaded.delete(root);
+      showError(root, "Failed to load matrices — refresh to retry.");
+    }
+  }
+
+  for (const root of document.querySelectorAll<HTMLElement>("[data-code-matrices]")) {
+    const detail = root.closest<HTMLElement>("[data-collapsible-detail]");
+    if (!detail) {
+      // No collapsible wrapper (shouldn't happen in practice) — load eagerly.
+      loadMatrices(root);
+      continue;
+    }
+    detail.addEventListener("collapsible-open", () => {
+      void loadMatrices(root);
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Toolbar interactions (unchanged behaviour, attached to server-rendered
+  // buttons — these exist whether or not matrices have loaded yet).
+  // ---------------------------------------------------------------------------
+
   for (const btn of document.querySelectorAll<HTMLButtonElement>(".code-matrix-toggle")) {
     btn.addEventListener("click", () => {
       const target = btn.dataset.target;
@@ -318,10 +324,7 @@ const isPauli = (v: typeof view) => v === "pauli";
         peer.className = `code-matrix-toggle ${isActive ? ACTIVE_CLASS : INACTIVE_CLASS}`;
       }
 
-      // The NumPy toggle is meaningless on Pauli — hide it. Also reset its
-      // pressed state, otherwise activeFormatFor() would still report "numpy"
-      // and syncPanes() would hide the Pauli pane (which only has
-      // data-format="human"), leaving no pane visible.
+      // NumPy is meaningless on Pauli — hide it and reset its pressed state.
       const numpyBtn = document.querySelector<HTMLButtonElement>(
         `.code-matrix-numpy${sel}`,
       );
@@ -339,7 +342,6 @@ const isPauli = (v: typeof view) => v === "pauli";
     });
   }
 
-  // NumPy toggle.
   for (const btn of document.querySelectorAll<HTMLButtonElement>(".code-matrix-numpy")) {
     btn.addEventListener("click", () => {
       const target = btn.dataset.target;

--- a/src/components/CollapsibleSection.astro
+++ b/src/components/CollapsibleSection.astro
@@ -31,6 +31,7 @@ const detailId = `${id}-detail`;
   </button>
   <div
     id={detailId}
+    data-collapsible-detail
     class="overflow-hidden transition-[max-height] duration-300 ease-in-out"
     style={open ? undefined : "max-height: 0px;"}
   >

--- a/src/lib/code-matrices-format.ts
+++ b/src/lib/code-matrices-format.ts
@@ -1,0 +1,48 @@
+/**
+ * Pure formatting helpers used by `<CodeMatrices>` to render symplectic
+ * stabilizer / logical-operator matrices into the various display formats.
+ *
+ * Extracted from CodeMatrices.astro so the same helpers run in both the
+ * Astro (server) module graph and the client-side script that lazy-loads
+ * matrices on first expand of the collapsible.
+ */
+
+import { formatMatrixRows, symplecticToPauli } from "./utils";
+
+/** Join one row per line of Pauli-formatted stabilizers / logicals. */
+export function paulisJoined(matrix: number[][], n: number): string {
+  return symplecticToPauli(matrix, n).join("\n");
+}
+
+/** Symplectic view: pad cells, split X/Z halves with `│`. */
+export function symplecticJoined(matrix: number[][], n: number): string {
+  const flat = matrix.flat();
+  const colWidth = flat.length > 0 ? Math.max(...flat.map((v) => String(v).length)) : 1;
+  const padCells = (cells: number[]) =>
+    cells.map((v) => String(v).padStart(colWidth, " ")).join("  ");
+  return matrix
+    .map((row) => `[ ${padCells(row.slice(0, n))} │ ${padCells(row.slice(n, 2 * n))} ]`)
+    .join("\n");
+}
+
+/**
+ * CSS Hx/Hz view: two labelled matrix groups, sharing styling with the other
+ * views. Sub-labels keep "[ row ]" formatting consistent and the two groups
+ * are separated by a blank line.
+ */
+export function hxhzJoined(blocks: { label: string; matrix: number[][] }[]): string {
+  return blocks
+    .map(({ label, matrix }) => `${label}\n${formatMatrixRows(matrix).join("\n")}`)
+    .join("\n\n");
+}
+
+/** Paste-ready `np.array(...)` literal. */
+export function numpyArray(matrix: number[][]): string {
+  if (matrix.length === 0) return "np.array([])";
+  const rows = matrix.map((row) => `    [${row.join(", ")}],`).join("\n");
+  return `np.array([\n${rows}\n])`;
+}
+
+export function numpyAssign(blocks: { name: string; matrix: number[][] }[]): string {
+  return blocks.map(({ name, matrix }) => `${name} = ${numpyArray(matrix)}`).join("\n\n");
+}

--- a/src/lib/queries/circuits.ts
+++ b/src/lib/queries/circuits.ts
@@ -3,7 +3,7 @@ import type {
   Circuit,
   CircuitBody,
   CircuitFilters,
-  CircuitOriginal,
+  CircuitOriginalLight,
   CircuitSort,
   TagWithCount,
 } from "../../types";
@@ -185,14 +185,15 @@ export function getCircuitsByQecIds(
   })[];
 }
 
-export function getOriginalForCircuit(circuitId: number): CircuitOriginal | null {
+export function getOriginalForCircuit(circuitId: number): CircuitOriginalLight | null {
   const db = getDb();
   return (
     (db
       .prepare(
-        `SELECT original_stim, original_h, original_logical
-       FROM circuit_originals WHERE circuit_id = ?`,
+        `SELECT original_stim,
+                (original_h IS NOT NULL AND original_logical IS NOT NULL) AS has_original_matrices
+         FROM circuit_originals WHERE circuit_id = ?`,
       )
-      .get(circuitId) as CircuitOriginal | undefined) ?? null
+      .get(circuitId) as CircuitOriginalLight | undefined) ?? null
   );
 }

--- a/src/lib/queries/codes.ts
+++ b/src/lib/queries/codes.ts
@@ -1,5 +1,5 @@
 import { getDb } from "../db";
-import type { Code, CodeFilters, CodeSort, CodeWithMeta } from "../../types";
+import type { Code, CodeFilters, CodeListItem, CodeSort, CodeWithMeta } from "../../types";
 import {
   withTags,
   withCircuitCounts,
@@ -8,13 +8,20 @@ import {
   buildCodeOrderBy,
 } from "./shared";
 
-export function formatCodeParams(code: Code): string {
+// Columns to select for list/search views. Excludes `h` and `logical` which
+// can be multi-MB JSON blobs for large codes (e.g. [[144,12,12]] BB codes).
+// Pages that need the matrices use getCodeBySlug, which selects everything.
+const CODE_LIST_COLUMNS = "c.id, c.name, c.slug, c.n, c.k, c.d, c.zoo_url, c.canonical_hash";
+
+export function formatCodeParams(code: Pick<Code, "n" | "k" | "d">): string {
   return code.d != null ? `[[${code.n},${code.k},${code.d}]]` : `[[${code.n},${code.k}]]`;
 }
 
 export function getAllCodes(): CodeWithMeta[] {
   const db = getDb();
-  const codes = db.prepare("SELECT * FROM codes ORDER BY name").all() as Code[];
+  const codes = db
+    .prepare(`SELECT ${CODE_LIST_COLUMNS} FROM codes c ORDER BY c.name`)
+    .all() as CodeListItem[];
   return withCircuitCounts(withTags(codes, "code"), "code_id");
 }
 
@@ -35,7 +42,9 @@ export function filterCodes(filters: CodeFilters, sort?: CodeSort): CodeWithMeta
 
   const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
   const orderBy = buildCodeOrderBy(sort);
-  const codes = db.prepare(`SELECT * FROM codes c ${where} ${orderBy}`).all(...params) as Code[];
+  const codes = db
+    .prepare(`SELECT ${CODE_LIST_COLUMNS} FROM codes c ${where} ${orderBy}`)
+    .all(...params) as CodeListItem[];
   return withCircuitCounts(withTags(codes, "code"), "code_id");
 }
 

--- a/src/lib/queries/codes.ts
+++ b/src/lib/queries/codes.ts
@@ -1,5 +1,12 @@
 import { getDb } from "../db";
-import type { Code, CodeFilters, CodeListItem, CodeSort, CodeWithMeta } from "../../types";
+import type {
+  Code,
+  CodeDetail,
+  CodeFilters,
+  CodeListItem,
+  CodeSort,
+  CodeWithMeta,
+} from "../../types";
 import {
   withTags,
   withCircuitCounts,
@@ -10,8 +17,14 @@ import {
 
 // Columns to select for list/search views. Excludes `h` and `logical` which
 // can be multi-MB JSON blobs for large codes (e.g. [[144,12,12]] BB codes).
-// Pages that need the matrices use getCodeBySlug, which selects everything.
+// Pages that need the matrices use the lazy /api/codes/[slug]/matrices
+// endpoint, which is the only call site that selects h/logical.
 const CODE_LIST_COLUMNS = "c.id, c.name, c.slug, c.n, c.k, c.d, c.zoo_url, c.canonical_hash";
+
+// getCodeBySlug returns the same columns as the list views plus a
+// `has_matrices` flag so the detail page knows whether to render the
+// (lazy-loaded) matrices section.
+const CODE_DETAIL_COLUMNS = `${CODE_LIST_COLUMNS}, (c.h IS NOT NULL AND c.logical IS NOT NULL) AS has_matrices`;
 
 export function formatCodeParams(code: Pick<Code, "n" | "k" | "d">): string {
   return code.d != null ? `[[${code.n},${code.k},${code.d}]]` : `[[${code.n},${code.k}]]`;
@@ -25,9 +38,11 @@ export function getAllCodes(): CodeWithMeta[] {
   return withCircuitCounts(withTags(codes, "code"), "code_id");
 }
 
-export function getCodeBySlug(slug: string): Code | undefined {
+export function getCodeBySlug(slug: string): CodeDetail | undefined {
   const db = getDb();
-  return db.prepare("SELECT * FROM codes WHERE slug = ?").get(slug) as Code | undefined;
+  return db.prepare(`SELECT ${CODE_DETAIL_COLUMNS} FROM codes c WHERE c.slug = ?`).get(slug) as
+    | CodeDetail
+    | undefined;
 }
 
 export function filterCodes(filters: CodeFilters, sort?: CodeSort): CodeWithMeta[] {

--- a/src/lib/queries/search.ts
+++ b/src/lib/queries/search.ts
@@ -1,5 +1,5 @@
 import { getDb } from "../db";
-import type { Code, Circuit, Tool } from "../../types";
+import type { Circuit, CodeListItem, Tool } from "../../types";
 import { withTags } from "./shared";
 
 function rawTokenize(query: string): string[] {
@@ -18,6 +18,7 @@ function searchByType<T extends { id: number }>(
   taggableType: "code" | "circuit" | "tool",
   query: string,
   limit: number,
+  columns: string = "c.*",
 ): (T & { tags: string[] })[] {
   const patterns = tokenize(query);
   if (patterns.length === 0) return [];
@@ -35,7 +36,7 @@ function searchByType<T extends { id: number }>(
 
   const rows = db
     .prepare(
-      `SELECT c.* FROM ${table} c
+      `SELECT ${columns} FROM ${table} c
        WHERE ${tokenClauses.join(" AND ")}
        ORDER BY c.name
        LIMIT ?`,
@@ -44,8 +45,12 @@ function searchByType<T extends { id: number }>(
   return withTags(rows, taggableType);
 }
 
-export function searchCodes(query: string): (Code & { tags: string[] })[] {
-  return searchByType<Code>("codes", "code", query, 20);
+// Match CODE_LIST_COLUMNS in queries/codes.ts — skip the large h/logical
+// JSON blobs since the search dropdown never renders matrices.
+const CODE_SEARCH_COLUMNS = "c.id, c.name, c.slug, c.n, c.k, c.d, c.zoo_url, c.canonical_hash";
+
+export function searchCodes(query: string): (CodeListItem & { tags: string[] })[] {
+  return searchByType<CodeListItem>("codes", "code", query, 20, CODE_SEARCH_COLUMNS);
 }
 
 export function searchCircuits(

--- a/src/lib/toggle-client.ts
+++ b/src/lib/toggle-client.ts
@@ -15,6 +15,9 @@ export function initToggle(buttonId: string, detailId: string): void {
       detail.style.maxHeight = detail.scrollHeight + "px";
       chevron?.classList.add("rotate-90");
       toggle.setAttribute("aria-expanded", "true");
+      // Notify in-section listeners (e.g. lazy-loaders) that the section
+      // opened. Per-instance dedup is the listener's responsibility.
+      detail.dispatchEvent(new CustomEvent("collapsible-open"));
     }
   });
 }

--- a/src/pages/api/circuits/[qec_id]/originals.ts
+++ b/src/pages/api/circuits/[qec_id]/originals.ts
@@ -1,0 +1,49 @@
+export const prerender = false;
+
+import type { APIRoute } from "astro";
+import { getDb } from "../../../../lib/db";
+
+interface Row {
+  n: number;
+  k: number;
+  original_h: string | null;
+  original_logical: string | null;
+}
+
+export const GET: APIRoute = ({ params }) => {
+  const qecIdParam = params.qec_id;
+  const qecId = Number(qecIdParam);
+  if (!Number.isInteger(qecId) || qecId < 1) {
+    return new Response("Invalid qec_id", { status: 400 });
+  }
+
+  const db = getDb();
+  const row = db
+    .prepare(
+      `SELECT co.n AS n, co.k AS k, o.original_h, o.original_logical
+       FROM circuit_originals o
+       JOIN circuits c ON c.id = o.circuit_id
+       JOIN codes co ON co.id = c.code_id
+       WHERE c.qec_id = ?`,
+    )
+    .get(qecId) as Row | undefined;
+
+  if (!row || !row.original_h || !row.original_logical) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  return new Response(
+    JSON.stringify({
+      n: row.n,
+      k: row.k,
+      h: JSON.parse(row.original_h),
+      logical: JSON.parse(row.original_logical),
+    }),
+    {
+      headers: {
+        "Content-Type": "application/json",
+        "Cache-Control": "public, max-age=3600",
+      },
+    },
+  );
+};

--- a/src/pages/api/codes/[slug]/matrices.ts
+++ b/src/pages/api/codes/[slug]/matrices.ts
@@ -1,0 +1,42 @@
+export const prerender = false;
+
+import type { APIRoute } from "astro";
+import { getDb } from "../../../../lib/db";
+
+interface Row {
+  n: number;
+  k: number;
+  h: string | null;
+  logical: string | null;
+}
+
+export const GET: APIRoute = ({ params }) => {
+  const slug = params.slug;
+  if (!slug) return new Response("Missing slug", { status: 400 });
+
+  const db = getDb();
+  const row = db.prepare("SELECT n, k, h, logical FROM codes WHERE slug = ?").get(slug) as
+    | Row
+    | undefined;
+
+  if (!row || !row.h || !row.logical) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  return new Response(
+    JSON.stringify({
+      n: row.n,
+      k: row.k,
+      h: JSON.parse(row.h),
+      logical: JSON.parse(row.logical),
+    }),
+    {
+      headers: {
+        "Content-Type": "application/json",
+        // The page passes ?v=<canonical_hash> as a cache key; when matrices
+        // change between deploys the hash changes and the browser refetches.
+        "Cache-Control": "public, max-age=3600",
+      },
+    },
+  );
+};

--- a/src/pages/circuits/[qec_id].astro
+++ b/src/pages/circuits/[qec_id].astro
@@ -16,7 +16,6 @@ import {
   formatCircuitId,
 } from "../../lib/queries";
 import { buildStimFilename } from "../../lib/filename";
-import { safeParseMatrix } from "../../lib/utils";
 
 const qecId = Number(Astro.params.qec_id);
 if (!Number.isInteger(qecId) || qecId < 1) {
@@ -45,13 +44,8 @@ const stimFilename = buildStimFilename({
   qubitCount: circuit.qubit_count,
 });
 
-const origH = original
-  ? safeParseMatrix(original.original_h, circuit.code_n - circuit.code_k, 2 * circuit.code_n)
-  : null;
-const origLogical = original
-  ? safeParseMatrix(original.original_logical, 2 * circuit.code_k, 2 * circuit.code_n)
-  : null;
-const hasOriginalMatrices = !!(origH && origLogical);
+const hasOriginalMatrices = original?.has_original_matrices === 1;
+const originalsUrl = `/api/circuits/${qecId}/originals`;
 ---
 
 <Layout title={`${circuit.name} ${displayId}`} description={`Circuit ${displayId} for ${circuit.code_name}`}>
@@ -161,13 +155,10 @@ const hasOriginalMatrices = !!(origH && origLogical);
           {original?.original_stim && (
             <CodeBlock code={original.original_stim} label="Original STIM Circuit" source={circuit.source} />
           )}
-          {hasOriginalMatrices && origH && origLogical && (
+          {hasOriginalMatrices && (
             <CodeMatrices
               id="original-matrices"
-              n={circuit.code_n}
-              k={circuit.code_k}
-              h={origH}
-              logical={origLogical}
+              dataUrl={originalsUrl}
               prefix="Original "
             />
           )}

--- a/src/pages/codes/[code].astro
+++ b/src/pages/codes/[code].astro
@@ -19,7 +19,6 @@ import {
   getToolsForCircuits,
 } from "../../lib/queries";
 import { parseCircuitParams, circuitSortToggleUrl } from "../../lib/url";
-import { safeParseMatrix } from "../../lib/utils";
 
 const { code: codeSlug } = Astro.params;
 const code = getCodeBySlug(codeSlug!);
@@ -31,9 +30,9 @@ if (!code) {
 const tags = getTagsFor("code", code.id);
 const params = formatCodeParams(code);
 
-const h = safeParseMatrix(code.h, code.n - code.k, 2 * code.n);
-const logical = safeParseMatrix(code.logical, 2 * code.k, 2 * code.n);
-const hasMatrices = !!(h && logical);
+const matricesUrl = code.canonical_hash
+  ? `/api/codes/${codeSlug}/matrices?v=${code.canonical_hash}`
+  : `/api/codes/${codeSlug}/matrices`;
 
 // Parse circuit filter and sort params
 const { raw, errors, tags: selectedTags, focus, filters, sort } = parseCircuitParams(Astro.url);
@@ -90,16 +89,10 @@ const sortHref = (field: "gate_count" | "two_qubit_gate_count" | "depth" | "qubi
     <TagList tags={tags} />
   </div>
 
-  {hasMatrices && h && logical && (
+  {code.has_matrices === 1 && (
     <div class="mb-6">
       <CollapsibleSection id="matrices" label="Check Matrices & Logical Operators">
-        <CodeMatrices
-          id="code-matrices"
-          n={code.n}
-          k={code.k}
-          h={h}
-          logical={logical}
-        />
+        <CodeMatrices id="code-matrices" dataUrl={matricesUrl} />
       </CollapsibleSection>
     </div>
   )}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -96,5 +96,13 @@ export interface TagWithCount {
   count: number;
 }
 
-export type CodeWithMeta = Code & { tags: string[]; circuit_count: number };
+/**
+ * Narrower view of Code without the large `h` / `logical` JSON columns.
+ * Use this for list and search results — anything that does not render the
+ * stabilizer / logical matrices. The detail page (`getCodeBySlug`) returns
+ * the full Code, including h/logical.
+ */
+export type CodeListItem = Omit<Code, "h" | "logical">;
+
+export type CodeWithMeta = CodeListItem & { tags: string[]; circuit_count: number };
 export type ToolWithMeta = Tool & { tags: string[]; circuit_count: number };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -100,9 +100,26 @@ export interface TagWithCount {
  * Narrower view of Code without the large `h` / `logical` JSON columns.
  * Use this for list and search results — anything that does not render the
  * stabilizer / logical matrices. The detail page (`getCodeBySlug`) returns
- * the full Code, including h/logical.
+ * `CodeDetail` (same shape plus a `has_matrices` flag); the matrices
+ * themselves are fetched lazily from `/api/codes/[slug]/matrices`.
  */
 export type CodeListItem = Omit<Code, "h" | "logical">;
 
+/**
+ * Shape returned by `getCodeBySlug`. Same as `CodeListItem` plus a boolean
+ * (better-sqlite3 returns SQLite booleans as 0 or 1) indicating whether the
+ * code has stabilizer / logical matrices available for lazy loading.
+ */
+export type CodeDetail = CodeListItem & { has_matrices: 0 | 1 };
+
 export type CodeWithMeta = CodeListItem & { tags: string[]; circuit_count: number };
 export type ToolWithMeta = Tool & { tags: string[]; circuit_count: number };
+
+/**
+ * Narrower view of CircuitOriginal without the large `original_h` /
+ * `original_logical` JSON columns. The matrices themselves are fetched
+ * lazily from `/api/circuits/[qec_id]/originals`.
+ */
+export type CircuitOriginalLight = Pick<CircuitOriginal, "original_stim"> & {
+  has_original_matrices: 0 | 1;
+};


### PR DESCRIPTION
## Summary

Two commits, both targeting the multi-MB `h` / `logical` JSON columns on
the BB-family codes (`[[72,12,6]]`, `[[90,8,10]]`, `[[108,8,10]]`,
`[[144,12,12]]`). Together they keep the SSR runtime from touching those
columns on the hot routes, in response to the Railway memory spikes
observed after the recent encoders+state-prep PR.

### Part 1 — skip matrices in list/search queries

`filterCodes`, `getAllCodes`, and `searchCodes` switched from `SELECT *`
to explicit column lists that exclude `h`/`logical`. `getCodeBySlug`
unchanged at this step.

Measured: homepage SQLite→Node payload **226 KB → 2.8 KB** (~80×).

### Part 2 — lazy-load matrices on first expand

The `<CodeMatrices>` block on `/codes/<slug>` and the Original-submission
block on `/circuits/<qec_id>` no longer ship matrix data in the initial
HTML. New endpoints serve the JSON on demand:

- `GET /api/codes/[slug]/matrices` (cache-busted via `?v=<canonical_hash>`)
- `GET /api/circuits/[qec_id]/originals`

Both set `Cache-Control: public, max-age=3600`.

`CodeMatrices` now takes a single `dataUrl` prop. Server renders only the
toolbar and 10 empty `<pre>` placeholders ("Loading matrices…"). Client
script listens for a new `collapsible-open` `CustomEvent` (dispatched by
`initToggle`), fetches once, derives `is_css` client-side, hides the
Hx/Hz tab for non-CSS codes, and `textContent`-populates each pane. The
existing PAULI / SYMPLECTIC / HX-HZ / NUMPY toggle handlers stay attached
to the server-rendered toolbar buttons, so no re-binding after load.

Matrix-formatting helpers (`paulisJoined`, `symplecticJoined`,
`hxhzJoined`, `numpyAssign`) extracted to `src/lib/code-matrices-format.ts`
for client/server reuse.

`getCodeBySlug` and `getOriginalForCircuit` narrowed: the queries no
longer select the JSON blobs, instead returning a `has_matrices` /
`has_original_matrices` boolean so the page knows whether to render the
section at all. New narrow types `CodeDetail`, `CodeListItem`,
`CircuitOriginalLight` give TypeScript a safety net against future
accidental access to the dropped fields.

## Effect

Bots, link-previews, and humans who don't open the matrices block now
pay **zero matrix cost**. Crawler bursts on BB-code pages no longer
spike Node heap by 5–12 MB per concurrent request. Together with Part 1,
the SSR runtime never touches the multi-MB JSON on hot routes.

The deploy-time build spike in `scripts/db/create_database.mjs` is
**not** addressed by this PR — that's a separate piece of work if the
600 MB peaks turn out to be deploy-dominated rather than runtime-burst-
dominated.

## Test plan

- [ ] `/codes/144-12-12` — page loads quickly, no matrix data in HTML.
      Expand "Check Matrices & Logical Operators" → "Loading matrices…"
      briefly visible → 10 panes populate. PAULI / SYMPLECTIC / HX-HZ
      tabs all switch; NUMPY toggle works.
- [ ] `/codes/five-qubit-code` — non-CSS regression: after lazy load,
      HX-HZ tab is hidden.
- [ ] `/codes/30-6-5` — small-code regression.
- [ ] `/circuits/27` (or any BB circuit) — "Original submission" block
      lazy-loads its matrices the same way; inline STIM CodeBlock
      continues to render server-side.
- [ ] DevTools Network tab — `/api/codes/144-12-12/matrices?v=<hash>`
      returns 200 with `Cache-Control: public, max-age=3600`; second
      visit serves from disk cache.
- [ ] Error path — temporarily 500 the endpoint → expand →
      "Failed to load matrices — refresh to retry." appears.