### PR TITLE
docs: CLAUDE.md tech stack reflects Astro v7

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,12 +100,12 @@ A maintainer reviews the issue, then uses the ingestion pipeline to add the circ
 
 | Layer     | Choice                      | Rationale                                      |
 | --------- | --------------------------- | ---------------------------------------------- |
-| Framework | Astro v6 (TypeScript)       | Static-first with SSR opt-in for dynamic pages |
+| Framework | Astro v7 (TypeScript)       | Static-first with SSR opt-in for dynamic pages |
 | Database  | SQLite via `better-sqlite3` | Zero external services, file-based, simple     |
 | Styling   | Tailwind CSS                | Standard utility-first, minimal custom CSS     |
 | Hosting   | Self-hosted (agnostic)      | Avoid platform lock-in                         |
 
-**Rendering strategy — Astro v6 (static default, SSR opt-in):**
+**Rendering strategy — Astro v7 (static default, SSR opt-in):**
 
 - Static pages: landing page, 404 (pre-rendered at build time)
 - SSR pages (`prerender = false`): all `/codes/...` and `/circuits/...` routes, `/api/search` (rendered on request, read from SQLite)


### PR DESCRIPTION
Follow-up to the Astro 6→7 Renovate merge: update the two "Astro v6" references in CLAUDE.md (tech-stack table + rendering-strategy heading). Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)