### PR TITLE
Harden circuit ingestion + validation pipeline

### DIFF
--- a/.claude/commands/add-circuit.md
+++ b/.claude/commands/add-circuit.md
@@ -193,10 +193,12 @@ Circuit tags require user input. Ask explicitly:
 
 ### 4e. Apply tags
 
-Edit the generated YAML files to add the `tags:` field:
+Add the `tags:` field:
 
-- `data_yaml/codes/<slug>.yaml` — code-level tags
-- `data_yaml/circuits/<code-slug>--<circuit-slug>.yaml` — circuit-level tags
+- `data_yaml/codes/<slug>.yaml` — code-level tags (edit the YAML)
+- `data_yaml/circuits/<code-slug>--<circuit-slug>.yaml` — circuit-level tags.
+  Prefer passing these up front via `add_circuit(..., tags=[...])` (Phase 3) so
+  no manual edit is needed; otherwise edit the YAML here.
 
 ### Tag rules
 
@@ -212,9 +214,11 @@ Edit the generated YAML files to add the `tags:` field:
 1. Read and show the final YAML files to the user (code YAML + circuit YAML).
 2. Ask: "Does everything look correct? You can edit anything before we rebuild."
 3. Let the user make manual corrections if needed.
-4. Once approved, rebuild:
+4. Once approved, Prettier-format the generated YAML (the ingestion writes plain
+   YAML, which is **not** Prettier-styled; CI runs `format:check`), then rebuild:
 
 ```bash
+npm run format                    # required — CI gate; do not skip
 npm run db:create && npm run dev
 ```
 
@@ -235,6 +239,8 @@ npm run db:create && npm run dev
 | Tool slug not in `data_yaml/tools/`     | Ask user to confirm; note a new tool YAML may be needed                                                                                       |
 | Zoo URL not found                       | Continue without it — not required                                                                                                            |
 | Zoo page fetch fails                    | Continue — tag manually with user input                                                                                                       |
+| Code already exists (dedup match)       | Omit `code_name` — the stored slug is used automatically. A `code_name` passed here is ignored for the slug (do not rely on it)               |
+| `FileExistsError` (circuit slug exists) | A circuit with that `<code>--<circuit>` slug already exists. Use a distinct `circuit_name`, or pass `overwrite=True` to replace it in place   |
 
 ---
 

--- a/docs/adding-circuits.md
+++ b/docs/adding-circuits.md
@@ -187,7 +187,7 @@ Add `--dry-run` to preview without writing. Multiple circuits per code: pass mul
 
 ## Step 3: Add tags
 
-The pipeline only auto-assigns mathematically verified code tags (`CSS`, `self-dual`). All other tags must be added manually by editing the generated YAML files.
+The pipeline only auto-assigns mathematically verified code tags (`CSS`, `self-dual`). All other tags must be added — either by passing them to `add_circuit(..., tags=[...])` up front (circuit tags only), or by editing the generated YAML files afterwards. Fault tolerance (`ft` / `non-ft`) is never inferred, so always set it explicitly.
 
 ### Code tags (`data_yaml/codes/<slug>.yaml`)
 
@@ -222,9 +222,14 @@ Prefer reusing existing tags over inventing new ones.
 ## Step 4: Rebuild
 
 ```bash
+npm run format                    # Prettier-format the generated YAML (CI gate)
 git diff                          # Review changes
 npm run db:create && npm run dev  # Rebuild database and restart
 ```
+
+> The ingestion writes plain YAML, which is **not** Prettier-formatted. CI runs
+> `format:check`, so run `npm run format` after generating (or editing) any
+> `data_yaml/` files or the build will fail.
 
 ---
 
@@ -323,3 +328,5 @@ Tools must be added manually before circuits can reference them.
 - **Restart the dev server** after `db:create` — the Astro process caches the DB connection.
 - Running generate twice for the same code detects the existing entry via canonical hash.
 - To edit existing data, modify the YAML files directly and run `npm run db:create`.
+- **Existing codes: omit `code_name`.** On a dedup match the circuit files under the code's _stored_ slug (e.g. `23-1-7`); any `code_name` you pass is ignored for the slug. Passing a name that _doesn't_ resolve to the stored slug would otherwise orphan the circuit.
+- **Overwrites are refused by default.** If a circuit with the same `<code>--<circuit>` slug already exists, `add_circuit` raises `FileExistsError`. Pass `overwrite=True` to replace it in place (the existing `qec_id` is preserved), or choose a distinct `circuit_name`.

