### PR TITLE
fix(metrics): exclude SWAP from 2q count; use 2-qubit (entangling) depth

### DIFF
--- a/data_yaml/circuits/steane-code--non-ft-optimized-zero-state-preparation.yaml
+++ b/data_yaml/circuits/steane-code--non-ft-optimized-zero-state-preparation.yaml
@@ -3,7 +3,7 @@ name: Non-FT Optimized Zero State Preparation
 source: https://journals.aps.org/prxquantum/abstract/10.1103/PRXQuantum.6.020330
 gate_count: 11
 two_qubit_gate_count: 8
-depth: 5
+depth: 4
 qubit_count: 7
 crumble_url: https://algassert.com/crumble#circuit=H_3_0_2;CX_0_1_2_4_3_5_4_0_1_3_1_6_5_4_4_6_
 quirk_url: https://algassert.com/quirk#circuit={"cols":[["H",1,"H","H"],["•","X"],[1,1,"•",1,"X"],[1,1,1,"•",1,"X"],["X",1,1,1,"•"],[1,"•",1,"X"],[1,"•",1,1,1,1,"X"],[1,1,1,1,"X","•"],[1,1,1,1,"•",1,"X"]]}

--- a/data_yaml/circuits/steane-code--standard-encoding.yaml
+++ b/data_yaml/circuits/steane-code--standard-encoding.yaml
@@ -8,7 +8,7 @@ notes: |
   This circuit prepares the logical |0> state from a single physical |0> input qubit and six ancilla qubits initialized to |0>.
 gate_count: 12
 two_qubit_gate_count: 9
-depth: 5
+depth: 4
 qubit_count: 7
 crumble_url: https://algassert.com/crumble#circuit=H_4_2_6;CX_2_1_4_3_1_5_6_4_2_0_5_3_6_0_4_2_3_1_
 quirk_url: https://algassert.com/quirk#circuit={"cols":[[1,1,"H",1,"H",1,"H"],[1,"X","•"],[1,1,1,"X","•"],[1,"•",1,1,1,"X"],[1,1,1,1,"X",1,"•"],["X",1,"•"],[1,1,1,"X",1,"•"],["X",1,1,1,1,1,"•"],[1,1,"X",1,"•"],[1,"X",1,"•"]]}

--- a/scripts/add_circuit/circuit_validate.py
+++ b/scripts/add_circuit/circuit_validate.py
@@ -17,6 +17,25 @@ from .models import CircuitProperties, ExtractedCode
 _ALL_GATES = stim.gate_data()
 
 
+def _is_entangling(name: str) -> bool:
+    """True for genuinely-entangling two-qubit gates.
+
+    A plain ``SWAP`` is a qubit relabeling — free AOD routing on neutral atoms —
+    so it is NOT counted as a two-qubit/entangling gate. Two-qubit gates that do
+    entangle (``CX``/``CZ`` and hybrids like ``ISWAP``, ``CXSWAP``, ``SWAPCX``)
+    still count.
+    """
+    g = _ALL_GATES.get(name)
+    return g is not None and g.is_unitary and g.is_two_qubit_gate and name != "SWAP"
+
+
+def _counts_in_total(name: str) -> bool:
+    """True for gates counted in ``gate_count``: any unitary gate except a free
+    ``SWAP`` (SWAPs are free routing, excluded from every metric)."""
+    g = _ALL_GATES.get(name)
+    return g is not None and g.is_unitary and name != "SWAP"
+
+
 def _count_gates(instr: stim.CircuitInstruction) -> int:
     """Count the number of gate applications in an instruction.
 
@@ -25,10 +44,14 @@ def _count_gates(instr: stim.CircuitInstruction) -> int:
     return len(instr.target_groups())
 
 
-def _compute_depth_layered(circ: stim.Circuit, repeat_multiplier: int = 1) -> int:
-    """Compute depth by greedy layering when TICKs are absent.
+def _entangling_depth(circ: stim.Circuit) -> int:
+    """Two-qubit (entangling) circuit depth by greedy layering.
 
-    Assigns each gate to the earliest layer where none of its qubits are busy.
+    Only entangling two-qubit gates open layers; single-qubit gates and free
+    SWAPs are ignored. This is the neutral-atom-relevant depth and matches the
+    convention circuit-synth and the QEC literature report (TICK annotations are
+    not used — parallelism is derived from qubit usage). A ``REPEAT n`` block
+    contributes ``n ×`` the entangling depth of its body.
     """
     depth = 0
     # qubit_index -> layer that qubit is next free
@@ -36,14 +59,8 @@ def _compute_depth_layered(circ: stim.Circuit, repeat_multiplier: int = 1) -> in
 
     for item in circ:
         if isinstance(item, stim.CircuitRepeatBlock):
-            inner_depth = _compute_depth_layered(
-                item.body_copy(), repeat_multiplier * item.repeat_count
-            )
-            depth += inner_depth
-        else:
-            name = item.name
-            if name not in _ALL_GATES or not _ALL_GATES[name].is_unitary:
-                continue
+            depth += item.repeat_count * _entangling_depth(item.body_copy())
+        elif _is_entangling(item.name):
             for group in item.target_groups():
                 qubits = [t.value for t in group if t.is_qubit_target]
                 if not qubits:
@@ -55,53 +72,36 @@ def _compute_depth_layered(circ: stim.Circuit, repeat_multiplier: int = 1) -> in
                 if layer > depth:
                     depth = layer
 
-    return depth * repeat_multiplier
-
-
-def _has_ticks(circ: stim.Circuit) -> bool:
-    """Check whether a circuit (or any nested REPEAT block) contains TICK instructions."""
-    for item in circ:
-        if isinstance(item, stim.CircuitRepeatBlock):
-            if _has_ticks(item.body_copy()):
-                return True
-        elif item.name == "TICK":
-            return True
-    return False
+    return depth
 
 
 def _compute_depth_and_gates(
     circ: stim.Circuit, repeat_multiplier: int = 1
 ) -> tuple[int, int, int]:
-    """Recursively compute depth, gate count, and 2Q gate count, respecting REPEAT blocks.
+    """Compute (2q-entangling depth, gate count, 2q gate count), respecting
+    REPEAT blocks.
 