--- a/scripts/add_circuit/__init__.py
+++ b/scripts/add_circuit/__init__.py
@@ -124,9 +124,11 @@ def add_circuit(
     zoo_url: str = "",
     tool: str = "",
     notes: str = "",
+    tags: Optional[list[str]] = None,
     data_dir: Union[str, Path] = "data_yaml",
     dry_run: bool = False,
     assume_new: bool = False,
+    overwrite: bool = False,
 ) -> AddCircuitResult:
     """
     Add a circuit to the QECirc library by writing YAML files to data_yaml/.
@@ -152,10 +154,18 @@ def add_circuit(
         zoo_url: QEC Zoo URL for the code.
         tool: Tool slug (e.g. "mqt-qecc").
         notes: Circuit notes.
+        tags: Circuit tags written to the YAML (e.g. ``["encoding", "non-ft"]``).
+            The functionality tag (``encoding`` / ``state-preparation``) drives
+            circuit-type routing in ``validate:circuits``; fault tolerance
+            (``ft`` / ``non-ft``) is never inferred, so pass it explicitly.
         data_dir: Path to data_yaml directory.
         dry_run: If True, report what would be written without writing.
         assume_new: If True, suppress :exc:`UncertainDedupError` and add as a
             new code even when invariants align with stored candidates.
+        overwrite: If a circuit with the same ``<code>--<circuit>`` slug already
+            exists, ``False`` (the default) raises :exc:`FileExistsError` rather
+            than silently clobbering it; ``True`` replaces it in place, keeping
+            the existing ``qec_id`` so the public ``#N`` identifier is stable.
 
     Returns:
         AddCircuitResult with code/circuit info and list of files written.
@@ -218,12 +228,34 @@ def add_circuit(
         source=source,
         tool=tool,
         notes=notes,
+        tags=tags,
     )
-    circ_data["qec_id"] = next_qec_id(data_dir)
 
     # Collect files to write
     code_slug = code["slug"]
     circ_slug = circ_data["slug"]
+    circ_yaml_path = data_dir / "circuits" / f"{code_slug}--{circ_slug}.yaml"
+
+    # Guard against silently overwriting a different circuit that shares the
+    # same <code>--<circuit> slug (e.g. two distinct constructions of the same
+    # code submitted under the same circuit name). On a real write we refuse
+    # unless `overwrite=True`; when overwriting we reuse the existing qec_id so
+    # the public #N identifier is stable rather than being reallocated.
+    existing_qec_id = None
+    if circ_yaml_path.exists():
+        if not dry_run and not overwrite:
+            raise FileExistsError(
+                f"circuit '{code_slug}--{circ_slug}' already exists at "
+                f"{circ_yaml_path}. Pass overwrite=True to replace it, or use a "
+                f"distinct circuit_name."
+            )
+        import yaml as _yaml
+
+        prev = _yaml.safe_load(circ_yaml_path.read_text())
+        if prev and isinstance(prev.get("qec_id"), int):
+            existing_qec_id = prev["qec_id"]
+    circ_data["qec_id"] = existing_qec_id or next_qec_id(data_dir)
+
     files_to_write: list[tuple[Path, str]] = []
 
     if code.get("status") == "new":

--- a/scripts/add_circuit/circuit_validate.py
+++ b/scripts/add_circuit/circuit_validate.py
@@ -138,16 +138,62 @@ def _to_stim_circuit(circuit: Union[stim.Circuit, str]) -> stim.Circuit:
     return stim.Circuit(circuit)
 
 
+def _check_codespace_on_zero_input(circ: stim.Circuit, Hx: np.ndarray, Hz: np.ndarray) -> str:
+    """Simulate ``circ`` on ``|0...0>`` and check every code stabilizer is +1.
+
+    Reset-tolerant: uses a ``TableauSimulator`` (which supports ``R``/``RX``)
+    rather than ``to_tableau``, so it works for ancilla-initialising circuits.
+    Shared by :func:`validate_state_prep` and by :func:`validate_encoding`'s
+    non-unitary fallback.
+
+    Returns 'passed' or 'failed: <reason>'.
+    """
+    sim = stim.TableauSimulator()
+    sim.do_circuit(circ)
+    n = Hx.shape[1]
+
+    for row in Hz:
+        ps = stim.PauliString(n)
+        for i, v in enumerate(row):
+            if v:
+                ps[i] = 3  # Z
+        if sim.peek_observable_expectation(ps) != 1:
+            return "failed: Z-stabilizer not satisfied"
+
+    for row in Hx:
+        ps = stim.PauliString(n)
+        for i, v in enumerate(row):
+            if v:
+                ps[i] = 1  # X
+        if sim.peek_observable_expectation(ps) != 1:
+            return "failed: X-stabilizer not satisfied"
+
+    return "passed"
+
+
 def validate_encoding(circuit: Union[stim.Circuit, str], Hx: np.ndarray, Hz: np.ndarray) -> str:
     """Verify encoding circuit maps |0...0> to the code space.
 
     An encoding circuit U should satisfy: for every stabilizer S of the code,
     U^dag S U stabilizes |0...0> (only Z and I components, no X or Y).
 
+    Ancilla-initialising encoders contain reset instructions (``R``/``RX`` on
+    the ancilla qubits) and so have no unitary tableau. For those we fall back
+    to simulating on |0...0>: the encoder then prepares |0_L>, so every code
+    stabilizer must be a +1 eigenstate of the output — the same
+    ``|0...0> -> codespace`` property the unitary path checks, just evaluated by
+    simulation instead of by pulling the stabilizers back through U.
+
     Returns 'passed' or 'failed: <reason>'.
     """
     circ = _to_stim_circuit(circuit)
-    tableau = circ.to_tableau()
+    try:
+        tableau = circ.to_tableau()
+    except ValueError:
+        # Non-unitary (contains resets/measurements) — use the reset-tolerant
+        # simulation check.
+        return _check_codespace_on_zero_input(circ, Hx, Hz)
+
     num_qubits = len(tableau)
     inv = tableau.inverse()
 
@@ -174,28 +220,7 @@ def validate_state_prep(circuit: Union[stim.Circuit, str], Hx: np.ndarray, Hz: n
 
     Returns 'passed' or 'failed: <reason>'.
     """
-    circ = _to_stim_circuit(circuit)
-    sim = stim.TableauSimulator()
-    sim.do_circuit(circ)
-    n = Hx.shape[1]
-
-    for row in Hz:
-        ps = stim.PauliString(n)
-        for i, v in enumerate(row):
-            if v:
-                ps[i] = 3  # Z
-        if sim.peek_observable_expectation(ps) != 1:
-            return "failed: Z-stabilizer not satisfied"
-
-    for row in Hx:
-        ps = stim.PauliString(n)
-        for i, v in enumerate(row):
-            if v:
-                ps[i] = 1  # X
-        if sim.peek_observable_expectation(ps) != 1:
-            return "failed: X-stabilizer not satisfied"
-
-    return "passed"
+    return _check_codespace_on_zero_input(_to_stim_circuit(circuit), Hx, Hz)
 
 
 def validate_syndrome_extraction(

--- a/scripts/add_circuit/code_identify.py
+++ b/scripts/add_circuit/code_identify.py
@@ -179,6 +179,29 @@ def extract_params(Hx: np.ndarray, Hz: np.ndarray) -> CodeParams:
 # ---------------------------------------------------------------------------
 
 
+def _pad_to_equal_rows(A: np.ndarray, B: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Zero-pad the row-shorter of two equal-width matrices so both have the
+    same row count.
+
+    A no-op when the row counts already match, so symmetric / self-dual CSS
+    codes (``rank(Hx) == rank(Hz)``) are byte-for-byte unchanged and keep their
+    existing :func:`canonical_hash`. For asymmetric CSS codes
+    (``rank(Hx) != rank(Hz)``, e.g. the Shor code's 2 X- vs 6 Z-generators) it
+    makes the ``np.hstack`` below well-defined; the padding rows are all-zero
+    and are stripped again by the RREF zero-row removal, so they don't affect
+    the canonicalization.
+    """
+    ra, rb = A.shape[0], B.shape[0]
+    if ra == rb:
+        return A, B
+    r = max(ra, rb)
+    if ra < r:
+        A = np.vstack([A, np.zeros((r - ra, A.shape[1]), dtype=A.dtype)])
+    if rb < r:
+        B = np.vstack([B, np.zeros((r - rb, B.shape[1]), dtype=B.dtype)])
+    return A, B
+
+
 def canonical_form(Hx: np.ndarray, Hz: np.ndarray) -> tuple[np.ndarray, np.ndarray, list[int]]:
     """
     Compute the canonical representation of a code given by (Hx, Hz).
@@ -190,8 +213,14 @@ def canonical_form(Hx: np.ndarray, Hz: np.ndarray) -> tuple[np.ndarray, np.ndarr
 
     Returns (canon_Hx, canon_Hz, column_permutation) where the permutation
     maps canonical column index -> original column index.
+
+    ``Hx`` and ``Hz`` may have different row counts (CSS codes with
+    ``rank(Hx) != rank(Hz)``); they are zero-padded to a common height before
+    the joint RREF (a no-op for symmetric codes — see
+    :func:`_pad_to_equal_rows`).
     """
     n = Hx.shape[1]
+    Hx, Hz = _pad_to_equal_rows(Hx, Hz)
     symplectic = np.hstack([Hx, Hz])
     rref = gf2_rref(symplectic)
     # Remove all-zero rows
@@ -229,7 +258,11 @@ def canonical_hash(Hx: np.ndarray, Hz: np.ndarray) -> str:
     codes with different generator splits but same concatenated bytes.
     """
     canon_Hx, canon_Hz, _ = canonical_form(Hx, Hz)
+    # Row counts (before padding) go in the prefix so asymmetric codes keep a
+    # distinct fingerprint; padding to equal heights makes the hstack valid and
+    # is a no-op for symmetric codes (preserving their existing hash).
     prefix = f"{canon_Hx.shape[0]}:{canon_Hz.shape[0]}:".encode()
+    canon_Hx, canon_Hz = _pad_to_equal_rows(canon_Hx, canon_Hz)
     combined = np.hstack([canon_Hx, canon_Hz])
     return hashlib.sha256(prefix + combined.tobytes()).hexdigest()
 

--- a/scripts/add_circuit/compute.py
+++ b/scripts/add_circuit/compute.py
@@ -130,9 +130,14 @@ def compute_code_data(
         if dedup.status == "match":
             code_status = "existing"
             yaml_qubit_perm = dedup.qubit_permutation
-            # Use existing slug if no name was provided
-            if not slug:
-                slug = dedup.slug
+            # The existing code's stored slug is authoritative. A circuit for an
+            # existing code must file under that slug (e.g. `23-1-7`) regardless
+            # of any `code_name` passed in — otherwise it lands under
+            # `slugify(code_name)`, which has no matching code YAML and is
+            # rejected by the DB build ("code '<slug>' not found"). This is why
+            # you may omit `code_name` for existing codes: it is ignored for
+            # slug purposes on a match either way.
+            slug = dedup.slug
 
     # For existing codes, use the yaml dedup permutation (maps user qubits to
     # the stored canonical form). For new codes, use the canonical_form

--- a/scripts/add_circuit/compute_circuit.py
+++ b/scripts/add_circuit/compute_circuit.py
@@ -18,6 +18,7 @@ def compute_circuit_data(
     source: str = "",
     tool: str = "",
     notes: str = "",
+    tags: Optional[list[str]] = None,
 ) -> dict:
     """
     Compute all circuit-level data.
@@ -70,6 +71,7 @@ def compute_circuit_data(
         "quirk_url": quirk_url,
         "original_stim": original_stim,
         "bodies": bodies,
+        "tags": list(tags) if tags else [],
     }
 
 

--- a/scripts/add_circuit/yaml_helpers.py
+++ b/scripts/add_circuit/yaml_helpers.py
@@ -58,6 +58,9 @@ def build_circuit_yaml(circ):
     if circ.get("quirk_url"):
         data["quirk_url"] = circ["quirk_url"]
 
+    if circ.get("tags"):
+        data["tags"] = list(circ["tags"])
+
     return data
 
 

--- a/scripts/tests/test_add_circuit_api.py
+++ b/scripts/tests/test_add_circuit_api.py
@@ -78,3 +78,90 @@ def test_add_circuit_qec_id_increments(tmp_path: Path) -> None:
     id1 = yaml.safe_load(Path(p1).read_text(encoding="utf-8"))["qec_id"]
     id2 = yaml.safe_load(Path(p2).read_text(encoding="utf-8"))["qec_id"]
     assert id2 == id1 + 1
+
+
+def _circuit_yaml(result):
+    p = next(
+        p
+        for p in result.files_written
+        if p.endswith(".yaml") and "circuits" in Path(p).parts and "originals" not in Path(p).parts
+    )
+    return Path(p), yaml.safe_load(Path(p).read_text(encoding="utf-8"))
+
+
+def test_tags_written_to_yaml(tmp_path: Path) -> None:
+    """The tags param is persisted to the circuit YAML."""
+    result = add_circuit(
+        circuit=_TRIVIAL_STIM,
+        circuit_name="Tagged",
+        d=3,
+        Hx=_STEANE_HX,
+        Hz=_STEANE_HZ,
+        code_name="Steane Code",
+        tags=["encoding", "non-ft"],
+        data_dir=tmp_path,
+    )
+    _, data = _circuit_yaml(result)
+    assert data["tags"] == ["encoding", "non-ft"]
+
+
+def test_existing_code_match_uses_stored_slug(tmp_path: Path) -> None:
+    """A second circuit for the same code files under the stored slug even when
+    a different code_name is passed (code_name must not orphan the circuit)."""
+    add_circuit(
+        circuit=_TRIVIAL_STIM,
+        circuit_name="First",
+        d=3,
+        Hx=_STEANE_HX,
+        Hz=_STEANE_HZ,
+        code_name="Steane Code",
+        data_dir=tmp_path,
+    )
+    r2 = add_circuit(
+        circuit=_TRIVIAL_STIM + "X 0\n",
+        circuit_name="Second",
+        d=3,
+        Hx=_STEANE_HX,
+        Hz=_STEANE_HZ,
+        code_name="A Totally Different Name",  # must be ignored on a dedup match
+        data_dir=tmp_path,
+    )
+    assert r2.code_status == "existing"
+    assert r2.code_slug == "steane-code"
+    # no orphan code YAML created for the second name
+    assert not (tmp_path / "codes" / "a-totally-different-name.yaml").exists()
+
+
+def test_overwrite_guard_raises(tmp_path: Path) -> None:
+    """Re-adding the same <code>--<circuit> slug raises unless overwrite=True."""
+    import pytest
+
+    kw = dict(
+        circuit=_TRIVIAL_STIM,
+        circuit_name="Dup",
+        d=3,
+        Hx=_STEANE_HX,
+        Hz=_STEANE_HZ,
+        code_name="Steane Code",
+        data_dir=tmp_path,
+    )
+    add_circuit(**kw)
+    with pytest.raises(FileExistsError):
+        add_circuit(**kw)
+
+
+def test_overwrite_preserves_qec_id(tmp_path: Path) -> None:
+    """overwrite=True replaces in place and keeps the original qec_id."""
+    kw = dict(
+        circuit_name="Dup",
+        d=3,
+        Hx=_STEANE_HX,
+        Hz=_STEANE_HZ,
+        code_name="Steane Code",
+        data_dir=tmp_path,
+    )
+    r1 = add_circuit(circuit=_TRIVIAL_STIM, **kw)
+    _, d1 = _circuit_yaml(r1)
+    r2 = add_circuit(circuit=_TRIVIAL_STIM + "X 0\n", overwrite=True, **kw)
+    _, d2 = _circuit_yaml(r2)
+    assert d2["qec_id"] == d1["qec_id"]

--- a/scripts/tests/test_circuit_validate.py
+++ b/scripts/tests/test_circuit_validate.py
@@ -177,6 +177,19 @@ class TestValidateEncoding:
         result = validate_encoding(bad_circuit, STEANE_H, STEANE_H)
         assert result.startswith("failed:")
 
+    def test_reset_encoder_passes_via_simulation(self):
+        # Ancilla-initialising encoders contain resets and have no unitary
+        # tableau; validate_encoding must fall back to simulation. Prepending
+        # a reset of all qubits is a no-op on |0...0> but forces that path.
+        reset_encoder = "R 0 1 2 3 4 5 6\n" + STEANE_STIM
+        assert validate_encoding(reset_encoder, STEANE_H, STEANE_H) == "passed"
+
+    def test_reset_encoder_bad_fails(self):
+        # A reset-containing circuit that does not prepare a codeword must
+        # still be reported as failed (not error out) via the fallback.
+        result = validate_encoding("R 0 1 2 3 4 5 6\nH 0\n", STEANE_H, STEANE_H)
+        assert result.startswith("failed:")
+
 
 # ---------------------------------------------------------------------------
 # validate_state_prep

--- a/scripts/tests/test_code_identify.py
+++ b/scripts/tests/test_code_identify.py
@@ -284,6 +284,36 @@ class TestCanonicalHash:
         p = [4, 2, 0, 3, 1]
         assert canonical_hash(Hx, Hz) == canonical_hash(Hx[:, p], Hz[:, p])
 
+    def test_asymmetric_css_shor(self):
+        """Asymmetric CSS code (rank(Hx) != rank(Hz)) must hash without error.
+
+        The Shor [[9,1,3]] code has 2 X-generators and 6 Z-generators; the
+        earlier ``np.hstack([Hx, Hz])`` assumed equal row counts and raised.
+        """
+        Hx = np.array(
+            [
+                [1, 1, 1, 1, 1, 1, 0, 0, 0],
+                [0, 0, 0, 1, 1, 1, 1, 1, 1],
+            ]
+        )
+        Hz = np.array(
+            [
+                [1, 1, 0, 0, 0, 0, 0, 0, 0],
+                [0, 1, 1, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 1, 1, 0, 0, 0, 0],
+                [0, 0, 0, 0, 1, 1, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 1, 1, 0],
+                [0, 0, 0, 0, 0, 0, 0, 1, 1],
+            ]
+        )
+        h = canonical_hash(Hx, Hz)
+        assert isinstance(h, str) and len(h) == 64
+        # deterministic and invariant under (independent) row permutations
+        assert h == canonical_hash(Hx, Hz)
+        assert h == canonical_hash(Hx[[1, 0], :], Hz[[5, 0, 3, 1, 4, 2], :])
+        # a genuinely different code hashes differently
+        assert h != canonical_hash(Hz, Hx)
+
 
 # ---------------------------------------------------------------------------
 # find_qubit_permutation

--- a/scripts/tests/test_validate_circuits.py
+++ b/scripts/tests/test_validate_circuits.py
@@ -33,3 +33,19 @@ def test_skips_non_css_with_explanatory_message(tmp_path):
     results = validate_all(data_dir=str(tmp_path))
     statuses = [c.status for r in results for c in r.checks]
     assert "skipped" in statuses
+
+
+def test_all_skipped_checks_count_as_skipped_not_failed():
+    """A circuit whose only check is 'skipped' (e.g. a non-CSS code) must report
+    is_skipped=True and passed=False, so the summary counts it as skipped."""
+    from scripts.validate_circuits import CheckResult, CircuitResult
+
+    r = CircuitResult(stem="x--y", circuit_type="state-preparation")
+    r.checks.append(CheckResult("load_code", "skipped", "non-CSS validation not yet supported"))
+    assert r.is_skipped is True
+    assert r.passed is False
+
+    ok = CircuitResult(stem="x--z", circuit_type="encoding")
+    ok.checks.append(CheckResult("validate_encoding", "passed"))
+    assert ok.is_skipped is False
+    assert ok.passed is True

--- a/scripts/validate-yaml.mjs
+++ b/scripts/validate-yaml.mjs
@@ -79,6 +79,12 @@ function validate(file, data, schema) {
       errors.push(
         `${file}: field "${key}" should be ${schema.required[key]}, got ${typeof data[key]}`,
       );
+    } else if (schema.required[key] === "string" && data[key].trim() === "") {
+      // Required string fields must be non-empty. The DB build
+      // (create_database.mjs) treats an empty string as missing (falsy), so
+      // rejecting it here keeps the two validators consistent and catches it in
+      // CI before the build (e.g. an empty `source` — provenance is required).
+      errors.push(`${file}: required field "${key}" must not be empty`);
     }
   }
 

--- a/scripts/validate_circuits.py
+++ b/scripts/validate_circuits.py
@@ -54,6 +54,15 @@ class CircuitResult:
             c.status == "passed" for c in self.checks
         )
 
+    @property
+    def is_skipped(self) -> bool:
+        # Skipped = no runnable validation for this circuit: either it lacks a
+        # functionality tag, or every check was skipped (e.g. non-CSS codes,
+        # which have no CSS validator yet). These must not count as failures.
+        return self.circuit_type == "skipped" or (
+            bool(self.checks) and all(c.status == "skipped" for c in self.checks)
+        )
+
 
 def validate_all(data_dir: str = "data_yaml") -> list[CircuitResult]:
     data_path = Path(data_dir)
@@ -173,8 +182,8 @@ def _check_state_prep(
 
 
 def print_results(results: list[CircuitResult]) -> None:
-    checked = [r for r in results if r.circuit_type != "skipped"]
-    skipped = [r for r in results if r.circuit_type == "skipped"]
+    checked = [r for r in results if not r.is_skipped]
+    skipped = [r for r in results if r.is_skipped]
     passed = [r for r in checked if r.passed]
     failed = [r for r in checked if not r.passed]
 
@@ -205,7 +214,7 @@ def main():
     results = validate_all(args.data_dir)
     print_results(results)
 
-    failed = [r for r in results if r.circuit_type != "skipped" and not r.passed]
+    failed = [r for r in results if not r.is_skipped and not r.passed]
     sys.exit(1 if failed else 0)
 
 


### PR DESCRIPTION
## Summary

Five independent fixes to the ingestion + validation pipeline, found while running it end-to-end on codes that stress paths the current (self-dual, unitary-encoder) library never exercised. No circuit data is added here — pipeline/validator/docs only.

Each is its own commit and stands alone.

## Fixes

- **`fix(dedup)`: asymmetric CSS in `canonical_hash`.** `canonical_form`/`canonical_hash` did `np.hstack([Hx, Hz])`, assuming `rank(Hx) == rank(Hz)` — so any CSS code with unequal X/Z generator counts (e.g. Shor `[[9,1,3]]`, 2 vs 6) raised `ValueError`. Zero-pad the shorter block to equal height before the hstack; a **no-op for symmetric/self-dual codes**, so their stored `canonical_hash` is byte-for-byte unchanged (verified: Golay `23-1-7`). Adds a Shor regression test.

- **`feat(ingest)`: `tags` param, overwrite guard, stored-slug on dedup match.**
  - On a dedup match the existing code's **stored slug is authoritative**, so passing a `code_name` for an already-stored code no longer files the circuit under `slugify(code_name)` (which has no matching code YAML and is rejected by the DB build).
  - New `tags` param writes circuit tags in the same call (no separate manual YAML edit). Fault tolerance is still never inferred.
  - New `overwrite` param (default `False`) raises `FileExistsError` instead of **silently clobbering** an existing `<code>--<circuit>` slug; `overwrite=True` replaces in place and preserves the existing `qec_id`.

- **`fix(validate)`: require non-empty `source`; count non-CSS as skipped.** `validate:yaml` now rejects empty required strings (it previously only type-checked, so an empty `source` passed `validate:yaml` but failed the DB build, which treats `""` as missing). `validate:circuits` now counts all-skipped circuits (e.g. non-CSS, which have no CSS validator yet) as **skipped** rather than **failed**, and exits non-zero only on real failures.

- **`fix(validate)`: validate ancilla-initialising (reset) encoders.** `validate_encoding` called `to_tableau()`, which raises on any reset instruction — so every stored `<code>--encoding` circuit (all of which reset ancillas) errored out despite being valid. Falls back to a reset-tolerant `TableauSimulator` check (the same `|0…0⟩ → codespace` property) when the circuit has no unitary tableau. **`validate:circuits` goes from 12 failed → 0 failed.**

- **`docs(ingest)`:** require `npm run format` after ingestion (the pipeline writes non-Prettier YAML; CI gates on `format:check`), and document the `tags`/`overwrite` params + the existing-code slug behavior.

## Verification

- 155 Python tests pass (+7 new regression tests), ruff + Prettier clean, `validate:yaml` ✓.
- `validate:circuits`: 0 failed (was 12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)