-    If the circuit contains TICKs (at any nesting level), depth is the TICK count.
-    Otherwise, depth is computed by greedy gate layering.
+    SWAPs are excluded from all three metrics (free routing). ``depth`` is the
+    two-qubit entangling depth; ``gate_count`` counts every non-SWAP unitary
+    gate; ``two_qubit_gate_count`` counts entangling two-qubit gates only.
     """
-    depth = 0
     gate_count = 0
     two_qubit_gate_count = 0
 
     for item in circ:
         if isinstance(item, stim.CircuitRepeatBlock):
-            inner_depth, inner_gates, inner_2q = _compute_depth_and_gates(
+            _, inner_gates, inner_2q = _compute_depth_and_gates(
                 item.body_copy(), repeat_multiplier * item.repeat_count
             )
-            depth += inner_depth
             gate_count += inner_gates
             two_qubit_gate_count += inner_2q
-        else:
-            name = item.name
-            if name == "TICK":
-                depth += repeat_multiplier
-            elif name in _ALL_GATES and _ALL_GATES[name].is_unitary:
-                n_apps = _count_gates(item) * repeat_multiplier
-                gate_count += n_apps
-                if _ALL_GATES[name].is_two_qubit_gate:
-                    two_qubit_gate_count += n_apps
+        elif _counts_in_total(item.name):
+            n_apps = _count_gates(item) * repeat_multiplier
+            gate_count += n_apps
+            if _is_entangling(item.name):
+                two_qubit_gate_count += n_apps
 
-    if not _has_ticks(circ):
-        depth = _compute_depth_layered(circ, repeat_multiplier)
-
+    depth = _entangling_depth(circ)
     return depth, gate_count, two_qubit_gate_count
 
 

--- a/scripts/tests/test_circuit_validate.py
+++ b/scripts/tests/test_circuit_validate.py
@@ -93,14 +93,15 @@ class TestCircuitProperties:
         assert props.qubit_count == 4
 
     def test_depth_from_ticks(self):
+        # 2q-entangling depth (TICKs ignored): CNOT(0,1) layer 1, CNOT(0,2) layer 2.
         props = circuit_properties(CIRCUIT_WITH_TICKS)
         assert props.depth == 2
 
     def test_depth_no_ticks(self):
         props = circuit_properties(ENCODING_CIRCUIT)
-        # No TICKs → layered depth: H(q0) layer 1, CNOT(q0,q1) layer 2,
-        # CNOT(q0,q2) layer 3, CNOT(q0,q3) layer 4
-        assert props.depth == 4
+        # 2q-entangling depth (single-qubit H ignored): CNOT(0,1) layer 1,
+        # CNOT(0,2) layer 2, CNOT(0,3) layer 3.
+        assert props.depth == 3
 
     def test_gate_count(self):
         props = circuit_properties(ENCODING_CIRCUIT)
@@ -130,8 +131,8 @@ class TestCircuitProperties:
 
     def test_repeat_depth(self):
         props = circuit_properties(CIRCUIT_WITH_REPEAT)
-        # 1 TICK before REPEAT + 10 * 2 TICKs inside = 21
-        assert props.depth == 21
+        # 2q-entangling depth: 10 * (CNOT(0,1) layer 1, CNOT(0,2) layer 2) = 20
+        assert props.depth == 20
 
     def test_repeat_qubit_count(self):
         props = circuit_properties(CIRCUIT_WITH_REPEAT)
@@ -150,8 +151,8 @@ class TestCircuitProperties:
 
     def test_nested_repeat_depth(self):
         props = circuit_properties(CIRCUIT_NESTED_REPEAT)
-        # 5*(1 TICK + 3*1 TICK) = 20
-        assert props.depth == 20
+        # 2q-entangling depth: 5 * (3 * CNOT(0,1) layer 1) = 15
+        assert props.depth == 15
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes how circuit metrics are computed. Two issues:

1. **`two_qubit_gate_count` counted SWAPs.** stim classifies `SWAP` as a two-qubit gate, so it was included — but a plain SWAP is free AOD routing (qubit relabeling), not an entangling operation.
2. **`depth` was full-circuit depth**, layering *all* gates including single-qubit ones (and using TICK counts when present), rather than the two-qubit (entangling) depth that circuit-synth and the QEC literature report.

## Changes (`scripts/add_circuit/circuit_validate.py`)

- **SWAP excluded everywhere** — from `two_qubit_gate_count`, `gate_count`, and `depth`. Genuinely-entangling hybrids (`ISWAP`, `CXSWAP`, `SWAPCX`) still count.
- **`depth` is now the 2-qubit (entangling) depth** — greedy layering over entangling gates only; single-qubit gates and SWAPs don't open layers. TICK annotations no longer drive depth. (Also fixes a nested-`REPEAT` double-count found via the `2q_depth ≤ 2q_count` sanity check.)

## Impact on existing data

Recomputed all stored circuit metrics. **Only the two Steane circuits with single-qubit gates change** (depth 5 → 4). The mqt-qecc circuits use resets + CX only (no single-qubit unitary gates) and contain no SWAPs, so their `two_qubit_gate_count`/`gate_count`/`depth` are unchanged. Metrics are stored per-circuit in YAML (read verbatim by the DB build), which is why they're recomputed here.

## Tests

Updated the 3 depth unit tests to the new 2q-entangling semantics. Full suite: 155 passed; ruff + `validate:yaml` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)