### PR TITLE
feat(tools): rework tools section — paper links, new entries, two-section page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,8 +43,9 @@ codes
   -- canonical_hash: SHA256 of canonical form for dedup (indexed)
 
 tools
-  id, name, slug, description, homepage_url, github_url, created_at
+  id, name, slug, description, homepage_url, github_url, paper_urls, created_at
   -- software tools used to create circuits
+  -- paper_urls: JSON-encoded array of associated paper URLs
 
 circuits
   id, qec_id, code_id → codes, name, slug, notes, source,

--- a/data/migrations/013_tool_paper_urls.sql
+++ b/data/migrations/013_tool_paper_urls.sql
@@ -1,0 +1,3 @@
+-- Migration: Add paper_urls (JSON-encoded array of paper URLs) to tools
+
+ALTER TABLE tools ADD COLUMN paper_urls TEXT;

--- a/data_yaml/circuits/17-1-5--rl-fully-connected-zero-0.yaml
+++ b/data_yaml/circuits/17-1-5--rl-fully-connected-zero-0.yaml
@@ -1,5 +1,6 @@
 qec_id: 200
 name: RL fully-connected zero 0
+tool: rlftqc
 notes: "Source file: distance-5/17-1-5/17_3_1_combined.stim. Logical state: zero.
   Connectivity: fully-connected. Gate set: CX,H,I. Flag/ancilla qubits: [17, 18, 19].
   Canonicalization qubit permutation (stored qubit i = original qubit permutation[i]):

--- a/data_yaml/circuits/17-1-5--rl-fully-connected-zero-1.yaml
+++ b/data_yaml/circuits/17-1-5--rl-fully-connected-zero-1.yaml
@@ -1,5 +1,6 @@
 qec_id: 201
 name: RL fully-connected zero 1
+tool: rlftqc
 notes: "Source file: distance-5/17-1-5/17_3_3_combined.stim. Logical state: zero.
   Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla qubits: [17, 18, 19].
   Canonicalization qubit permutation (stored qubit i = original qubit permutation[i]):

--- a/data_yaml/circuits/17-1-5--rl-fully-connected-zero-2.yaml
+++ b/data_yaml/circuits/17-1-5--rl-fully-connected-zero-2.yaml
@@ -1,5 +1,6 @@
 qec_id: 202
 name: RL fully-connected zero 2
+tool: rlftqc
 notes: "Source file: distance-5/17-1-5/17_3_5_combined.stim. Logical state: zero.
   Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla qubits: [17, 18, 19].
   Canonicalization qubit permutation (stored qubit i = original qubit permutation[i]):

--- a/data_yaml/circuits/17-1-5--rl-fully-connected-zero-3.yaml
+++ b/data_yaml/circuits/17-1-5--rl-fully-connected-zero-3.yaml
@@ -1,5 +1,6 @@
 qec_id: 315
 name: RL fully-connected zero 3
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/17-1-5/17_3.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H. Canonicalization qubit
   permutation (stored qubit i = original qubit permutation[i]): [0, 1, 4, 8, 12, 6,

--- a/data_yaml/circuits/17-1-5--rl-fully-connected-zero-4.yaml
+++ b/data_yaml/circuits/17-1-5--rl-fully-connected-zero-4.yaml
@@ -1,5 +1,6 @@
 qec_id: 316
 name: RL fully-connected zero 4
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/17-1-5/17_9.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H. Canonicalization qubit
   permutation (stored qubit i = original qubit permutation[i]): [0, 1, 4, 8, 12, 6,

--- a/data_yaml/circuits/19-1-5--rl-fully-connected-zero-0.yaml
+++ b/data_yaml/circuits/19-1-5--rl-fully-connected-zero-0.yaml
@@ -1,5 +1,6 @@
 qec_id: 203
 name: RL fully-connected zero 0
+tool: rlftqc
 notes: "Source file: distance-5/19-1-5/19_0_9_combined.stim. Logical state: zero.
   Connectivity: fully-connected. Gate set: CX,H,I. Flag/ancilla qubits: [19, 20, 21,
   22]. Canonicalization qubit permutation (stored qubit i = original qubit permutation[i]):

--- a/data_yaml/circuits/19-1-5--rl-fully-connected-zero-1.yaml
+++ b/data_yaml/circuits/19-1-5--rl-fully-connected-zero-1.yaml
@@ -1,5 +1,6 @@
 qec_id: 204
 name: RL fully-connected zero 1
+tool: rlftqc
 notes: "Source file: distance-5/19-1-5/19_4_0_combined.stim. Logical state: zero.
   Connectivity: fully-connected. Gate set: CX,H,I. Flag/ancilla qubits: [19, 20, 21,
   22]. Canonicalization qubit permutation (stored qubit i = original qubit permutation[i]):

--- a/data_yaml/circuits/19-1-5--rl-fully-connected-zero-2.yaml
+++ b/data_yaml/circuits/19-1-5--rl-fully-connected-zero-2.yaml
@@ -1,5 +1,6 @@
 qec_id: 317
 name: RL fully-connected zero 2
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/19-1-5/19_4.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H. Canonicalization qubit
   permutation (stored qubit i = original qubit permutation[i]): [11, 10, 6, 5, 4,

--- a/data_yaml/circuits/19-1-5--rl-fully-connected-zero-3.yaml
+++ b/data_yaml/circuits/19-1-5--rl-fully-connected-zero-3.yaml
@@ -1,5 +1,6 @@
 qec_id: 318
 name: RL fully-connected zero 3
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/19-1-5/19_5.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H. Canonicalization qubit
   permutation (stored qubit i = original qubit permutation[i]): [11, 10, 6, 5, 4,

--- a/data_yaml/circuits/23-1-7--rl-fully-connected-zero-0.yaml
+++ b/data_yaml/circuits/23-1-7--rl-fully-connected-zero-0.yaml
@@ -1,5 +1,6 @@
 qec_id: 319
 name: RL fully-connected zero 0
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/23-1-7/23_2.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H,S. Canonicalization qubit
   permutation (stored qubit i = original qubit permutation[i]): [10, 9, 8, 7, 6, 5,

--- a/data_yaml/circuits/five-qubit-code--rl-fully-connected-minus-0.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-fully-connected-minus-0.yaml
@@ -1,5 +1,6 @@
 qec_id: 239
 name: RL fully-connected minus 0
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/5-1-3/minus_logical/5_4_0.stim.
   Logical state: minus. Connectivity: fully-connected. Gate set: CX,CZ,H. Flag/ancilla

--- a/data_yaml/circuits/five-qubit-code--rl-fully-connected-minus-1.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-fully-connected-minus-1.yaml
@@ -1,5 +1,6 @@
 qec_id: 240
 name: RL fully-connected minus 1
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/5-1-3/minus_logical/5_7_2.stim.
   Logical state: minus. Connectivity: fully-connected. Gate set: CX,CZ,H. Flag/ancilla

--- a/data_yaml/circuits/five-qubit-code--rl-fully-connected-minus-2.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-fully-connected-minus-2.yaml
@@ -1,5 +1,6 @@
 qec_id: 241
 name: RL fully-connected minus 2
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/5-1-3/minus_logical/5_7_6.stim.
   Logical state: minus. Connectivity: fully-connected. Gate set: CX,CZ,H. Flag/ancilla

--- a/data_yaml/circuits/five-qubit-code--rl-fully-connected-minus-3.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-fully-connected-minus-3.yaml
@@ -1,5 +1,6 @@
 qec_id: 242
 name: RL fully-connected minus 3
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/5-1-3/minus_logical/5_7_7.stim.
   Logical state: minus. Connectivity: fully-connected. Gate set: CX,CZ,H. Flag/ancilla

--- a/data_yaml/circuits/five-qubit-code--rl-fully-connected-minus-4.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-fully-connected-minus-4.yaml
@@ -1,5 +1,6 @@
 qec_id: 243
 name: RL fully-connected minus 4
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/5-1-3/minus_logical/5_7_8.stim.
   Logical state: minus. Connectivity: fully-connected. Gate set: CX,CZ,H. Flag/ancilla

--- a/data_yaml/circuits/five-qubit-code--rl-fully-connected-one-0.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-fully-connected-one-0.yaml
@@ -1,5 +1,6 @@
 qec_id: 244
 name: RL fully-connected one 0
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/5-1-3/one_logical/5_3_0.stim.
   Logical state: one. Connectivity: fully-connected. Gate set: CX,CZ,H. Flag/ancilla

--- a/data_yaml/circuits/five-qubit-code--rl-fully-connected-one-1.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-fully-connected-one-1.yaml
@@ -1,5 +1,6 @@
 qec_id: 245
 name: RL fully-connected one 1
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/5-1-3/one_logical/5_3_2.stim.
   Logical state: one. Connectivity: fully-connected. Gate set: CX,CZ,H. Flag/ancilla

--- a/data_yaml/circuits/five-qubit-code--rl-fully-connected-one-2.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-fully-connected-one-2.yaml
@@ -1,5 +1,6 @@
 qec_id: 246
 name: RL fully-connected one 2
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/5-1-3/one_logical/5_3_5.stim.
   Logical state: one. Connectivity: fully-connected. Gate set: CX,CZ,H. Flag/ancilla

--- a/data_yaml/circuits/five-qubit-code--rl-fully-connected-one-3.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-fully-connected-one-3.yaml
@@ -1,5 +1,6 @@
 qec_id: 247
 name: RL fully-connected one 3
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/5-1-3/one_logical/5_3_6.stim.
   Logical state: one. Connectivity: fully-connected. Gate set: CX,CZ,H. Flag/ancilla

--- a/data_yaml/circuits/five-qubit-code--rl-fully-connected-one-4.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-fully-connected-one-4.yaml
@@ -1,5 +1,6 @@
 qec_id: 248
 name: RL fully-connected one 4
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/5-1-3/one_logical/5_3_7.stim.
   Logical state: one. Connectivity: fully-connected. Gate set: CX,CZ,H. Flag/ancilla

--- a/data_yaml/circuits/five-qubit-code--rl-fully-connected-one-5.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-fully-connected-one-5.yaml
@@ -1,5 +1,6 @@
 qec_id: 249
 name: RL fully-connected one 5
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/5-1-3/one_logical/5_3_8.stim.
   Logical state: one. Connectivity: fully-connected. Gate set: CX,CZ,H. Flag/ancilla

--- a/data_yaml/circuits/five-qubit-code--rl-fully-connected-one-6.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-fully-connected-one-6.yaml
@@ -1,5 +1,6 @@
 qec_id: 250
 name: RL fully-connected one 6
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/5-1-3/one_logical/5_3_9.stim.
   Logical state: one. Connectivity: fully-connected. Gate set: CX,CZ,H. Flag/ancilla

--- a/data_yaml/circuits/five-qubit-code--rl-fully-connected-zero-0.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-fully-connected-zero-0.yaml
@@ -1,5 +1,6 @@
 qec_id: 320
 name: RL fully-connected zero 0
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/5-1-3/5_0.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H,S. Canonicalization qubit
   permutation (stored qubit i = original qubit permutation[i]): [0, 1, 2, 3, 4]"

--- a/data_yaml/circuits/five-qubit-code--rl-fully-connected-zero-1.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-fully-connected-zero-1.yaml
@@ -1,5 +1,6 @@
 qec_id: 321
 name: RL fully-connected zero 1
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/5-1-3/5_1.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H,S. Canonicalization qubit
   permutation (stored qubit i = original qubit permutation[i]): [0, 1, 2, 3, 4]"

--- a/data_yaml/circuits/five-qubit-code--rl-fully-connected-zero-10.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-fully-connected-zero-10.yaml
@@ -1,5 +1,6 @@
 qec_id: 404
 name: RL fully-connected zero 10
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/5-1-3/5-0-quantinuum_1_combined.stim.
   Logical state: zero. Connectivity: fully-connected. Gate set: CX,CZ,H. Flag/ancilla
   qubits: [5, 6, 7]. Canonicalization qubit permutation (stored qubit i = original

--- a/data_yaml/circuits/five-qubit-code--rl-fully-connected-zero-11.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-fully-connected-zero-11.yaml
@@ -1,5 +1,6 @@
 qec_id: 405
 name: RL fully-connected zero 11
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/5-1-3/5-0-quantinuum_2_combined.stim.
   Logical state: zero. Connectivity: fully-connected. Gate set: CX,CZ,H. Flag/ancilla
   qubits: [5, 6, 7]. Canonicalization qubit permutation (stored qubit i = original

--- a/data_yaml/circuits/five-qubit-code--rl-fully-connected-zero-12.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-fully-connected-zero-12.yaml
@@ -1,5 +1,6 @@
 qec_id: 406
 name: RL fully-connected zero 12
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/5-1-3/5-0-quantinuum_4_combined.stim.
   Logical state: zero. Connectivity: fully-connected. Gate set: CX,CZ,H. Flag/ancilla
   qubits: [5, 6, 7]. Canonicalization qubit permutation (stored qubit i = original

--- a/data_yaml/circuits/five-qubit-code--rl-fully-connected-zero-13.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-fully-connected-zero-13.yaml
@@ -1,5 +1,6 @@
 qec_id: 407
 name: RL fully-connected zero 13
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/5-1-3/5-0-quantinuum_5_combined.stim.
   Logical state: zero. Connectivity: fully-connected. Gate set: CX,CZ,H. Flag/ancilla
   qubits: [5, 6, 7]. Canonicalization qubit permutation (stored qubit i = original

--- a/data_yaml/circuits/five-qubit-code--rl-fully-connected-zero-14.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-fully-connected-zero-14.yaml
@@ -1,5 +1,6 @@
 qec_id: 408
 name: RL fully-connected zero 14
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/5-1-3/5-0-quantinuum_9_combined.stim.
   Logical state: zero. Connectivity: fully-connected. Gate set: CX,CZ,H. Flag/ancilla
   qubits: [5, 6, 7]. Canonicalization qubit permutation (stored qubit i = original

--- a/data_yaml/circuits/five-qubit-code--rl-fully-connected-zero-2.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-fully-connected-zero-2.yaml
@@ -1,5 +1,6 @@
 qec_id: 322
 name: RL fully-connected zero 2
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/5-1-3/5_2.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H,S. Canonicalization qubit
   permutation (stored qubit i = original qubit permutation[i]): [0, 1, 2, 3, 4]"

--- a/data_yaml/circuits/five-qubit-code--rl-fully-connected-zero-3.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-fully-connected-zero-3.yaml
@@ -1,5 +1,6 @@
 qec_id: 323
 name: RL fully-connected zero 3
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/5-1-3/5_3.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H,S. Canonicalization qubit
   permutation (stored qubit i = original qubit permutation[i]): [0, 1, 2, 3, 4]"

--- a/data_yaml/circuits/five-qubit-code--rl-fully-connected-zero-4.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-fully-connected-zero-4.yaml
@@ -1,5 +1,6 @@
 qec_id: 324
 name: RL fully-connected zero 4
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/5-1-3/5_4.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H,S. Canonicalization qubit
   permutation (stored qubit i = original qubit permutation[i]): [0, 1, 2, 3, 4]"

--- a/data_yaml/circuits/five-qubit-code--rl-fully-connected-zero-5.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-fully-connected-zero-5.yaml
@@ -1,5 +1,6 @@
 qec_id: 325
 name: RL fully-connected zero 5
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/5-1-3/5_5.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H,S. Canonicalization qubit
   permutation (stored qubit i = original qubit permutation[i]): [0, 1, 2, 3, 4]"

--- a/data_yaml/circuits/five-qubit-code--rl-fully-connected-zero-6.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-fully-connected-zero-6.yaml
@@ -1,5 +1,6 @@
 qec_id: 326
 name: RL fully-connected zero 6
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/5-1-3/5_6.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H,S. Canonicalization qubit
   permutation (stored qubit i = original qubit permutation[i]): [0, 1, 2, 3, 4]"

--- a/data_yaml/circuits/five-qubit-code--rl-fully-connected-zero-7.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-fully-connected-zero-7.yaml
@@ -1,5 +1,6 @@
 qec_id: 327
 name: RL fully-connected zero 7
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/5-1-3/5_7.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H,S. Canonicalization qubit
   permutation (stored qubit i = original qubit permutation[i]): [0, 1, 2, 3, 4]"

--- a/data_yaml/circuits/five-qubit-code--rl-fully-connected-zero-8.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-fully-connected-zero-8.yaml
@@ -1,5 +1,6 @@
 qec_id: 328
 name: RL fully-connected zero 8
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/5-1-3/5_8.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H,S. Canonicalization qubit
   permutation (stored qubit i = original qubit permutation[i]): [0, 1, 2, 3, 4]"

--- a/data_yaml/circuits/five-qubit-code--rl-fully-connected-zero-9.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-fully-connected-zero-9.yaml
@@ -1,5 +1,6 @@
 qec_id: 329
 name: RL fully-connected zero 9
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/5-1-3/5_9.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H,S. Canonicalization qubit
   permutation (stored qubit i = original qubit permutation[i]): [0, 1, 2, 3, 4]"

--- a/data_yaml/circuits/five-qubit-code--rl-ibm-lima-zero-0.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-ibm-lima-zero-0.yaml
@@ -1,5 +1,6 @@
 qec_id: 358
 name: RL ibm lima zero 0
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/5-1-3-lima/5_0.stim. Logical state:
   zero. Connectivity: ibm. Gate set: CX,S,SQRT_X,X. Device: lima. Device qubit placement
   (Qiskit indices): 0,4,2,1,3. Canonicalization qubit permutation (stored qubit i

--- a/data_yaml/circuits/five-qubit-code--rl-ibm-lima-zero-1.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-ibm-lima-zero-1.yaml
@@ -1,5 +1,6 @@
 qec_id: 359
 name: RL ibm lima zero 1
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/5-1-3-lima/5_1.stim. Logical state:
   zero. Connectivity: ibm. Gate set: CX,S,SQRT_X,X. Device: lima. Device qubit placement
   (Qiskit indices): 0,4,2,1,3. Canonicalization qubit permutation (stored qubit i

--- a/data_yaml/circuits/five-qubit-code--rl-ibm-lima-zero-2.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-ibm-lima-zero-2.yaml
@@ -1,5 +1,6 @@
 qec_id: 360
 name: RL ibm lima zero 2
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/5-1-3-lima/5_2.stim. Logical state:
   zero. Connectivity: ibm. Gate set: CX,S,SQRT_X,X. Device: lima. Device qubit placement
   (Qiskit indices): 0,4,2,1,3. Canonicalization qubit permutation (stored qubit i

--- a/data_yaml/circuits/five-qubit-code--rl-ibm-lima-zero-3.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-ibm-lima-zero-3.yaml
@@ -1,5 +1,6 @@
 qec_id: 361
 name: RL ibm lima zero 3
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/5-1-3-lima/5_3.stim. Logical state:
   zero. Connectivity: ibm. Gate set: CX,S,SQRT_X,X. Device: lima. Device qubit placement
   (Qiskit indices): 0,4,2,1,3. Canonicalization qubit permutation (stored qubit i

--- a/data_yaml/circuits/five-qubit-code--rl-ibm-lima-zero-4.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-ibm-lima-zero-4.yaml
@@ -1,5 +1,6 @@
 qec_id: 362
 name: RL ibm lima zero 4
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/5-1-3-lima/5_4.stim. Logical state:
   zero. Connectivity: ibm. Gate set: CX,S,SQRT_X,X. Device: lima. Device qubit placement
   (Qiskit indices): 0,4,2,1,3. Canonicalization qubit permutation (stored qubit i

--- a/data_yaml/circuits/five-qubit-code--rl-ibm-lima-zero-5.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-ibm-lima-zero-5.yaml
@@ -1,5 +1,6 @@
 qec_id: 363
 name: RL ibm lima zero 5
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/5-1-3-lima/5_5.stim. Logical state:
   zero. Connectivity: ibm. Gate set: CX,S,SQRT_X,X. Device: lima. Device qubit placement
   (Qiskit indices): 0,4,2,1,3. Canonicalization qubit permutation (stored qubit i

--- a/data_yaml/circuits/five-qubit-code--rl-ibm-lima-zero-6.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-ibm-lima-zero-6.yaml
@@ -1,5 +1,6 @@
 qec_id: 364
 name: RL ibm lima zero 6
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/5-1-3-lima/5_6.stim. Logical state:
   zero. Connectivity: ibm. Gate set: CX,S,SQRT_X,X. Device: lima. Device qubit placement
   (Qiskit indices): 0,4,2,1,3. Canonicalization qubit permutation (stored qubit i

--- a/data_yaml/circuits/five-qubit-code--rl-ibm-lima-zero-7.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-ibm-lima-zero-7.yaml
@@ -1,5 +1,6 @@
 qec_id: 365
 name: RL ibm lima zero 7
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/5-1-3-lima/5_7.stim. Logical state:
   zero. Connectivity: ibm. Gate set: CX,S,SQRT_X,X. Device: lima. Device qubit placement
   (Qiskit indices): 0,4,2,1,3. Canonicalization qubit permutation (stored qubit i

--- a/data_yaml/circuits/five-qubit-code--rl-ibm-lima-zero-8.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-ibm-lima-zero-8.yaml
@@ -1,5 +1,6 @@
 qec_id: 366
 name: RL ibm lima zero 8
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/5-1-3-lima/5_8.stim. Logical state:
   zero. Connectivity: ibm. Gate set: CX,S,SQRT_X,X. Device: lima. Device qubit placement
   (Qiskit indices): 0,4,2,1,3. Canonicalization qubit permutation (stored qubit i

--- a/data_yaml/circuits/five-qubit-code--rl-ibm-lima-zero-9.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-ibm-lima-zero-9.yaml
@@ -1,5 +1,6 @@
 qec_id: 367
 name: RL ibm lima zero 9
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/5-1-3-lima/5_9.stim. Logical state:
   zero. Connectivity: ibm. Gate set: CX,S,SQRT_X. Device: lima. Device qubit placement
   (Qiskit indices): 0,4,2,1,3. Canonicalization qubit permutation (stored qubit i

--- a/data_yaml/circuits/five-qubit-code--rl-ibm-manila-zero-0.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-ibm-manila-zero-0.yaml
@@ -1,5 +1,6 @@
 qec_id: 368
 name: RL ibm manila zero 0
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/5-1-3-manila/5_0.stim. Logical
   state: zero. Connectivity: ibm. Gate set: CX,S,SQRT_X,X. Device: manila. Device
   qubit placement (Qiskit indices): 4,3,0,2,1. Canonicalization qubit permutation

--- a/data_yaml/circuits/five-qubit-code--rl-ibm-manila-zero-1.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-ibm-manila-zero-1.yaml
@@ -1,5 +1,6 @@
 qec_id: 369
 name: RL ibm manila zero 1
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/5-1-3-manila/5_1.stim. Logical
   state: zero. Connectivity: ibm. Gate set: CX,SQRT_X,X. Device: manila. Device qubit
   placement (Qiskit indices): 4,3,0,2,1. Canonicalization qubit permutation (stored

--- a/data_yaml/circuits/five-qubit-code--rl-ibm-manila-zero-2.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-ibm-manila-zero-2.yaml
@@ -1,5 +1,6 @@
 qec_id: 370
 name: RL ibm manila zero 2
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/5-1-3-manila/5_2.stim. Logical
   state: zero. Connectivity: ibm. Gate set: CX,S,SQRT_X,X. Device: manila. Device
   qubit placement (Qiskit indices): 4,3,0,2,1. Canonicalization qubit permutation

--- a/data_yaml/circuits/five-qubit-code--rl-ibm-manila-zero-3.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-ibm-manila-zero-3.yaml
@@ -1,5 +1,6 @@
 qec_id: 371
 name: RL ibm manila zero 3
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/5-1-3-manila/5_3.stim. Logical
   state: zero. Connectivity: ibm. Gate set: CX,SQRT_X,X. Device: manila. Device qubit
   placement (Qiskit indices): 4,3,0,2,1. Canonicalization qubit permutation (stored

--- a/data_yaml/circuits/five-qubit-code--rl-ibm-manila-zero-4.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-ibm-manila-zero-4.yaml
@@ -1,5 +1,6 @@
 qec_id: 372
 name: RL ibm manila zero 4
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/5-1-3-manila/5_4.stim. Logical
   state: zero. Connectivity: ibm. Gate set: CX,S,SQRT_X,X. Device: manila. Device
   qubit placement (Qiskit indices): 4,3,0,2,1. Canonicalization qubit permutation

--- a/data_yaml/circuits/five-qubit-code--rl-ibm-manila-zero-5.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-ibm-manila-zero-5.yaml
@@ -1,5 +1,6 @@
 qec_id: 373
 name: RL ibm manila zero 5
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/5-1-3-manila/5_5.stim. Logical
   state: zero. Connectivity: ibm. Gate set: CX,SQRT_X,X. Device: manila. Device qubit
   placement (Qiskit indices): 4,3,0,2,1. Canonicalization qubit permutation (stored

--- a/data_yaml/circuits/five-qubit-code--rl-ibm-manila-zero-6.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-ibm-manila-zero-6.yaml
@@ -1,5 +1,6 @@
 qec_id: 374
 name: RL ibm manila zero 6
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/5-1-3-manila/5_6.stim. Logical
   state: zero. Connectivity: ibm. Gate set: CX,S,SQRT_X. Device: manila. Device qubit
   placement (Qiskit indices): 4,3,0,2,1. Canonicalization qubit permutation (stored

--- a/data_yaml/circuits/five-qubit-code--rl-ibm-manila-zero-7.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-ibm-manila-zero-7.yaml
@@ -1,5 +1,6 @@
 qec_id: 375
 name: RL ibm manila zero 7
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/5-1-3-manila/5_7.stim. Logical
   state: zero. Connectivity: ibm. Gate set: CX,SQRT_X,X. Device: manila. Device qubit
   placement (Qiskit indices): 4,3,0,2,1. Canonicalization qubit permutation (stored

--- a/data_yaml/circuits/five-qubit-code--rl-ibm-manila-zero-8.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-ibm-manila-zero-8.yaml
@@ -1,5 +1,6 @@
 qec_id: 376
 name: RL ibm manila zero 8
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/5-1-3-manila/5_8.stim. Logical
   state: zero. Connectivity: ibm. Gate set: CX,SQRT_X,X. Device: manila. Device qubit
   placement (Qiskit indices): 4,3,0,2,1. Canonicalization qubit permutation (stored

--- a/data_yaml/circuits/five-qubit-code--rl-ibm-manila-zero-9.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-ibm-manila-zero-9.yaml
@@ -1,5 +1,6 @@
 qec_id: 377
 name: RL ibm manila zero 9
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/5-1-3-manila/5_9.stim. Logical
   state: zero. Connectivity: ibm. Gate set: CX,S,SQRT_X. Device: manila. Device qubit
   placement (Qiskit indices): 4,3,0,2,1. Canonicalization qubit permutation (stored

--- a/data_yaml/circuits/five-qubit-code--rl-ibm-tokyo-zero-0.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-ibm-tokyo-zero-0.yaml
@@ -1,5 +1,6 @@
 qec_id: 284
 name: RL ibm tokyo zero 0
+tool: rlftqc
 notes: "Source file: integrated-ft-logical-state-preparation/ibm/5-1-3-tokyo/1/5_4_1.stim.
   Logical state: zero. Connectivity: ibm. Gate set: CX,CZ,H. Device: tokyo. Flag/ancilla
   qubits: [5, 6]. Device qubit placement (Qiskit indices): 6,5,1,7,11. Canonicalization

--- a/data_yaml/circuits/five-qubit-code--rl-ibm-tokyo-zero-1.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-ibm-tokyo-zero-1.yaml
@@ -1,5 +1,6 @@
 qec_id: 285
 name: RL ibm tokyo zero 1
+tool: rlftqc
 notes: "Source file: integrated-ft-logical-state-preparation/ibm/5-1-3-tokyo/1/5_4_5.stim.
   Logical state: zero. Connectivity: ibm. Gate set: CX,CZ,H. Device: tokyo. Flag/ancilla
   qubits: [5, 6]. Device qubit placement (Qiskit indices): 6,5,1,7,11. Canonicalization

--- a/data_yaml/circuits/five-qubit-code--rl-ibm-tokyo-zero-2.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-ibm-tokyo-zero-2.yaml
@@ -1,5 +1,6 @@
 qec_id: 286
 name: RL ibm tokyo zero 2
+tool: rlftqc
 notes: "Source file: integrated-ft-logical-state-preparation/ibm/5-1-3-tokyo/1/5_4_7.stim.
   Logical state: zero. Connectivity: ibm. Gate set: CX,CZ,H. Device: tokyo. Flag/ancilla
   qubits: [5, 6]. Device qubit placement (Qiskit indices): 6,5,1,7,11. Canonicalization

--- a/data_yaml/circuits/five-qubit-code--rl-ibm-tokyo-zero-3.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-ibm-tokyo-zero-3.yaml
@@ -1,5 +1,6 @@
 qec_id: 287
 name: RL ibm tokyo zero 3
+tool: rlftqc
 notes: "Source file: integrated-ft-logical-state-preparation/ibm/5-1-3-tokyo/1/5_4_9.stim.
   Logical state: zero. Connectivity: ibm. Gate set: CX,CZ,H. Device: tokyo. Flag/ancilla
   qubits: [5, 6]. Device qubit placement (Qiskit indices): 6,5,1,7,11. Canonicalization

--- a/data_yaml/circuits/five-qubit-code--rl-ibm-tokyo-zero-4.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-ibm-tokyo-zero-4.yaml
@@ -1,5 +1,6 @@
 qec_id: 288
 name: RL ibm tokyo zero 4
+tool: rlftqc
 notes: "Source file: integrated-ft-logical-state-preparation/ibm/5-1-3-tokyo/2/5_4_0.stim.
   Logical state: zero. Connectivity: ibm. Gate set: CX,CZ,H. Device: tokyo. Flag/ancilla
   qubits: [5, 6]. Device qubit placement (Qiskit indices): 6,5,1,7,11. Canonicalization

--- a/data_yaml/circuits/five-qubit-code--rl-ibm-tokyo-zero-5.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-ibm-tokyo-zero-5.yaml
@@ -1,5 +1,6 @@
 qec_id: 289
 name: RL ibm tokyo zero 5
+tool: rlftqc
 notes: "Source file: integrated-ft-logical-state-preparation/ibm/5-1-3-tokyo/2/5_4_1.stim.
   Logical state: zero. Connectivity: ibm. Gate set: CX,CZ,H. Device: tokyo. Flag/ancilla
   qubits: [5, 6]. Device qubit placement (Qiskit indices): 6,5,1,7,11. Canonicalization

--- a/data_yaml/circuits/five-qubit-code--rl-ibm-tokyo-zero-6.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-ibm-tokyo-zero-6.yaml
@@ -1,5 +1,6 @@
 qec_id: 290
 name: RL ibm tokyo zero 6
+tool: rlftqc
 notes: "Source file: integrated-ft-logical-state-preparation/ibm/5-1-3-tokyo/2/5_4_3.stim.
   Logical state: zero. Connectivity: ibm. Gate set: CX,CZ,H. Device: tokyo. Flag/ancilla
   qubits: [5, 6]. Device qubit placement (Qiskit indices): 6,5,1,7,11. Canonicalization

--- a/data_yaml/circuits/five-qubit-code--rl-ibm-tokyo-zero-7.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-ibm-tokyo-zero-7.yaml
@@ -1,5 +1,6 @@
 qec_id: 291
 name: RL ibm tokyo zero 7
+tool: rlftqc
 notes: "Source file: integrated-ft-logical-state-preparation/ibm/5-1-3-tokyo/2/5_4_7.stim.
   Logical state: zero. Connectivity: ibm. Gate set: CX,CZ,H. Device: tokyo. Flag/ancilla
   qubits: [5, 6]. Device qubit placement (Qiskit indices): 6,5,1,7,11. Canonicalization

--- a/data_yaml/circuits/five-qubit-code--rl-ibm-tokyo-zero-8.yaml
+++ b/data_yaml/circuits/five-qubit-code--rl-ibm-tokyo-zero-8.yaml
@@ -1,5 +1,6 @@
 qec_id: 292
 name: RL ibm tokyo zero 8
+tool: rlftqc
 notes: "Source file: integrated-ft-logical-state-preparation/ibm/5-1-3-tokyo/2/5_4_8.stim.
   Logical state: zero. Connectivity: ibm. Gate set: CX,CZ,H. Device: tokyo. Flag/ancilla
   qubits: [5, 6]. Device qubit placement (Qiskit indices): 6,5,1,7,11. Canonicalization

--- a/data_yaml/circuits/rotated-surface-code-d-3--rl-2d-grid-zero-0.yaml
+++ b/data_yaml/circuits/rotated-surface-code-d-3--rl-2d-grid-zero-0.yaml
@@ -1,5 +1,6 @@
 qec_id: 221
 name: RL 2d-grid zero 0
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/2d-grid/9-1-3-surface/26-16-8-4-24-14-6-33/9_0.stim.
   Logical state: zero. Connectivity: 2d-grid. Gate set: CX,H. Device: google-sycamore.

--- a/data_yaml/circuits/rotated-surface-code-d-3--rl-2d-grid-zero-1.yaml
+++ b/data_yaml/circuits/rotated-surface-code-d-3--rl-2d-grid-zero-1.yaml
@@ -1,5 +1,6 @@
 qec_id: 222
 name: RL 2d-grid zero 1
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/2d-grid/9-1-3-surface/26-16-8-4-24-14-6-33/9_1.stim.
   Logical state: zero. Connectivity: 2d-grid. Gate set: CX,H. Device: google-sycamore.

--- a/data_yaml/circuits/rotated-surface-code-d-3--rl-2d-grid-zero-2.yaml
+++ b/data_yaml/circuits/rotated-surface-code-d-3--rl-2d-grid-zero-2.yaml
@@ -1,5 +1,6 @@
 qec_id: 223
 name: RL 2d-grid zero 2
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/2d-grid/9-1-3-surface/26-16-8-4-24-14-6-33/9_2.stim.
   Logical state: zero. Connectivity: 2d-grid. Gate set: CX,H. Device: google-sycamore.

--- a/data_yaml/circuits/rotated-surface-code-d-3--rl-2d-grid-zero-3.yaml
+++ b/data_yaml/circuits/rotated-surface-code-d-3--rl-2d-grid-zero-3.yaml
@@ -1,5 +1,6 @@
 qec_id: 224
 name: RL 2d-grid zero 3
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/2d-grid/9-1-3-surface/26-16-8-4-24-14-6-33/9_4.stim.
   Logical state: zero. Connectivity: 2d-grid. Gate set: CX,H. Device: google-sycamore.

--- a/data_yaml/circuits/rotated-surface-code-d-3--rl-2d-grid-zero-4.yaml
+++ b/data_yaml/circuits/rotated-surface-code-d-3--rl-2d-grid-zero-4.yaml
@@ -1,5 +1,6 @@
 qec_id: 225
 name: RL 2d-grid zero 4
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/2d-grid/9-1-3-surface/26-16-8-4-24-14-6-33/9_5.stim.
   Logical state: zero. Connectivity: 2d-grid. Gate set: CX,H. Device: google-sycamore.

--- a/data_yaml/circuits/rotated-surface-code-d-3--rl-2d-grid-zero-5.yaml
+++ b/data_yaml/circuits/rotated-surface-code-d-3--rl-2d-grid-zero-5.yaml
@@ -1,5 +1,6 @@
 qec_id: 226
 name: RL 2d-grid zero 5
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/2d-grid/9-1-3-surface/26-16-8-4-24-14-6-33/9_7.stim.
   Logical state: zero. Connectivity: 2d-grid. Gate set: CX,H. Device: google-sycamore.

--- a/data_yaml/circuits/rotated-surface-code-d-3--rl-2d-grid-zero-6.yaml
+++ b/data_yaml/circuits/rotated-surface-code-d-3--rl-2d-grid-zero-6.yaml
@@ -1,5 +1,6 @@
 qec_id: 227
 name: RL 2d-grid zero 6
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/2d-grid/9-1-3-surface/26-16-8-4-24-14-6-33/9_8.stim.
   Logical state: zero. Connectivity: 2d-grid. Gate set: CX,H. Device: google-sycamore.

--- a/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-plus-0.yaml
+++ b/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-plus-0.yaml
@@ -1,5 +1,6 @@
 qec_id: 267
 name: RL fully-connected plus 0
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/9-1-3-surface/plus-logical/9_1.stim.
   Logical state: plus. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla

--- a/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-plus-1.yaml
+++ b/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-plus-1.yaml
@@ -1,5 +1,6 @@
 qec_id: 268
 name: RL fully-connected plus 1
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/9-1-3-surface/plus-logical/9_2.stim.
   Logical state: plus. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla

--- a/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-plus-2.yaml
+++ b/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-plus-2.yaml
@@ -1,5 +1,6 @@
 qec_id: 269
 name: RL fully-connected plus 2
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/9-1-3-surface/plus-logical/9_4.stim.
   Logical state: plus. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla

--- a/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-plus-3.yaml
+++ b/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-plus-3.yaml
@@ -1,5 +1,6 @@
 qec_id: 270
 name: RL fully-connected plus 3
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/9-1-3-surface/plus-logical/9_5.stim.
   Logical state: plus. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla

--- a/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-plus-4.yaml
+++ b/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-plus-4.yaml
@@ -1,5 +1,6 @@
 qec_id: 271
 name: RL fully-connected plus 4
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/9-1-3-surface/plus-logical/9_6.stim.
   Logical state: plus. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla

--- a/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-plus-5.yaml
+++ b/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-plus-5.yaml
@@ -1,5 +1,6 @@
 qec_id: 272
 name: RL fully-connected plus 5
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/9-1-3-surface/plus-logical/9_7.stim.
   Logical state: plus. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla

--- a/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-plus-6.yaml
+++ b/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-plus-6.yaml
@@ -1,5 +1,6 @@
 qec_id: 273
 name: RL fully-connected plus 6
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/9-1-3-surface/plus-logical/9_8.stim.
   Logical state: plus. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla

--- a/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-plus-7.yaml
+++ b/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-plus-7.yaml
@@ -1,5 +1,6 @@
 qec_id: 274
 name: RL fully-connected plus 7
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/9-1-3-surface/plus-logical/9_9.stim.
   Logical state: plus. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla

--- a/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-zero-0.yaml
+++ b/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-zero-0.yaml
@@ -1,5 +1,6 @@
 qec_id: 275
 name: RL fully-connected zero 0
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/9-1-3-surface/zero-logical/9_1.stim.
   Logical state: zero. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla

--- a/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-zero-1.yaml
+++ b/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-zero-1.yaml
@@ -1,5 +1,6 @@
 qec_id: 276
 name: RL fully-connected zero 1
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/9-1-3-surface/zero-logical/9_2.stim.
   Logical state: zero. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla

--- a/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-zero-10.yaml
+++ b/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-zero-10.yaml
@@ -1,5 +1,6 @@
 qec_id: 430
 name: RL fully-connected zero 10
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/9-1-3-surface/9_1_1_combined.stim.
   Logical state: zero. Connectivity: fully-connected. Gate set: CX,H,S. Flag/ancilla
   qubits: [9]. Canonicalization qubit permutation (stored qubit i = original qubit

--- a/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-zero-11.yaml
+++ b/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-zero-11.yaml
@@ -1,5 +1,6 @@
 qec_id: 431
 name: RL fully-connected zero 11
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/9-1-3-surface/9_1_2_combined.stim.
   Logical state: zero. Connectivity: fully-connected. Gate set: CX,H,S. Flag/ancilla
   qubits: [9]. Canonicalization qubit permutation (stored qubit i = original qubit

--- a/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-zero-12.yaml
+++ b/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-zero-12.yaml
@@ -1,5 +1,6 @@
 qec_id: 432
 name: RL fully-connected zero 12
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/9-1-3-surface/9_1_3_combined.stim.
   Logical state: zero. Connectivity: fully-connected. Gate set: CX,H,S. Flag/ancilla
   qubits: [9]. Canonicalization qubit permutation (stored qubit i = original qubit

--- a/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-zero-13.yaml
+++ b/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-zero-13.yaml
@@ -1,5 +1,6 @@
 qec_id: 433
 name: RL fully-connected zero 13
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/9-1-3-surface/9_1_4_combined.stim.
   Logical state: zero. Connectivity: fully-connected. Gate set: CX,H,S. Flag/ancilla
   qubits: [9]. Canonicalization qubit permutation (stored qubit i = original qubit

--- a/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-zero-14.yaml
+++ b/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-zero-14.yaml
@@ -1,5 +1,6 @@
 qec_id: 434
 name: RL fully-connected zero 14
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/9-1-3-surface/9_1_5_combined.stim.
   Logical state: zero. Connectivity: fully-connected. Gate set: CX,H,S. Flag/ancilla
   qubits: [9]. Canonicalization qubit permutation (stored qubit i = original qubit

--- a/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-zero-15.yaml
+++ b/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-zero-15.yaml
@@ -1,5 +1,6 @@
 qec_id: 435
 name: RL fully-connected zero 15
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/9-1-3-surface/9_1_6_combined.stim.
   Logical state: zero. Connectivity: fully-connected. Gate set: CX,H,S. Flag/ancilla
   qubits: [9]. Canonicalization qubit permutation (stored qubit i = original qubit

--- a/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-zero-16.yaml
+++ b/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-zero-16.yaml
@@ -1,5 +1,6 @@
 qec_id: 436
 name: RL fully-connected zero 16
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/9-1-3-surface/9_1_8_combined.stim.
   Logical state: zero. Connectivity: fully-connected. Gate set: CX,H,S. Flag/ancilla
   qubits: [9]. Canonicalization qubit permutation (stored qubit i = original qubit

--- a/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-zero-17.yaml
+++ b/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-zero-17.yaml
@@ -1,5 +1,6 @@
 qec_id: 437
 name: RL fully-connected zero 17
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/9-1-3-surface/9_1_9_combined.stim.
   Logical state: zero. Connectivity: fully-connected. Gate set: CX,H,S. Flag/ancilla
   qubits: [9]. Canonicalization qubit permutation (stored qubit i = original qubit

--- a/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-zero-2.yaml
+++ b/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-zero-2.yaml
@@ -1,5 +1,6 @@
 qec_id: 277
 name: RL fully-connected zero 2
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/9-1-3-surface/zero-logical/9_3.stim.
   Logical state: zero. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla

--- a/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-zero-3.yaml
+++ b/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-zero-3.yaml
@@ -1,5 +1,6 @@
 qec_id: 278
 name: RL fully-connected zero 3
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/9-1-3-surface/zero-logical/9_4.stim.
   Logical state: zero. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla

--- a/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-zero-4.yaml
+++ b/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-zero-4.yaml
@@ -1,5 +1,6 @@
 qec_id: 279
 name: RL fully-connected zero 4
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/9-1-3-surface/zero-logical/9_5.stim.
   Logical state: zero. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla

--- a/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-zero-5.yaml
+++ b/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-zero-5.yaml
@@ -1,5 +1,6 @@
 qec_id: 280
 name: RL fully-connected zero 5
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/9-1-3-surface/zero-logical/9_6.stim.
   Logical state: zero. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla

--- a/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-zero-6.yaml
+++ b/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-zero-6.yaml
@@ -1,5 +1,6 @@
 qec_id: 281
 name: RL fully-connected zero 6
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/9-1-3-surface/zero-logical/9_7.stim.
   Logical state: zero. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla

--- a/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-zero-7.yaml
+++ b/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-zero-7.yaml
@@ -1,5 +1,6 @@
 qec_id: 282
 name: RL fully-connected zero 7
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/9-1-3-surface/zero-logical/9_8.stim.
   Logical state: zero. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla

--- a/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-zero-8.yaml
+++ b/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-zero-8.yaml
@@ -1,5 +1,6 @@
 qec_id: 283
 name: RL fully-connected zero 8
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/9-1-3-surface/zero-logical/9_9.stim.
   Logical state: zero. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla

--- a/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-zero-9.yaml
+++ b/data_yaml/circuits/rotated-surface-code-d-3--rl-fully-connected-zero-9.yaml
@@ -1,5 +1,6 @@
 qec_id: 429
 name: RL fully-connected zero 9
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/9-1-3-surface/9_1_0_combined.stim.
   Logical state: zero. Connectivity: fully-connected. Gate set: CX,H,S. Flag/ancilla
   qubits: [9]. Canonicalization qubit permutation (stored qubit i = original qubit

--- a/data_yaml/circuits/shor-code--rl-2d-grid-plus-0.yaml
+++ b/data_yaml/circuits/shor-code--rl-2d-grid-plus-0.yaml
@@ -1,5 +1,6 @@
 qec_id: 213
 name: RL 2d-grid plus 0
+tool: rlftqc
 notes: "Source file: integrated-ft-logical-state-preparation/2d-grid/9-1-3-shor/2-3-15/9_1.stim.
   Logical state: zero. Original (source) logical state: plus. Connectivity: 2d-grid.
   Gate set: CX,H. Device: google-sycamore. Flag/ancilla qubits: [9, 10, 11]. Device

--- a/data_yaml/circuits/shor-code--rl-2d-grid-plus-1.yaml
+++ b/data_yaml/circuits/shor-code--rl-2d-grid-plus-1.yaml
@@ -1,5 +1,6 @@
 qec_id: 214
 name: RL 2d-grid plus 1
+tool: rlftqc
 notes: "Source file: integrated-ft-logical-state-preparation/2d-grid/9-1-3-shor/2-3-15/9_8.stim.
   Logical state: zero. Original (source) logical state: plus. Connectivity: 2d-grid.
   Gate set: CX,H. Device: google-sycamore. Flag/ancilla qubits: [9, 10, 11]. Device

--- a/data_yaml/circuits/shor-code--rl-2d-grid-plus-2.yaml
+++ b/data_yaml/circuits/shor-code--rl-2d-grid-plus-2.yaml
@@ -1,5 +1,6 @@
 qec_id: 215
 name: RL 2d-grid plus 2
+tool: rlftqc
 notes: "Source file: integrated-ft-logical-state-preparation/2d-grid/9-1-3-shor/2-3-15/9_9.stim.
   Logical state: zero. Original (source) logical state: plus. Connectivity: 2d-grid.
   Gate set: CX,H. Device: google-sycamore. Flag/ancilla qubits: [9, 10, 11]. Device

--- a/data_yaml/circuits/shor-code--rl-2d-grid-plus-3.yaml
+++ b/data_yaml/circuits/shor-code--rl-2d-grid-plus-3.yaml
@@ -1,5 +1,6 @@
 qec_id: 216
 name: RL 2d-grid plus 3
+tool: rlftqc
 notes: "Source file: integrated-ft-logical-state-preparation/2d-grid/9-1-3-shor/2-4-16/9_5.stim.
   Logical state: zero. Original (source) logical state: plus. Connectivity: 2d-grid.
   Gate set: CX,H. Device: google-sycamore. Flag/ancilla qubits: [9, 10, 11]. Device

--- a/data_yaml/circuits/shor-code--rl-2d-grid-plus-4.yaml
+++ b/data_yaml/circuits/shor-code--rl-2d-grid-plus-4.yaml
@@ -1,5 +1,6 @@
 qec_id: 217
 name: RL 2d-grid plus 4
+tool: rlftqc
 notes: "Source file: integrated-ft-logical-state-preparation/2d-grid/9-1-3-shor/2-7-16/9_0.stim.
   Logical state: zero. Original (source) logical state: plus. Connectivity: 2d-grid.
   Gate set: CX,H. Device: google-sycamore. Flag/ancilla qubits: [9, 10, 11]. Device

--- a/data_yaml/circuits/shor-code--rl-2d-grid-plus-5.yaml
+++ b/data_yaml/circuits/shor-code--rl-2d-grid-plus-5.yaml
@@ -1,5 +1,6 @@
 qec_id: 218
 name: RL 2d-grid plus 5
+tool: rlftqc
 notes: "Source file: integrated-ft-logical-state-preparation/2d-grid/9-1-3-shor/3-4-15/9_3.stim.
   Logical state: zero. Original (source) logical state: plus. Connectivity: 2d-grid.
   Gate set: CX,H. Device: google-sycamore. Flag/ancilla qubits: [9, 10, 11]. Device

--- a/data_yaml/circuits/shor-code--rl-2d-grid-plus-6.yaml
+++ b/data_yaml/circuits/shor-code--rl-2d-grid-plus-6.yaml
@@ -1,5 +1,6 @@
 qec_id: 219
 name: RL 2d-grid plus 6
+tool: rlftqc
 notes: "Source file: integrated-ft-logical-state-preparation/2d-grid/9-1-3-shor/3-4-15/9_8.stim.
   Logical state: zero. Original (source) logical state: plus. Connectivity: 2d-grid.
   Gate set: CX,H. Device: google-sycamore. Flag/ancilla qubits: [9, 10, 11]. Device

--- a/data_yaml/circuits/shor-code--rl-2d-grid-plus-7.yaml
+++ b/data_yaml/circuits/shor-code--rl-2d-grid-plus-7.yaml
@@ -1,5 +1,6 @@
 qec_id: 220
 name: RL 2d-grid plus 7
+tool: rlftqc
 notes: "Source file: integrated-ft-logical-state-preparation/2d-grid/9-1-3-shor/3-8-16/9_0.stim.
   Logical state: zero. Original (source) logical state: plus. Connectivity: 2d-grid.
   Gate set: CX,H. Device: google-sycamore. Flag/ancilla qubits: [9, 10, 11]. Device

--- a/data_yaml/circuits/shor-code--rl-fully-connected-plus-0.yaml
+++ b/data_yaml/circuits/shor-code--rl-fully-connected-plus-0.yaml
@@ -1,5 +1,6 @@
 qec_id: 259
 name: RL fully-connected plus 0
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/9-1-3-shor/plus-logical/9_0.stim.
   Logical state: zero. Original (source) logical state: plus. Connectivity: fully-connected.

--- a/data_yaml/circuits/shor-code--rl-fully-connected-plus-1.yaml
+++ b/data_yaml/circuits/shor-code--rl-fully-connected-plus-1.yaml
@@ -1,5 +1,6 @@
 qec_id: 260
 name: RL fully-connected plus 1
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/9-1-3-shor/plus-logical/9_1.stim.
   Logical state: zero. Original (source) logical state: plus. Connectivity: fully-connected.

--- a/data_yaml/circuits/shor-code--rl-fully-connected-plus-10.yaml
+++ b/data_yaml/circuits/shor-code--rl-fully-connected-plus-10.yaml
@@ -1,5 +1,6 @@
 qec_id: 346
 name: RL fully-connected plus 10
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/9-1-3/9_7.stim. Logical
   state: zero. Original (source) logical state: plus. Connectivity: fully-connected.
   Gate set: CX,H. Canonicalization qubit permutation (stored qubit i = original qubit

--- a/data_yaml/circuits/shor-code--rl-fully-connected-plus-11.yaml
+++ b/data_yaml/circuits/shor-code--rl-fully-connected-plus-11.yaml
@@ -1,5 +1,6 @@
 qec_id: 347
 name: RL fully-connected plus 11
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/9-1-3/9_8.stim. Logical
   state: zero. Original (source) logical state: plus. Connectivity: fully-connected.
   Gate set: CX,H. Canonicalization qubit permutation (stored qubit i = original qubit

--- a/data_yaml/circuits/shor-code--rl-fully-connected-plus-12.yaml
+++ b/data_yaml/circuits/shor-code--rl-fully-connected-plus-12.yaml
@@ -1,5 +1,6 @@
 qec_id: 348
 name: RL fully-connected plus 12
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/9-1-3/9_9.stim. Logical
   state: zero. Original (source) logical state: plus. Connectivity: fully-connected.
   Gate set: CX,H. Canonicalization qubit permutation (stored qubit i = original qubit

--- a/data_yaml/circuits/shor-code--rl-fully-connected-plus-13.yaml
+++ b/data_yaml/circuits/shor-code--rl-fully-connected-plus-13.yaml
@@ -1,5 +1,6 @@
 qec_id: 419
 name: RL fully-connected plus 13
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/9-1-3-shor/9_0_0_combined.stim.
   Logical state: zero. Original (source) logical state: plus. Connectivity: fully-connected.
   Gate set: CX,H. Flag/ancilla qubits: [9]. Canonicalization qubit permutation (stored

--- a/data_yaml/circuits/shor-code--rl-fully-connected-plus-14.yaml
+++ b/data_yaml/circuits/shor-code--rl-fully-connected-plus-14.yaml
@@ -1,5 +1,6 @@
 qec_id: 420
 name: RL fully-connected plus 14
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/9-1-3-shor/9_0_1_combined.stim.
   Logical state: zero. Original (source) logical state: plus. Connectivity: fully-connected.
   Gate set: CX,H. Flag/ancilla qubits: [9]. Canonicalization qubit permutation (stored

--- a/data_yaml/circuits/shor-code--rl-fully-connected-plus-15.yaml
+++ b/data_yaml/circuits/shor-code--rl-fully-connected-plus-15.yaml
@@ -1,5 +1,6 @@
 qec_id: 421
 name: RL fully-connected plus 15
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/9-1-3-shor/9_0_2_combined.stim.
   Logical state: zero. Original (source) logical state: plus. Connectivity: fully-connected.
   Gate set: CX,H. Flag/ancilla qubits: [9]. Canonicalization qubit permutation (stored

--- a/data_yaml/circuits/shor-code--rl-fully-connected-plus-16.yaml
+++ b/data_yaml/circuits/shor-code--rl-fully-connected-plus-16.yaml
@@ -1,5 +1,6 @@
 qec_id: 422
 name: RL fully-connected plus 16
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/9-1-3-shor/9_0_3_combined.stim.
   Logical state: zero. Original (source) logical state: plus. Connectivity: fully-connected.
   Gate set: CX,H. Flag/ancilla qubits: [9]. Canonicalization qubit permutation (stored

--- a/data_yaml/circuits/shor-code--rl-fully-connected-plus-17.yaml
+++ b/data_yaml/circuits/shor-code--rl-fully-connected-plus-17.yaml
@@ -1,5 +1,6 @@
 qec_id: 423
 name: RL fully-connected plus 17
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/9-1-3-shor/9_0_4_combined.stim.
   Logical state: zero. Original (source) logical state: plus. Connectivity: fully-connected.
   Gate set: CX,H. Flag/ancilla qubits: [9]. Canonicalization qubit permutation (stored

--- a/data_yaml/circuits/shor-code--rl-fully-connected-plus-18.yaml
+++ b/data_yaml/circuits/shor-code--rl-fully-connected-plus-18.yaml
@@ -1,5 +1,6 @@
 qec_id: 424
 name: RL fully-connected plus 18
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/9-1-3-shor/9_0_5_combined.stim.
   Logical state: zero. Original (source) logical state: plus. Connectivity: fully-connected.
   Gate set: CX,H. Flag/ancilla qubits: [9]. Canonicalization qubit permutation (stored

--- a/data_yaml/circuits/shor-code--rl-fully-connected-plus-19.yaml
+++ b/data_yaml/circuits/shor-code--rl-fully-connected-plus-19.yaml
@@ -1,5 +1,6 @@
 qec_id: 425
 name: RL fully-connected plus 19
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/9-1-3-shor/9_0_6_combined.stim.
   Logical state: zero. Original (source) logical state: plus. Connectivity: fully-connected.
   Gate set: CX,H. Flag/ancilla qubits: [9]. Canonicalization qubit permutation (stored

--- a/data_yaml/circuits/shor-code--rl-fully-connected-plus-2.yaml
+++ b/data_yaml/circuits/shor-code--rl-fully-connected-plus-2.yaml
@@ -1,5 +1,6 @@
 qec_id: 261
 name: RL fully-connected plus 2
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/9-1-3-shor/plus-logical/9_2.stim.
   Logical state: zero. Original (source) logical state: plus. Connectivity: fully-connected.

--- a/data_yaml/circuits/shor-code--rl-fully-connected-plus-20.yaml
+++ b/data_yaml/circuits/shor-code--rl-fully-connected-plus-20.yaml
@@ -1,5 +1,6 @@
 qec_id: 426
 name: RL fully-connected plus 20
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/9-1-3-shor/9_0_7_combined.stim.
   Logical state: zero. Original (source) logical state: plus. Connectivity: fully-connected.
   Gate set: CX,H. Flag/ancilla qubits: [9]. Canonicalization qubit permutation (stored

--- a/data_yaml/circuits/shor-code--rl-fully-connected-plus-21.yaml
+++ b/data_yaml/circuits/shor-code--rl-fully-connected-plus-21.yaml
@@ -1,5 +1,6 @@
 qec_id: 427
 name: RL fully-connected plus 21
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/9-1-3-shor/9_0_8_combined.stim.
   Logical state: zero. Original (source) logical state: plus. Connectivity: fully-connected.
   Gate set: CX,H. Flag/ancilla qubits: [9]. Canonicalization qubit permutation (stored

--- a/data_yaml/circuits/shor-code--rl-fully-connected-plus-22.yaml
+++ b/data_yaml/circuits/shor-code--rl-fully-connected-plus-22.yaml
@@ -1,5 +1,6 @@
 qec_id: 428
 name: RL fully-connected plus 22
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/9-1-3-shor/9_0_9_combined.stim.
   Logical state: zero. Original (source) logical state: plus. Connectivity: fully-connected.
   Gate set: CX,H. Flag/ancilla qubits: [9]. Canonicalization qubit permutation (stored

--- a/data_yaml/circuits/shor-code--rl-fully-connected-plus-3.yaml
+++ b/data_yaml/circuits/shor-code--rl-fully-connected-plus-3.yaml
@@ -1,5 +1,6 @@
 qec_id: 262
 name: RL fully-connected plus 3
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/9-1-3-shor/plus-logical/9_6.stim.
   Logical state: zero. Original (source) logical state: plus. Connectivity: fully-connected.

--- a/data_yaml/circuits/shor-code--rl-fully-connected-plus-4.yaml
+++ b/data_yaml/circuits/shor-code--rl-fully-connected-plus-4.yaml
@@ -1,5 +1,6 @@
 qec_id: 340
 name: RL fully-connected plus 4
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/9-1-3/9_0.stim. Logical
   state: zero. Original (source) logical state: plus. Connectivity: fully-connected.
   Gate set: CX,H. Canonicalization qubit permutation (stored qubit i = original qubit

--- a/data_yaml/circuits/shor-code--rl-fully-connected-plus-5.yaml
+++ b/data_yaml/circuits/shor-code--rl-fully-connected-plus-5.yaml
@@ -1,5 +1,6 @@
 qec_id: 341
 name: RL fully-connected plus 5
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/9-1-3/9_1.stim. Logical
   state: zero. Original (source) logical state: plus. Connectivity: fully-connected.
   Gate set: CX,H. Canonicalization qubit permutation (stored qubit i = original qubit

--- a/data_yaml/circuits/shor-code--rl-fully-connected-plus-6.yaml
+++ b/data_yaml/circuits/shor-code--rl-fully-connected-plus-6.yaml
@@ -1,5 +1,6 @@
 qec_id: 342
 name: RL fully-connected plus 6
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/9-1-3/9_2.stim. Logical
   state: zero. Original (source) logical state: plus. Connectivity: fully-connected.
   Gate set: CX,H. Canonicalization qubit permutation (stored qubit i = original qubit

--- a/data_yaml/circuits/shor-code--rl-fully-connected-plus-7.yaml
+++ b/data_yaml/circuits/shor-code--rl-fully-connected-plus-7.yaml
@@ -1,5 +1,6 @@
 qec_id: 343
 name: RL fully-connected plus 7
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/9-1-3/9_3.stim. Logical
   state: zero. Original (source) logical state: plus. Connectivity: fully-connected.
   Gate set: CX,H. Canonicalization qubit permutation (stored qubit i = original qubit

--- a/data_yaml/circuits/shor-code--rl-fully-connected-plus-8.yaml
+++ b/data_yaml/circuits/shor-code--rl-fully-connected-plus-8.yaml
@@ -1,5 +1,6 @@
 qec_id: 344
 name: RL fully-connected plus 8
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/9-1-3/9_4.stim. Logical
   state: zero. Original (source) logical state: plus. Connectivity: fully-connected.
   Gate set: CX,H. Canonicalization qubit permutation (stored qubit i = original qubit

--- a/data_yaml/circuits/shor-code--rl-fully-connected-plus-9.yaml
+++ b/data_yaml/circuits/shor-code--rl-fully-connected-plus-9.yaml
@@ -1,5 +1,6 @@
 qec_id: 345
 name: RL fully-connected plus 9
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/9-1-3/9_5.stim. Logical
   state: zero. Original (source) logical state: plus. Connectivity: fully-connected.
   Gate set: CX,H. Canonicalization qubit permutation (stored qubit i = original qubit

--- a/data_yaml/circuits/shor-code--rl-fully-connected-zero-0.yaml
+++ b/data_yaml/circuits/shor-code--rl-fully-connected-zero-0.yaml
@@ -1,5 +1,6 @@
 qec_id: 263
 name: RL fully-connected zero 0
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/9-1-3-shor/zero-logical/9_0.stim.
   Logical state: plus. Original (source) logical state: zero. Connectivity: fully-connected.

--- a/data_yaml/circuits/shor-code--rl-fully-connected-zero-1.yaml
+++ b/data_yaml/circuits/shor-code--rl-fully-connected-zero-1.yaml
@@ -1,5 +1,6 @@
 qec_id: 264
 name: RL fully-connected zero 1
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/9-1-3-shor/zero-logical/9_1.stim.
   Logical state: plus. Original (source) logical state: zero. Connectivity: fully-connected.

--- a/data_yaml/circuits/shor-code--rl-fully-connected-zero-2.yaml
+++ b/data_yaml/circuits/shor-code--rl-fully-connected-zero-2.yaml
@@ -1,5 +1,6 @@
 qec_id: 265
 name: RL fully-connected zero 2
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/9-1-3-shor/zero-logical/9_4.stim.
   Logical state: plus. Original (source) logical state: zero. Connectivity: fully-connected.

--- a/data_yaml/circuits/shor-code--rl-fully-connected-zero-3.yaml
+++ b/data_yaml/circuits/shor-code--rl-fully-connected-zero-3.yaml
@@ -1,5 +1,6 @@
 qec_id: 266
 name: RL fully-connected zero 3
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/9-1-3-shor/zero-logical/9_6.stim.
   Logical state: plus. Original (source) logical state: zero. Connectivity: fully-connected.

--- a/data_yaml/circuits/shor-code--rl-ibm-guadalupe-plus-0.yaml
+++ b/data_yaml/circuits/shor-code--rl-ibm-guadalupe-plus-0.yaml
@@ -1,5 +1,6 @@
 qec_id: 388
 name: RL ibm guadalupe plus 0
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/9-1-3-guadalupe/9_0.stim. Logical
   state: zero. Original (source) logical state: plus. Connectivity: ibm. Gate set:
   CX,S,SQRT_X. Device: guadalupe. Device qubit placement (Qiskit indices): 5,3,8,7,6,4,0,1,2.

--- a/data_yaml/circuits/shor-code--rl-ibm-guadalupe-plus-1.yaml
+++ b/data_yaml/circuits/shor-code--rl-ibm-guadalupe-plus-1.yaml
@@ -1,5 +1,6 @@
 qec_id: 389
 name: RL ibm guadalupe plus 1
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/9-1-3-guadalupe/9_4.stim. Logical
   state: zero. Original (source) logical state: plus. Connectivity: ibm. Gate set:
   CX,S,SQRT_X. Device: guadalupe. Device qubit placement (Qiskit indices): 5,3,8,7,6,4,0,1,2.

--- a/data_yaml/circuits/shor-code--rl-ibm-guadalupe-plus-2.yaml
+++ b/data_yaml/circuits/shor-code--rl-ibm-guadalupe-plus-2.yaml
@@ -1,5 +1,6 @@
 qec_id: 390
 name: RL ibm guadalupe plus 2
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/9-1-3-guadalupe/9_6.stim. Logical
   state: zero. Original (source) logical state: plus. Connectivity: ibm. Gate set:
   CX,S,SQRT_X. Device: guadalupe. Device qubit placement (Qiskit indices): 5,3,8,7,6,4,0,1,2.

--- a/data_yaml/circuits/shor-code--rl-ibm-guadalupe-plus-3.yaml
+++ b/data_yaml/circuits/shor-code--rl-ibm-guadalupe-plus-3.yaml
@@ -1,5 +1,6 @@
 qec_id: 391
 name: RL ibm guadalupe plus 3
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/9-1-3-guadalupe/9_7.stim. Logical
   state: zero. Original (source) logical state: plus. Connectivity: ibm. Gate set:
   CX,S,SQRT_X. Device: guadalupe. Device qubit placement (Qiskit indices): 5,3,8,7,6,4,0,1,2.

--- a/data_yaml/circuits/shor-code--rl-ibm-guadalupe-plus-4.yaml
+++ b/data_yaml/circuits/shor-code--rl-ibm-guadalupe-plus-4.yaml
@@ -1,5 +1,6 @@
 qec_id: 392
 name: RL ibm guadalupe plus 4
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/9-1-3-guadalupe/9_8.stim. Logical
   state: zero. Original (source) logical state: plus. Connectivity: ibm. Gate set:
   CX,S,SQRT_X. Device: guadalupe. Device qubit placement (Qiskit indices): 5,3,8,7,6,4,0,1,2.

--- a/data_yaml/circuits/shor-code--rl-ibm-guadalupe-plus-5.yaml
+++ b/data_yaml/circuits/shor-code--rl-ibm-guadalupe-plus-5.yaml
@@ -1,5 +1,6 @@
 qec_id: 393
 name: RL ibm guadalupe plus 5
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/9-1-3-guadalupe/9_9.stim. Logical
   state: zero. Original (source) logical state: plus. Connectivity: ibm. Gate set:
   CX,S,SQRT_X. Device: guadalupe. Device qubit placement (Qiskit indices): 5,3,8,7,6,4,0,1,2.

--- a/data_yaml/circuits/steane-code--rl-2d-grid-zero-0.yaml
+++ b/data_yaml/circuits/steane-code--rl-2d-grid-zero-0.yaml
@@ -1,5 +1,6 @@
 qec_id: 205
 name: RL 2d-grid zero 0
+tool: rlftqc
 notes: "Source file: integrated-ft-logical-state-preparation/2d-grid/7-1-3/15-16/7_3.stim.
   Logical state: zero. Connectivity: 2d-grid. Gate set: CX,H. Device: google-sycamore.
   Flag/ancilla qubits: [7]. Device qubit placement (Qiskit indices): 2,7,14,3,4,8,9,15,16.

--- a/data_yaml/circuits/steane-code--rl-2d-grid-zero-1.yaml
+++ b/data_yaml/circuits/steane-code--rl-2d-grid-zero-1.yaml
@@ -1,5 +1,6 @@
 qec_id: 206
 name: RL 2d-grid zero 1
+tool: rlftqc
 notes: "Source file: integrated-ft-logical-state-preparation/2d-grid/7-1-3/2-3/7_2.stim.
   Logical state: zero. Connectivity: 2d-grid. Gate set: CX,H. Device: google-sycamore.
   Flag/ancilla qubits: [7, 8]. Device qubit placement (Qiskit indices): 4,9,16,7,8,14,15,2,3.

--- a/data_yaml/circuits/steane-code--rl-2d-grid-zero-2.yaml
+++ b/data_yaml/circuits/steane-code--rl-2d-grid-zero-2.yaml
@@ -1,5 +1,6 @@
 qec_id: 207
 name: RL 2d-grid zero 2
+tool: rlftqc
 notes: "Source file: integrated-ft-logical-state-preparation/2d-grid/7-1-3/2-9/7_3.stim.
   Logical state: zero. Connectivity: 2d-grid. Gate set: CX,H. Device: google-sycamore.
   Flag/ancilla qubits: [7, 8]. Device qubit placement (Qiskit indices): 7,3,8,14,16,4,15,2,9.

--- a/data_yaml/circuits/steane-code--rl-2d-grid-zero-3.yaml
+++ b/data_yaml/circuits/steane-code--rl-2d-grid-zero-3.yaml
@@ -1,5 +1,6 @@
 qec_id: 208
 name: RL 2d-grid zero 3
+tool: rlftqc
 notes: "Source file: integrated-ft-logical-state-preparation/2d-grid/7-1-3/8-14/7_3.stim.
   Logical state: zero. Connectivity: 2d-grid. Gate set: CX,H. Device: google-sycamore.
   Flag/ancilla qubits: [7]. Device qubit placement (Qiskit indices): 2,7,16,3,4,9,15,8,14.

--- a/data_yaml/circuits/steane-code--rl-2d-grid-zero-4.yaml
+++ b/data_yaml/circuits/steane-code--rl-2d-grid-zero-4.yaml
@@ -1,5 +1,6 @@
 qec_id: 209
 name: RL 2d-grid zero 4
+tool: rlftqc
 notes: "Source file: integrated-ft-logical-state-preparation/2d-grid/7-1-3/9-14/7_2.stim.
   Logical state: zero. Connectivity: 2d-grid. Gate set: CX,H. Device: google-sycamore.
   Flag/ancilla qubits: [7]. Device qubit placement (Qiskit indices): 2,7,16,3,4,8,15,9,14.

--- a/data_yaml/circuits/steane-code--rl-2d-grid-zero-5.yaml
+++ b/data_yaml/circuits/steane-code--rl-2d-grid-zero-5.yaml
@@ -1,5 +1,6 @@
 qec_id: 210
 name: RL 2d-grid zero 5
+tool: rlftqc
 notes: "Source file: integrated-ft-logical-state-preparation/2d-grid/7-1-3/9-14/7_5.stim.
   Logical state: zero. Connectivity: 2d-grid. Gate set: CX,H. Device: google-sycamore.
   Flag/ancilla qubits: [7]. Device qubit placement (Qiskit indices): 2,7,16,3,4,8,15,9,14.

--- a/data_yaml/circuits/steane-code--rl-2d-grid-zero-6.yaml
+++ b/data_yaml/circuits/steane-code--rl-2d-grid-zero-6.yaml
@@ -1,5 +1,6 @@
 qec_id: 211
 name: RL 2d-grid zero 6
+tool: rlftqc
 notes: "Source file: integrated-ft-logical-state-preparation/2d-grid/7-1-3/9-14/7_6.stim.
   Logical state: zero. Connectivity: 2d-grid. Gate set: CX,H. Device: google-sycamore.
   Flag/ancilla qubits: [7, 8]. Device qubit placement (Qiskit indices): 2,7,16,3,4,8,15,9,14.

--- a/data_yaml/circuits/steane-code--rl-2d-grid-zero-7.yaml
+++ b/data_yaml/circuits/steane-code--rl-2d-grid-zero-7.yaml
@@ -1,5 +1,6 @@
 qec_id: 212
 name: RL 2d-grid zero 7
+tool: rlftqc
 notes: "Source file: integrated-ft-logical-state-preparation/2d-grid/7-1-3/9-14/7_8.stim.
   Logical state: zero. Connectivity: 2d-grid. Gate set: CX,H. Device: google-sycamore.
   Flag/ancilla qubits: [7, 8]. Device qubit placement (Qiskit indices): 2,7,16,3,4,8,15,9,14.

--- a/data_yaml/circuits/steane-code--rl-fully-connected-plus-0.yaml
+++ b/data_yaml/circuits/steane-code--rl-fully-connected-plus-0.yaml
@@ -1,5 +1,6 @@
 qec_id: 251
 name: RL fully-connected plus 0
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/7-1-3/plus-logical/7_3.stim.
   Logical state: plus. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla

--- a/data_yaml/circuits/steane-code--rl-fully-connected-plus-1.yaml
+++ b/data_yaml/circuits/steane-code--rl-fully-connected-plus-1.yaml
@@ -1,5 +1,6 @@
 qec_id: 252
 name: RL fully-connected plus 1
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/7-1-3/plus-logical/7_6.stim.
   Logical state: plus. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla

--- a/data_yaml/circuits/steane-code--rl-fully-connected-plus-2.yaml
+++ b/data_yaml/circuits/steane-code--rl-fully-connected-plus-2.yaml
@@ -1,5 +1,6 @@
 qec_id: 253
 name: RL fully-connected plus 2
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/7-1-3/plus-logical/7_7.stim.
   Logical state: plus. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla

--- a/data_yaml/circuits/steane-code--rl-fully-connected-plus-3.yaml
+++ b/data_yaml/circuits/steane-code--rl-fully-connected-plus-3.yaml
@@ -1,5 +1,6 @@
 qec_id: 254
 name: RL fully-connected plus 3
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/7-1-3/plus-logical/7_9.stim.
   Logical state: plus. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla

--- a/data_yaml/circuits/steane-code--rl-fully-connected-zero-0.yaml
+++ b/data_yaml/circuits/steane-code--rl-fully-connected-zero-0.yaml
@@ -1,5 +1,6 @@
 qec_id: 255
 name: RL fully-connected zero 0
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/7-1-3/zero-logical/7_0.stim.
   Logical state: zero. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla

--- a/data_yaml/circuits/steane-code--rl-fully-connected-zero-1.yaml
+++ b/data_yaml/circuits/steane-code--rl-fully-connected-zero-1.yaml
@@ -1,5 +1,6 @@
 qec_id: 256
 name: RL fully-connected zero 1
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/7-1-3/zero-logical/7_1.stim.
   Logical state: zero. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla

--- a/data_yaml/circuits/steane-code--rl-fully-connected-zero-10.yaml
+++ b/data_yaml/circuits/steane-code--rl-fully-connected-zero-10.yaml
@@ -1,5 +1,6 @@
 qec_id: 336
 name: RL fully-connected zero 10
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/7-1-3/7_6.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H. Canonicalization qubit
   permutation (stored qubit i = original qubit permutation[i]): [0, 1, 2, 3, 4, 5,

--- a/data_yaml/circuits/steane-code--rl-fully-connected-zero-11.yaml
+++ b/data_yaml/circuits/steane-code--rl-fully-connected-zero-11.yaml
@@ -1,5 +1,6 @@
 qec_id: 337
 name: RL fully-connected zero 11
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/7-1-3/7_7.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H. Canonicalization qubit
   permutation (stored qubit i = original qubit permutation[i]): [0, 1, 2, 3, 4, 5,

--- a/data_yaml/circuits/steane-code--rl-fully-connected-zero-12.yaml
+++ b/data_yaml/circuits/steane-code--rl-fully-connected-zero-12.yaml
@@ -1,5 +1,6 @@
 qec_id: 338
 name: RL fully-connected zero 12
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/7-1-3/7_8.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H. Canonicalization qubit
   permutation (stored qubit i = original qubit permutation[i]): [0, 1, 2, 3, 4, 5,

--- a/data_yaml/circuits/steane-code--rl-fully-connected-zero-13.yaml
+++ b/data_yaml/circuits/steane-code--rl-fully-connected-zero-13.yaml
@@ -1,5 +1,6 @@
 qec_id: 339
 name: RL fully-connected zero 13
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/7-1-3/7_9.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H. Canonicalization qubit
   permutation (stored qubit i = original qubit permutation[i]): [0, 1, 2, 3, 4, 5,

--- a/data_yaml/circuits/steane-code--rl-fully-connected-zero-14.yaml
+++ b/data_yaml/circuits/steane-code--rl-fully-connected-zero-14.yaml
@@ -1,5 +1,6 @@
 qec_id: 409
 name: RL fully-connected zero 14
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/7-1-3/7_0_0_combined.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla qubits:
   [7]. Canonicalization qubit permutation (stored qubit i = original qubit permutation[i]):

--- a/data_yaml/circuits/steane-code--rl-fully-connected-zero-15.yaml
+++ b/data_yaml/circuits/steane-code--rl-fully-connected-zero-15.yaml
@@ -1,5 +1,6 @@
 qec_id: 410
 name: RL fully-connected zero 15
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/7-1-3/7_0_1_combined.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla qubits:
   [7]. Canonicalization qubit permutation (stored qubit i = original qubit permutation[i]):

--- a/data_yaml/circuits/steane-code--rl-fully-connected-zero-16.yaml
+++ b/data_yaml/circuits/steane-code--rl-fully-connected-zero-16.yaml
@@ -1,5 +1,6 @@
 qec_id: 411
 name: RL fully-connected zero 16
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/7-1-3/7_0_2_combined.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla qubits:
   [7]. Canonicalization qubit permutation (stored qubit i = original qubit permutation[i]):

--- a/data_yaml/circuits/steane-code--rl-fully-connected-zero-17.yaml
+++ b/data_yaml/circuits/steane-code--rl-fully-connected-zero-17.yaml
@@ -1,5 +1,6 @@
 qec_id: 412
 name: RL fully-connected zero 17
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/7-1-3/7_0_3_combined.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla qubits:
   [7]. Canonicalization qubit permutation (stored qubit i = original qubit permutation[i]):

--- a/data_yaml/circuits/steane-code--rl-fully-connected-zero-18.yaml
+++ b/data_yaml/circuits/steane-code--rl-fully-connected-zero-18.yaml
@@ -1,5 +1,6 @@
 qec_id: 413
 name: RL fully-connected zero 18
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/7-1-3/7_0_4_combined.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla qubits:
   [7]. Canonicalization qubit permutation (stored qubit i = original qubit permutation[i]):

--- a/data_yaml/circuits/steane-code--rl-fully-connected-zero-19.yaml
+++ b/data_yaml/circuits/steane-code--rl-fully-connected-zero-19.yaml
@@ -1,5 +1,6 @@
 qec_id: 414
 name: RL fully-connected zero 19
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/7-1-3/7_0_5_combined.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla qubits:
   [7]. Canonicalization qubit permutation (stored qubit i = original qubit permutation[i]):

--- a/data_yaml/circuits/steane-code--rl-fully-connected-zero-2.yaml
+++ b/data_yaml/circuits/steane-code--rl-fully-connected-zero-2.yaml
@@ -1,5 +1,6 @@
 qec_id: 257
 name: RL fully-connected zero 2
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/7-1-3/zero-logical/7_3.stim.
   Logical state: zero. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla

--- a/data_yaml/circuits/steane-code--rl-fully-connected-zero-20.yaml
+++ b/data_yaml/circuits/steane-code--rl-fully-connected-zero-20.yaml
@@ -1,5 +1,6 @@
 qec_id: 415
 name: RL fully-connected zero 20
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/7-1-3/7_0_6_combined.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla qubits:
   [7]. Canonicalization qubit permutation (stored qubit i = original qubit permutation[i]):

--- a/data_yaml/circuits/steane-code--rl-fully-connected-zero-21.yaml
+++ b/data_yaml/circuits/steane-code--rl-fully-connected-zero-21.yaml
@@ -1,5 +1,6 @@
 qec_id: 416
 name: RL fully-connected zero 21
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/7-1-3/7_0_7_combined.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla qubits:
   [7]. Canonicalization qubit permutation (stored qubit i = original qubit permutation[i]):

--- a/data_yaml/circuits/steane-code--rl-fully-connected-zero-22.yaml
+++ b/data_yaml/circuits/steane-code--rl-fully-connected-zero-22.yaml
@@ -1,5 +1,6 @@
 qec_id: 417
 name: RL fully-connected zero 22
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/7-1-3/7_0_8_combined.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla qubits:
   [7]. Canonicalization qubit permutation (stored qubit i = original qubit permutation[i]):

--- a/data_yaml/circuits/steane-code--rl-fully-connected-zero-23.yaml
+++ b/data_yaml/circuits/steane-code--rl-fully-connected-zero-23.yaml
@@ -1,5 +1,6 @@
 qec_id: 418
 name: RL fully-connected zero 23
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/7-1-3/7_0_9_combined.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla qubits:
   [7]. Canonicalization qubit permutation (stored qubit i = original qubit permutation[i]):

--- a/data_yaml/circuits/steane-code--rl-fully-connected-zero-3.yaml
+++ b/data_yaml/circuits/steane-code--rl-fully-connected-zero-3.yaml
@@ -1,5 +1,6 @@
 qec_id: 258
 name: RL fully-connected zero 3
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/7-1-3/zero-logical/7_4.stim.
   Logical state: zero. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla

--- a/data_yaml/circuits/steane-code--rl-fully-connected-zero-4.yaml
+++ b/data_yaml/circuits/steane-code--rl-fully-connected-zero-4.yaml
@@ -1,5 +1,6 @@
 qec_id: 330
 name: RL fully-connected zero 4
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/7-1-3/7_0.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H. Canonicalization qubit
   permutation (stored qubit i = original qubit permutation[i]): [0, 1, 2, 3, 4, 5,

--- a/data_yaml/circuits/steane-code--rl-fully-connected-zero-5.yaml
+++ b/data_yaml/circuits/steane-code--rl-fully-connected-zero-5.yaml
@@ -1,5 +1,6 @@
 qec_id: 331
 name: RL fully-connected zero 5
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/7-1-3/7_1.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H. Canonicalization qubit
   permutation (stored qubit i = original qubit permutation[i]): [0, 1, 2, 3, 4, 5,

--- a/data_yaml/circuits/steane-code--rl-fully-connected-zero-6.yaml
+++ b/data_yaml/circuits/steane-code--rl-fully-connected-zero-6.yaml
@@ -1,5 +1,6 @@
 qec_id: 332
 name: RL fully-connected zero 6
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/7-1-3/7_2.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H. Canonicalization qubit
   permutation (stored qubit i = original qubit permutation[i]): [0, 1, 2, 3, 4, 5,

--- a/data_yaml/circuits/steane-code--rl-fully-connected-zero-7.yaml
+++ b/data_yaml/circuits/steane-code--rl-fully-connected-zero-7.yaml
@@ -1,5 +1,6 @@
 qec_id: 333
 name: RL fully-connected zero 7
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/7-1-3/7_3.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H. Canonicalization qubit
   permutation (stored qubit i = original qubit permutation[i]): [0, 1, 2, 3, 4, 5,

--- a/data_yaml/circuits/steane-code--rl-fully-connected-zero-8.yaml
+++ b/data_yaml/circuits/steane-code--rl-fully-connected-zero-8.yaml
@@ -1,5 +1,6 @@
 qec_id: 334
 name: RL fully-connected zero 8
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/7-1-3/7_4.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H. Canonicalization qubit
   permutation (stored qubit i = original qubit permutation[i]): [0, 1, 2, 3, 4, 5,

--- a/data_yaml/circuits/steane-code--rl-fully-connected-zero-9.yaml
+++ b/data_yaml/circuits/steane-code--rl-fully-connected-zero-9.yaml
@@ -1,5 +1,6 @@
 qec_id: 335
 name: RL fully-connected zero 9
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/7-1-3/7_5.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H. Canonicalization qubit
   permutation (stored qubit i = original qubit permutation[i]): [0, 1, 2, 3, 4, 5,

--- a/data_yaml/circuits/steane-code--rl-ibm-guadalupe-zero-0.yaml
+++ b/data_yaml/circuits/steane-code--rl-ibm-guadalupe-zero-0.yaml
@@ -1,5 +1,6 @@
 qec_id: 293
 name: RL ibm guadalupe zero 0
+tool: rlftqc
 notes: "Source file: integrated-ft-logical-state-preparation/ibm/7-1-3-guadalupe/1/7_5.stim.
   Logical state: zero. Connectivity: ibm. Gate set: CX,H. Device: guadalupe. Flag/ancilla
   qubits: [7, 8]. Device qubit placement (Qiskit indices): 7,18,16,10,15,13,11,12,14.

--- a/data_yaml/circuits/steane-code--rl-ibm-guadalupe-zero-1.yaml
+++ b/data_yaml/circuits/steane-code--rl-ibm-guadalupe-zero-1.yaml
@@ -1,5 +1,6 @@
 qec_id: 294
 name: RL ibm guadalupe zero 1
+tool: rlftqc
 notes: "Source file: integrated-ft-logical-state-preparation/ibm/7-1-3-guadalupe/1/7_6.stim.
   Logical state: zero. Connectivity: ibm. Gate set: CX,H. Device: guadalupe. Flag/ancilla
   qubits: [7, 8]. Device qubit placement (Qiskit indices): 7,18,16,10,15,13,11,12,14.

--- a/data_yaml/circuits/steane-code--rl-ibm-guadalupe-zero-10.yaml
+++ b/data_yaml/circuits/steane-code--rl-ibm-guadalupe-zero-10.yaml
@@ -1,5 +1,6 @@
 qec_id: 303
 name: RL ibm guadalupe zero 10
+tool: rlftqc
 notes: "Source file: integrated-ft-logical-state-preparation/ibm/7-1-3-guadalupe/5/7_8.stim.
   Logical state: zero. Connectivity: ibm. Gate set: CX,H. Device: guadalupe. Flag/ancilla
   qubits: [7, 8]. Device qubit placement (Qiskit indices): 0,6,3,12,2,10,4,1,7. Canonicalization

--- a/data_yaml/circuits/steane-code--rl-ibm-guadalupe-zero-11.yaml
+++ b/data_yaml/circuits/steane-code--rl-ibm-guadalupe-zero-11.yaml
@@ -1,5 +1,6 @@
 qec_id: 304
 name: RL ibm guadalupe zero 11
+tool: rlftqc
 notes: "Source file: integrated-ft-logical-state-preparation/ibm/7-1-3-guadalupe/5/7_9.stim.
   Logical state: zero. Connectivity: ibm. Gate set: CX,H. Device: guadalupe. Flag/ancilla
   qubits: [7, 8]. Device qubit placement (Qiskit indices): 0,6,3,12,2,10,4,1,7. Canonicalization

--- a/data_yaml/circuits/steane-code--rl-ibm-guadalupe-zero-2.yaml
+++ b/data_yaml/circuits/steane-code--rl-ibm-guadalupe-zero-2.yaml
@@ -1,5 +1,6 @@
 qec_id: 295
 name: RL ibm guadalupe zero 2
+tool: rlftqc
 notes: "Source file: integrated-ft-logical-state-preparation/ibm/7-1-3-guadalupe/2/7_0.stim.
   Logical state: zero. Connectivity: ibm. Gate set: CX,H. Device: guadalupe. Flag/ancilla
   qubits: [7, 8]. Device qubit placement (Qiskit indices): 3,0,6,12,4,2,10,1,7. Canonicalization

--- a/data_yaml/circuits/steane-code--rl-ibm-guadalupe-zero-3.yaml
+++ b/data_yaml/circuits/steane-code--rl-ibm-guadalupe-zero-3.yaml
@@ -1,5 +1,6 @@
 qec_id: 296
 name: RL ibm guadalupe zero 3
+tool: rlftqc
 notes: "Source file: integrated-ft-logical-state-preparation/ibm/7-1-3-guadalupe/2/7_8.stim.
   Logical state: zero. Connectivity: ibm. Gate set: CX,H. Device: guadalupe. Flag/ancilla
   qubits: [7, 8]. Device qubit placement (Qiskit indices): 3,0,6,12,4,2,10,1,7. Canonicalization

--- a/data_yaml/circuits/steane-code--rl-ibm-guadalupe-zero-4.yaml
+++ b/data_yaml/circuits/steane-code--rl-ibm-guadalupe-zero-4.yaml
@@ -1,5 +1,6 @@
 qec_id: 297
 name: RL ibm guadalupe zero 4
+tool: rlftqc
 notes: "Source file: integrated-ft-logical-state-preparation/ibm/7-1-3-guadalupe/2/7_9.stim.
   Logical state: zero. Connectivity: ibm. Gate set: CX,H. Device: guadalupe. Flag/ancilla
   qubits: [7, 8]. Device qubit placement (Qiskit indices): 3,0,6,12,4,2,10,1,7. Canonicalization

--- a/data_yaml/circuits/steane-code--rl-ibm-guadalupe-zero-5.yaml
+++ b/data_yaml/circuits/steane-code--rl-ibm-guadalupe-zero-5.yaml
@@ -1,5 +1,6 @@
 qec_id: 298
 name: RL ibm guadalupe zero 5
+tool: rlftqc
 notes: "Source file: integrated-ft-logical-state-preparation/ibm/7-1-3-guadalupe/3/7_7.stim.
   Logical state: zero. Connectivity: ibm. Gate set: CX,H. Device: guadalupe. Flag/ancilla
   qubits: [7, 8]. Device qubit placement (Qiskit indices): 9,5,15,11,10,14,13,8,12.

--- a/data_yaml/circuits/steane-code--rl-ibm-guadalupe-zero-6.yaml
+++ b/data_yaml/circuits/steane-code--rl-ibm-guadalupe-zero-6.yaml
@@ -1,5 +1,6 @@
 qec_id: 299
 name: RL ibm guadalupe zero 6
+tool: rlftqc
 notes: "Source file: integrated-ft-logical-state-preparation/ibm/7-1-3-guadalupe/4/7_1.stim.
   Logical state: zero. Connectivity: ibm. Gate set: CX,H. Device: guadalupe. Flag/ancilla
   qubits: [7, 8, 9]. Device qubit placement (Qiskit indices): 6,15,0,2,13,10,4,1,7,12.

--- a/data_yaml/circuits/steane-code--rl-ibm-guadalupe-zero-7.yaml
+++ b/data_yaml/circuits/steane-code--rl-ibm-guadalupe-zero-7.yaml
@@ -1,5 +1,6 @@
 qec_id: 300
 name: RL ibm guadalupe zero 7
+tool: rlftqc
 notes: "Source file: integrated-ft-logical-state-preparation/ibm/7-1-3-guadalupe/4/7_7.stim.
   Logical state: zero. Connectivity: ibm. Gate set: CX,H. Device: guadalupe. Flag/ancilla
   qubits: [7, 8, 9]. Device qubit placement (Qiskit indices): 6,15,0,2,13,10,4,1,7,12.

--- a/data_yaml/circuits/steane-code--rl-ibm-guadalupe-zero-8.yaml
+++ b/data_yaml/circuits/steane-code--rl-ibm-guadalupe-zero-8.yaml
@@ -1,5 +1,6 @@
 qec_id: 301
 name: RL ibm guadalupe zero 8
+tool: rlftqc
 notes: "Source file: integrated-ft-logical-state-preparation/ibm/7-1-3-guadalupe/5/7_1.stim.
   Logical state: zero. Connectivity: ibm. Gate set: CX,H. Device: guadalupe. Flag/ancilla
   qubits: [7, 8]. Device qubit placement (Qiskit indices): 0,6,3,12,2,10,4,1,7. Canonicalization

--- a/data_yaml/circuits/steane-code--rl-ibm-guadalupe-zero-9.yaml
+++ b/data_yaml/circuits/steane-code--rl-ibm-guadalupe-zero-9.yaml
@@ -1,5 +1,6 @@
 qec_id: 302
 name: RL ibm guadalupe zero 9
+tool: rlftqc
 notes: "Source file: integrated-ft-logical-state-preparation/ibm/7-1-3-guadalupe/5/7_5.stim.
   Logical state: zero. Connectivity: ibm. Gate set: CX,H. Device: guadalupe. Flag/ancilla
   qubits: [7, 8]. Device qubit placement (Qiskit indices): 0,6,3,12,2,10,4,1,7. Canonicalization

--- a/data_yaml/circuits/steane-code--rl-ibm-jakarta-zero-0.yaml
+++ b/data_yaml/circuits/steane-code--rl-ibm-jakarta-zero-0.yaml
@@ -1,5 +1,6 @@
 qec_id: 378
 name: RL ibm jakarta zero 0
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/7-1-3-jakarta/7_0.stim. Logical
   state: zero. Connectivity: ibm. Gate set: CX,S,SQRT_X. Device: jakarta. Device qubit
   placement (Qiskit indices): 1,0,2,3,6,5,4. Canonicalization qubit permutation (stored

--- a/data_yaml/circuits/steane-code--rl-ibm-jakarta-zero-1.yaml
+++ b/data_yaml/circuits/steane-code--rl-ibm-jakarta-zero-1.yaml
@@ -1,5 +1,6 @@
 qec_id: 379
 name: RL ibm jakarta zero 1
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/7-1-3-jakarta/7_1.stim. Logical
   state: zero. Connectivity: ibm. Gate set: CX,S,SQRT_X. Device: jakarta. Device qubit
   placement (Qiskit indices): 1,0,2,3,6,5,4. Canonicalization qubit permutation (stored

--- a/data_yaml/circuits/steane-code--rl-ibm-jakarta-zero-2.yaml
+++ b/data_yaml/circuits/steane-code--rl-ibm-jakarta-zero-2.yaml
@@ -1,5 +1,6 @@
 qec_id: 380
 name: RL ibm jakarta zero 2
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/7-1-3-jakarta/7_2.stim. Logical
   state: zero. Connectivity: ibm. Gate set: CX,S,SQRT_X. Device: jakarta. Device qubit
   placement (Qiskit indices): 1,0,2,3,6,5,4. Canonicalization qubit permutation (stored

--- a/data_yaml/circuits/steane-code--rl-ibm-jakarta-zero-3.yaml
+++ b/data_yaml/circuits/steane-code--rl-ibm-jakarta-zero-3.yaml
@@ -1,5 +1,6 @@
 qec_id: 381
 name: RL ibm jakarta zero 3
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/7-1-3-jakarta/7_3.stim. Logical
   state: zero. Connectivity: ibm. Gate set: CX,S,SQRT_X. Device: jakarta. Device qubit
   placement (Qiskit indices): 1,0,2,3,6,5,4. Canonicalization qubit permutation (stored

--- a/data_yaml/circuits/steane-code--rl-ibm-jakarta-zero-4.yaml
+++ b/data_yaml/circuits/steane-code--rl-ibm-jakarta-zero-4.yaml
@@ -1,5 +1,6 @@
 qec_id: 382
 name: RL ibm jakarta zero 4
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/7-1-3-jakarta/7_4.stim. Logical
   state: zero. Connectivity: ibm. Gate set: CX,S,SQRT_X. Device: jakarta. Device qubit
   placement (Qiskit indices): 1,0,2,3,6,5,4. Canonicalization qubit permutation (stored

--- a/data_yaml/circuits/steane-code--rl-ibm-jakarta-zero-5.yaml
+++ b/data_yaml/circuits/steane-code--rl-ibm-jakarta-zero-5.yaml
@@ -1,5 +1,6 @@
 qec_id: 383
 name: RL ibm jakarta zero 5
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/7-1-3-jakarta/7_5.stim. Logical
   state: zero. Connectivity: ibm. Gate set: CX,S,SQRT_X. Device: jakarta. Device qubit
   placement (Qiskit indices): 1,0,2,3,6,5,4. Canonicalization qubit permutation (stored

--- a/data_yaml/circuits/steane-code--rl-ibm-jakarta-zero-6.yaml
+++ b/data_yaml/circuits/steane-code--rl-ibm-jakarta-zero-6.yaml
@@ -1,5 +1,6 @@
 qec_id: 384
 name: RL ibm jakarta zero 6
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/7-1-3-jakarta/7_6.stim. Logical
   state: zero. Connectivity: ibm. Gate set: CX,S,SQRT_X. Device: jakarta. Device qubit
   placement (Qiskit indices): 1,0,2,3,6,5,4. Canonicalization qubit permutation (stored

--- a/data_yaml/circuits/steane-code--rl-ibm-jakarta-zero-7.yaml
+++ b/data_yaml/circuits/steane-code--rl-ibm-jakarta-zero-7.yaml
@@ -1,5 +1,6 @@
 qec_id: 385
 name: RL ibm jakarta zero 7
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/7-1-3-jakarta/7_7.stim. Logical
   state: zero. Connectivity: ibm. Gate set: CX,S,SQRT_X. Device: jakarta. Device qubit
   placement (Qiskit indices): 1,0,2,3,6,5,4. Canonicalization qubit permutation (stored

--- a/data_yaml/circuits/steane-code--rl-ibm-jakarta-zero-8.yaml
+++ b/data_yaml/circuits/steane-code--rl-ibm-jakarta-zero-8.yaml
@@ -1,5 +1,6 @@
 qec_id: 386
 name: RL ibm jakarta zero 8
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/7-1-3-jakarta/7_8.stim. Logical
   state: zero. Connectivity: ibm. Gate set: CX,S,SQRT_X. Device: jakarta. Device qubit
   placement (Qiskit indices): 1,0,2,3,6,5,4. Canonicalization qubit permutation (stored

--- a/data_yaml/circuits/steane-code--rl-ibm-jakarta-zero-9.yaml
+++ b/data_yaml/circuits/steane-code--rl-ibm-jakarta-zero-9.yaml
@@ -1,5 +1,6 @@
 qec_id: 387
 name: RL ibm jakarta zero 9
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/7-1-3-jakarta/7_9.stim. Logical
   state: zero. Connectivity: ibm. Gate set: CX,S,SQRT_X. Device: jakarta. Device qubit
   placement (Qiskit indices): 1,0,2,3,6,5,4. Canonicalization qubit permutation (stored

--- a/data_yaml/circuits/tetrahedral-code--rl-fully-connected-plus-0.yaml
+++ b/data_yaml/circuits/tetrahedral-code--rl-fully-connected-plus-0.yaml
@@ -1,5 +1,6 @@
 qec_id: 228
 name: RL fully-connected plus 0
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/15-1-3/plus-logical/15_7_0.stim.
   Logical state: plus. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla

--- a/data_yaml/circuits/tetrahedral-code--rl-fully-connected-plus-1.yaml
+++ b/data_yaml/circuits/tetrahedral-code--rl-fully-connected-plus-1.yaml
@@ -1,5 +1,6 @@
 qec_id: 229
 name: RL fully-connected plus 1
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/15-1-3/plus-logical/15_7_2.stim.
   Logical state: plus. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla

--- a/data_yaml/circuits/tetrahedral-code--rl-fully-connected-plus-2.yaml
+++ b/data_yaml/circuits/tetrahedral-code--rl-fully-connected-plus-2.yaml
@@ -1,5 +1,6 @@
 qec_id: 230
 name: RL fully-connected plus 2
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/15-1-3/plus-logical/15_7_3.stim.
   Logical state: plus. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla

--- a/data_yaml/circuits/tetrahedral-code--rl-fully-connected-plus-3.yaml
+++ b/data_yaml/circuits/tetrahedral-code--rl-fully-connected-plus-3.yaml
@@ -1,5 +1,6 @@
 qec_id: 231
 name: RL fully-connected plus 3
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/15-1-3/plus-logical/15_7_4.stim.
   Logical state: plus. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla

--- a/data_yaml/circuits/tetrahedral-code--rl-fully-connected-plus-4.yaml
+++ b/data_yaml/circuits/tetrahedral-code--rl-fully-connected-plus-4.yaml
@@ -1,5 +1,6 @@
 qec_id: 232
 name: RL fully-connected plus 4
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/15-1-3/plus-logical/15_7_5.stim.
   Logical state: plus. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla

--- a/data_yaml/circuits/tetrahedral-code--rl-fully-connected-plus-5.yaml
+++ b/data_yaml/circuits/tetrahedral-code--rl-fully-connected-plus-5.yaml
@@ -1,5 +1,6 @@
 qec_id: 233
 name: RL fully-connected plus 5
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/15-1-3/plus-logical/15_7_6.stim.
   Logical state: plus. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla

--- a/data_yaml/circuits/tetrahedral-code--rl-fully-connected-plus-6.yaml
+++ b/data_yaml/circuits/tetrahedral-code--rl-fully-connected-plus-6.yaml
@@ -1,5 +1,6 @@
 qec_id: 234
 name: RL fully-connected plus 6
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/15-1-3/plus-logical/15_7_7.stim.
   Logical state: plus. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla

--- a/data_yaml/circuits/tetrahedral-code--rl-fully-connected-plus-7.yaml
+++ b/data_yaml/circuits/tetrahedral-code--rl-fully-connected-plus-7.yaml
@@ -1,5 +1,6 @@
 qec_id: 235
 name: RL fully-connected plus 7
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/15-1-3/plus-logical/15_7_8.stim.
   Logical state: plus. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla

--- a/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-0.yaml
+++ b/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-0.yaml
@@ -1,5 +1,6 @@
 qec_id: 236
 name: RL fully-connected zero 0
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/15-1-3/zero-logical/15_7.stim.
   Logical state: zero. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla

--- a/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-1.yaml
+++ b/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-1.yaml
@@ -1,5 +1,6 @@
 qec_id: 237
 name: RL fully-connected zero 1
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/15-1-3/zero-logical/15_8.stim.
   Logical state: zero. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla

--- a/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-10.yaml
+++ b/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-10.yaml
@@ -1,5 +1,6 @@
 qec_id: 312
 name: RL fully-connected zero 10
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/15-1-3/15_7.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H,S. Canonicalization qubit
   permutation (stored qubit i = original qubit permutation[i]): [0, 1, 2, 3, 4, 5,

--- a/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-11.yaml
+++ b/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-11.yaml
@@ -1,5 +1,6 @@
 qec_id: 313
 name: RL fully-connected zero 11
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/15-1-3/15_8.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H,S. Canonicalization qubit
   permutation (stored qubit i = original qubit permutation[i]): [0, 1, 2, 3, 4, 5,

--- a/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-12.yaml
+++ b/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-12.yaml
@@ -1,5 +1,6 @@
 qec_id: 314
 name: RL fully-connected zero 12
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/15-1-3/15_9.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H,S. Canonicalization qubit
   permutation (stored qubit i = original qubit permutation[i]): [0, 1, 2, 3, 4, 5,

--- a/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-13.yaml
+++ b/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-13.yaml
@@ -1,5 +1,6 @@
 qec_id: 394
 name: RL fully-connected zero 13
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/15-1-3/15_0_0_combined.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla qubits:
   [15, 16]. Canonicalization qubit permutation (stored qubit i = original qubit permutation[i]):

--- a/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-14.yaml
+++ b/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-14.yaml
@@ -1,5 +1,6 @@
 qec_id: 395
 name: RL fully-connected zero 14
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/15-1-3/15_0_1_combined.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H,S. Flag/ancilla qubits:
   [15, 16]. Canonicalization qubit permutation (stored qubit i = original qubit permutation[i]):

--- a/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-15.yaml
+++ b/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-15.yaml
@@ -1,5 +1,6 @@
 qec_id: 396
 name: RL fully-connected zero 15
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/15-1-3/15_0_2_combined.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H,S. Flag/ancilla qubits:
   [15, 16]. Canonicalization qubit permutation (stored qubit i = original qubit permutation[i]):

--- a/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-16.yaml
+++ b/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-16.yaml
@@ -1,5 +1,6 @@
 qec_id: 397
 name: RL fully-connected zero 16
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/15-1-3/15_0_3_combined.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H,S. Flag/ancilla qubits:
   [15, 16]. Canonicalization qubit permutation (stored qubit i = original qubit permutation[i]):

--- a/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-17.yaml
+++ b/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-17.yaml
@@ -1,5 +1,6 @@
 qec_id: 398
 name: RL fully-connected zero 17
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/15-1-3/15_0_4_combined.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H,S. Flag/ancilla qubits:
   [15, 16]. Canonicalization qubit permutation (stored qubit i = original qubit permutation[i]):

--- a/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-18.yaml
+++ b/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-18.yaml
@@ -1,5 +1,6 @@
 qec_id: 399
 name: RL fully-connected zero 18
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/15-1-3/15_0_5_combined.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H,S. Flag/ancilla qubits:
   [15, 16]. Canonicalization qubit permutation (stored qubit i = original qubit permutation[i]):

--- a/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-19.yaml
+++ b/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-19.yaml
@@ -1,5 +1,6 @@
 qec_id: 400
 name: RL fully-connected zero 19
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/15-1-3/15_0_6_combined.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H,S. Flag/ancilla qubits:
   [15, 16]. Canonicalization qubit permutation (stored qubit i = original qubit permutation[i]):

--- a/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-2.yaml
+++ b/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-2.yaml
@@ -1,5 +1,6 @@
 qec_id: 238
 name: RL fully-connected zero 2
+tool: rlftqc
 notes:
   "Source file: integrated-ft-logical-state-preparation/fully-connected/15-1-3/zero-logical/15_9.stim.
   Logical state: zero. Connectivity: fully-connected. Gate set: CX,H. Flag/ancilla

--- a/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-20.yaml
+++ b/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-20.yaml
@@ -1,5 +1,6 @@
 qec_id: 401
 name: RL fully-connected zero 20
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/15-1-3/15_0_7_combined.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H,S. Flag/ancilla qubits:
   [15, 16]. Canonicalization qubit permutation (stored qubit i = original qubit permutation[i]):

--- a/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-21.yaml
+++ b/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-21.yaml
@@ -1,5 +1,6 @@
 qec_id: 402
 name: RL fully-connected zero 21
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/15-1-3/15_0_8_combined.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H,S. Flag/ancilla qubits:
   [15, 16]. Canonicalization qubit permutation (stored qubit i = original qubit permutation[i]):

--- a/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-22.yaml
+++ b/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-22.yaml
@@ -1,5 +1,6 @@
 qec_id: 403
 name: RL fully-connected zero 22
+tool: rlftqc
 notes: "Source file: verification-circuit-synthesis/15-1-3/15_0_9_combined.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H,S. Flag/ancilla qubits:
   [15, 16]. Canonicalization qubit permutation (stored qubit i = original qubit permutation[i]):

--- a/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-3.yaml
+++ b/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-3.yaml
@@ -1,5 +1,6 @@
 qec_id: 305
 name: RL fully-connected zero 3
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/15-1-3/15_0.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H,S. Canonicalization qubit
   permutation (stored qubit i = original qubit permutation[i]): [0, 1, 2, 3, 4, 5,

--- a/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-4.yaml
+++ b/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-4.yaml
@@ -1,5 +1,6 @@
 qec_id: 306
 name: RL fully-connected zero 4
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/15-1-3/15_1.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H,S. Canonicalization qubit
   permutation (stored qubit i = original qubit permutation[i]): [0, 1, 2, 3, 4, 5,

--- a/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-5.yaml
+++ b/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-5.yaml
@@ -1,5 +1,6 @@
 qec_id: 307
 name: RL fully-connected zero 5
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/15-1-3/15_2.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H,S. Canonicalization qubit
   permutation (stored qubit i = original qubit permutation[i]): [0, 1, 2, 3, 4, 5,

--- a/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-6.yaml
+++ b/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-6.yaml
@@ -1,5 +1,6 @@
 qec_id: 308
 name: RL fully-connected zero 6
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/15-1-3/15_3.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H,S. Canonicalization qubit
   permutation (stored qubit i = original qubit permutation[i]): [0, 1, 2, 3, 4, 5,

--- a/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-7.yaml
+++ b/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-7.yaml
@@ -1,5 +1,6 @@
 qec_id: 309
 name: RL fully-connected zero 7
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/15-1-3/15_4.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H,S. Canonicalization qubit
   permutation (stored qubit i = original qubit permutation[i]): [0, 1, 2, 3, 4, 5,

--- a/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-8.yaml
+++ b/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-8.yaml
@@ -1,5 +1,6 @@
 qec_id: 310
 name: RL fully-connected zero 8
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/15-1-3/15_5.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H,S. Canonicalization qubit
   permutation (stored qubit i = original qubit permutation[i]): [0, 1, 2, 3, 4, 5,

--- a/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-9.yaml
+++ b/data_yaml/circuits/tetrahedral-code--rl-fully-connected-zero-9.yaml
@@ -1,5 +1,6 @@
 qec_id: 311
 name: RL fully-connected zero 9
+tool: rlftqc
 notes: "Source file: logical-state-preparation/fully-connected/15-1-3/15_6.stim. Logical
   state: zero. Connectivity: fully-connected. Gate set: CX,H,S. Canonicalization qubit
   permutation (stored qubit i = original qubit permutation[i]): [0, 1, 2, 3, 4, 5,

--- a/data_yaml/circuits/tetrahedral-code--rl-ibm-tokyo-zero-0.yaml
+++ b/data_yaml/circuits/tetrahedral-code--rl-ibm-tokyo-zero-0.yaml
@@ -1,5 +1,6 @@
 qec_id: 349
 name: RL ibm tokyo zero 0
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/15-1-3-tokyo/15_0.stim. Logical
   state: zero. Connectivity: ibm. Gate set: CX,S,SQRT_X. Device: tokyo. Device qubit
   placement (Qiskit indices): 0,4,11,2,7,5,1,10,13,3,6,14,12,8,9. Canonicalization

--- a/data_yaml/circuits/tetrahedral-code--rl-ibm-tokyo-zero-1.yaml
+++ b/data_yaml/circuits/tetrahedral-code--rl-ibm-tokyo-zero-1.yaml
@@ -1,5 +1,6 @@
 qec_id: 350
 name: RL ibm tokyo zero 1
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/15-1-3-tokyo/15_2.stim. Logical
   state: zero. Connectivity: ibm. Gate set: CX,S,SQRT_X. Device: tokyo. Device qubit
   placement (Qiskit indices): 0,4,11,2,7,5,1,10,13,3,6,14,12,8,9. Canonicalization

--- a/data_yaml/circuits/tetrahedral-code--rl-ibm-tokyo-zero-2.yaml
+++ b/data_yaml/circuits/tetrahedral-code--rl-ibm-tokyo-zero-2.yaml
@@ -1,5 +1,6 @@
 qec_id: 351
 name: RL ibm tokyo zero 2
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/15-1-3-tokyo/15_3.stim. Logical
   state: zero. Connectivity: ibm. Gate set: CX,S,SQRT_X. Device: tokyo. Device qubit
   placement (Qiskit indices): 0,4,11,2,7,5,1,10,13,3,6,14,12,8,9. Canonicalization

--- a/data_yaml/circuits/tetrahedral-code--rl-ibm-tokyo-zero-3.yaml
+++ b/data_yaml/circuits/tetrahedral-code--rl-ibm-tokyo-zero-3.yaml
@@ -1,5 +1,6 @@
 qec_id: 352
 name: RL ibm tokyo zero 3
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/15-1-3-tokyo/15_4.stim. Logical
   state: zero. Connectivity: ibm. Gate set: CX,S,SQRT_X. Device: tokyo. Device qubit
   placement (Qiskit indices): 0,4,11,2,7,5,1,10,13,3,6,14,12,8,9. Canonicalization

--- a/data_yaml/circuits/tetrahedral-code--rl-ibm-tokyo-zero-4.yaml
+++ b/data_yaml/circuits/tetrahedral-code--rl-ibm-tokyo-zero-4.yaml
@@ -1,5 +1,6 @@
 qec_id: 353
 name: RL ibm tokyo zero 4
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/15-1-3-tokyo/15_5.stim. Logical
   state: zero. Connectivity: ibm. Gate set: CX,S,SQRT_X. Device: tokyo. Device qubit
   placement (Qiskit indices): 0,4,11,2,7,5,1,10,13,3,6,14,12,8,9. Canonicalization

--- a/data_yaml/circuits/tetrahedral-code--rl-ibm-tokyo-zero-5.yaml
+++ b/data_yaml/circuits/tetrahedral-code--rl-ibm-tokyo-zero-5.yaml
@@ -1,5 +1,6 @@
 qec_id: 354
 name: RL ibm tokyo zero 5
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/15-1-3-tokyo/15_6.stim. Logical
   state: zero. Connectivity: ibm. Gate set: CX,S,SQRT_X. Device: tokyo. Device qubit
   placement (Qiskit indices): 0,4,11,2,7,5,1,10,13,3,6,14,12,8,9. Canonicalization

--- a/data_yaml/circuits/tetrahedral-code--rl-ibm-tokyo-zero-6.yaml
+++ b/data_yaml/circuits/tetrahedral-code--rl-ibm-tokyo-zero-6.yaml
@@ -1,5 +1,6 @@
 qec_id: 355
 name: RL ibm tokyo zero 6
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/15-1-3-tokyo/15_7.stim. Logical
   state: zero. Connectivity: ibm. Gate set: CX,S,SQRT_X. Device: tokyo. Device qubit
   placement (Qiskit indices): 0,4,11,2,7,5,1,10,13,3,6,14,12,8,9. Canonicalization

--- a/data_yaml/circuits/tetrahedral-code--rl-ibm-tokyo-zero-7.yaml
+++ b/data_yaml/circuits/tetrahedral-code--rl-ibm-tokyo-zero-7.yaml
@@ -1,5 +1,6 @@
 qec_id: 356
 name: RL ibm tokyo zero 7
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/15-1-3-tokyo/15_8.stim. Logical
   state: zero. Connectivity: ibm. Gate set: CX,S,SQRT_X. Device: tokyo. Device qubit
   placement (Qiskit indices): 0,4,11,2,7,5,1,10,13,3,6,14,12,8,9. Canonicalization

--- a/data_yaml/circuits/tetrahedral-code--rl-ibm-tokyo-zero-8.yaml
+++ b/data_yaml/circuits/tetrahedral-code--rl-ibm-tokyo-zero-8.yaml
@@ -1,5 +1,6 @@
 qec_id: 357
 name: RL ibm tokyo zero 8
+tool: rlftqc
 notes: "Source file: logical-state-preparation/ibm/15-1-3-tokyo/15_9.stim. Logical
   state: zero. Connectivity: ibm. Gate set: CX,S,SQRT_X. Device: tokyo. Device qubit
   placement (Qiskit indices): 0,4,11,2,7,5,1,10,13,3,6,14,12,8,9. Canonicalization

--- a/data_yaml/tools/autqec.yaml
+++ b/data_yaml/tools/autqec.yaml
@@ -1,0 +1,5 @@
+name: autqec
+description: Finds fault-tolerant logical Clifford gates of stabilizer codes from code automorphisms and converts them to physical Clifford circuits.
+github_url: https://github.com/hsayginel/autqec
+paper_urls: [https://arxiv.org/abs/2409.18175]
+tags: [Python, logical-gates, Clifford, fault-tolerant]

--- a/data_yaml/tools/cliffordopt.yaml
+++ b/data_yaml/tools/cliffordopt.yaml
@@ -1,4 +1,5 @@
 name: CliffordOpt
-description: Optimisation of Clifford circuits for fault-tolerant quantum error correction.
+description: Heuristic and optimal synthesis of CNOT and Clifford circuits from parity-check or symplectic matrices, minimizing two-qubit gate count or circuit depth.
 github_url: https://github.com/m-webster/CliffordOpt
-tags: [Python, optimization, Clifford]
+paper_urls: [https://arxiv.org/abs/2503.14660]
+tags: [Python, optimization, Clifford, encoding]

--- a/data_yaml/tools/flag-at-origin.yaml
+++ b/data_yaml/tools/flag-at-origin.yaml
@@ -1,4 +1,5 @@
 name: Flag at Origin
-description: Code and data for fault-tolerant flag-based syndrome extraction circuits.
+description: Code and circuits for modular fault-tolerant state preparation of CSS codes using flag gadgets, with results on Quantinuum H2-1.
 github_url: https://github.com/Quantinuum/flag_at_origin_paper
-tags: [Python, fault-tolerant, syndrome-extraction, flag]
+paper_urls: [https://arxiv.org/abs/2508.14200]
+tags: [Python, fault-tolerant, state-preparation, flag]

--- a/data_yaml/tools/mqt-qecc.yaml
+++ b/data_yaml/tools/mqt-qecc.yaml
@@ -1,6 +1,11 @@
 name: MQT QECC
-description: Tools for quantum error correcting codes, part of the Munich Quantum Toolkit.
+description: Tools for quantum error correcting codes, including automated synthesis of fault-tolerant state-preparation and encoding circuits; part of the Munich Quantum Toolkit.
 homepage_url: https://mqt.readthedocs.io/projects/qecc/en/latest/
 github_url: https://github.com/munich-quantum-toolkit/qecc
+paper_urls:
+  [
+    https://arxiv.org/abs/2408.11894,
+    https://arxiv.org/abs/2501.05527,
+    https://arxiv.org/abs/2605.15266,
+  ]
 tags: [Python, encoding, state-preparation]
-paper_urls: [https://arxiv.org/abs/2408.11894]

--- a/data_yaml/tools/mqt-qecc.yaml
+++ b/data_yaml/tools/mqt-qecc.yaml
@@ -3,3 +3,4 @@ description: Tools for quantum error correcting codes, part of the Munich Quantu
 homepage_url: https://mqt.readthedocs.io/projects/qecc/en/latest/
 github_url: https://github.com/munich-quantum-toolkit/qecc
 tags: [Python, encoding, state-preparation]
+paper_urls: [https://arxiv.org/abs/2408.11894]

--- a/data_yaml/tools/qldpc.yaml
+++ b/data_yaml/tools/qldpc.yaml
@@ -1,0 +1,5 @@
+name: qLDPC
+description: Library for constructing qLDPC, stabilizer, and subsystem codes that generates Stim circuits for encoding, memory experiments, and SWAP-transversal logical Clifford gates.
+homepage_url: https://qldpc.readthedocs.io/
+github_url: https://github.com/qLDPCOrg/qLDPC
+tags: [Python, encoding, syndrome-extraction, qLDPC]

--- a/data_yaml/tools/quits.yaml
+++ b/data_yaml/tools/quits.yaml
@@ -1,0 +1,5 @@
+name: QUITS
+description: Modular circuit-level simulator for qLDPC codes that constructs Stim syndrome-extraction circuits for hypergraph-product, lifted-product, balanced-product, and bivariate-bicycle codes.
+github_url: https://github.com/mkangquantum/quits
+paper_urls: [https://arxiv.org/abs/2504.02673]
+tags: [Python, syndrome-extraction, qLDPC]

--- a/data_yaml/tools/rlftqc.yaml
+++ b/data_yaml/tools/rlftqc.yaml
@@ -1,0 +1,6 @@
+name: rlftqc
+description: Reinforcement-learning discovery of fault-tolerant logical state preparation circuits for stabilizer codes, with customizable gate sets and qubit connectivity, producing Stim circuits.
+homepage_url: https://remmyzen.github.io/rlftqc/
+github_url: https://github.com/remmyzen/rlftqc
+paper_urls: [https://arxiv.org/abs/2402.17761]
+tags: [Python, state-preparation, fault-tolerant, reinforcement-learning]

--- a/data_yaml/tools/rustiq.yaml
+++ b/data_yaml/tools/rustiq.yaml
@@ -1,0 +1,5 @@
+name: Rustiq
+description: Rust-based synthesis engine for Clifford operators and isometries, stabilizer and graph states, and Pauli networks, producing gate-count- or depth-optimized circuits such as encoders from stabilizers.
+github_url: https://github.com/qiskit-community/rustiq
+paper_urls: [https://arxiv.org/abs/2212.06928, https://arxiv.org/abs/2404.03280]
+tags: [Rust, Python, encoding, state-preparation, Clifford]

--- a/data_yaml/tools/stac.yaml
+++ b/data_yaml/tools/stac.yaml
@@ -1,0 +1,5 @@
+name: Stac
+description: Pedagogical library for constructing stabilizer codes that generates encoding, decoding, and syndrome-measurement circuits with export to QASM and Stim.
+homepage_url: https://abdullahkhalid.com/qecft/
+github_url: https://github.com/abdullahkhalids/stac
+tags: [Python, encoding, syndrome-extraction]

--- a/docs/adding-circuits.md
+++ b/docs/adding-circuits.md
@@ -318,6 +318,7 @@ name: MQT QECC
 description: Tools for quantum error correcting codes.
 homepage_url: https://mqt.readthedocs.io/projects/qecc/en/latest/
 github_url: https://github.com/munich-quantum-toolkit/qecc
+paper_urls: [https://arxiv.org/abs/2408.11894]
 tags: [Python, encoding, state-preparation]
 ```
 

--- a/docs/superpowers/plans/2026-07-04-tools-section-rework.md
+++ b/docs/superpowers/plans/2026-07-04-tools-section-rework.md
@@ -17,6 +17,7 @@
 ### Task 1: `paper_urls` schema — validator, migration, DB build, docs
 
 **Files:**
+
 - Modify: `scripts/validate-yaml.mjs` (tools schema ~line 41, `checkType` ~line 54)
 - Create: `data/migrations/013_tool_paper_urls.sql`
 - Modify: `scripts/db/create_database.mjs` (`insertTool` statement ~line 34, tool insert loop ~line 99)
@@ -54,10 +55,10 @@ In `scripts/validate-yaml.mjs`, add to the `tools` schema's `optional` block:
 And add a `urls` type to `checkType` (after the `tags` case):
 
 ```js
-  if (type === "urls")
-    return (
-      Array.isArray(value) && value.every((v) => typeof v === "string" && /^https?:\/\//.test(v))
-    );
+if (type === "urls")
+  return (
+    Array.isArray(value) && value.every((v) => typeof v === "string" && /^https?:\/\//.test(v))
+  );
 ```
 
 Run: `npm run validate:yaml`
@@ -86,16 +87,16 @@ In `scripts/db/create_database.mjs`, change the `insertTool` prepared statement:
 and the tool insert call in the tools loop:
 
 ```js
-      const { lastInsertRowid } = stmts.insertTool.run(
-        data.name,
-        slug,
-        data.description || "",
-        data.homepage_url || null,
-        data.github_url || null,
-        Array.isArray(data.paper_urls) && data.paper_urls.length > 0
-          ? JSON.stringify(data.paper_urls)
-          : null,
-      );
+const { lastInsertRowid } = stmts.insertTool.run(
+  data.name,
+  slug,
+  data.description || "",
+  data.homepage_url || null,
+  data.github_url || null,
+  Array.isArray(data.paper_urls) && data.paper_urls.length > 0
+    ? JSON.stringify(data.paper_urls)
+    : null,
+);
 ```
 
 Run: `npm run db:create`
@@ -138,6 +139,7 @@ git commit -m "feat(tools): add paper_urls field to tool schema"
 ### Task 2: Type + query layer parsing
 
 **Files:**
+
 - Modify: `src/types/index.ts` (`Tool` interface ~line 42)
 - Modify: `src/lib/queries/tools.ts`
 
@@ -206,17 +208,17 @@ In `filterTools`, change the cast and keep `enrichTools`:
 In `getToolsForCircuits`, change the rows cast to `(ToolRow & { circuit_id: number })[]` and the map construction to:
 
 ```ts
-  for (const row of rows) {
-    result.set(row.circuit_id, {
-      id: row.id,
-      name: row.name,
-      slug: row.slug,
-      description: row.description,
-      homepage_url: row.homepage_url,
-      github_url: row.github_url,
-      paper_urls: row.paper_urls ? (JSON.parse(row.paper_urls) as string[]) : null,
-    });
-  }
+for (const row of rows) {
+  result.set(row.circuit_id, {
+    id: row.id,
+    name: row.name,
+    slug: row.slug,
+    description: row.description,
+    homepage_url: row.homepage_url,
+    github_url: row.github_url,
+    paper_urls: row.paper_urls ? (JSON.parse(row.paper_urls) as string[]) : null,
+  });
+}
 ```
 
 - [ ] **Step 3: Verify types compile and site builds**
@@ -239,6 +241,7 @@ git commit -m "feat(tools): parse paper_urls into Tool objects in query layer"
 ### Task 3: ToolCard — paper links and "no circuits yet"
 
 **Files:**
+
 - Modify: `src/components/ToolCard.astro`
 
 - [ ] **Step 1: Update the circuit-count label**
@@ -282,6 +285,7 @@ git commit -m "feat(tools): show paper links and friendlier zero-circuit label o
 ### Task 4: Two-section /tools page with contribute CTA
 
 **Files:**
+
 - Modify: `src/pages/tools/index.astro`
 
 - [ ] **Step 1: Split the tool list**
@@ -356,6 +360,7 @@ git commit -m "feat(tools): split tools page into contributed and other tools, a
 ### Task 5: Update existing tool YAMLs (verified facts)
 
 **Files:**
+
 - Modify: `data_yaml/tools/circuit-synth.yaml`
 - Modify: `data_yaml/tools/cliffordopt.yaml`
 - Modify: `data_yaml/tools/flag-at-origin.yaml`
@@ -424,6 +429,7 @@ git commit -m "fix(tools): correct flag-at-origin description, add verified pape
 ### Task 6: Add six new tool YAMLs (verified facts)
 
 **Files:**
+
 - Create: `data_yaml/tools/rlftqc.yaml`
 - Create: `data_yaml/tools/qldpc.yaml`
 - Create: `data_yaml/tools/quits.yaml`
@@ -516,6 +522,7 @@ git commit -m "feat(tools): add rlftqc, qLDPC, QUITS, Rustiq, autqec, and Stac t
 ### Task 7: Version bump and final verification
 
 **Files:**
+
 - Modify: `package.json` (version 0.3.2 → 0.4.0)
 - Modify: `pyproject.toml` (version 0.3.2 → 0.4.0)
 - Modify: `uv.lock`, `package-lock.json` (regenerated)

--- a/docs/superpowers/plans/2026-07-04-tools-section-rework.md
+++ b/docs/superpowers/plans/2026-07-04-tools-section-rework.md
@@ -1,0 +1,562 @@
+# Tools Section Rework Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend the tools section with a `paper_urls` field, six new tool entries, corrected existing entries, and a two-section `/tools` page separating contributing tools from other circuit-synthesis tools.
+
+**Architecture:** YAML in `data_yaml/tools/` is the source of truth; a SQLite DB is rebuilt from it (`npm run db:create`). `paper_urls` is stored as a JSON-encoded TEXT column (same convention as `codes.h`), parsed into `string[]` in the query layer so Astro components receive a ready array. The page split is pure presentation logic on the existing query result.
+
+**Tech Stack:** Astro v7 (SSR pages), better-sqlite3, Tailwind CSS, plain Node scripts for validation/DB build. No JS test framework exists in this repo — verification is via `npm run validate:yaml`, `npm run db:create`, `npm run lint`, `npm run format:check`, and a dev-server check (this matches repo convention).
+
+**Spec:** `docs/superpowers/specs/2026-07-04-tools-section-rework-design.md`
+
+**Verified facts (do not re-research):** All URLs/papers below were verified against live repos and arXiv on 2026-07-04. Circuit-Synth has no public repository or paper — its entry intentionally has no links. The current Flag at Origin description is factually wrong (the tool/paper is about FT **state preparation**, not syndrome extraction) and is corrected in Task 6.
+
+---
+
+### Task 1: `paper_urls` schema — validator, migration, DB build, docs
+
+**Files:**
+- Modify: `scripts/validate-yaml.mjs` (tools schema ~line 41, `checkType` ~line 54)
+- Create: `data/migrations/013_tool_paper_urls.sql`
+- Modify: `scripts/db/create_database.mjs` (`insertTool` statement ~line 34, tool insert loop ~line 99)
+- Modify: `docs/adding-circuits.md` (tool YAML reference ~line 314)
+- Modify: `CLAUDE.md` (tools table in the Database Schema section)
+
+- [ ] **Step 1: Add a failing-check exercise** — add `paper_urls` to one YAML before the schema knows it, to see validation fail:
+
+Temporarily append to `data_yaml/tools/mqt-qecc.yaml`:
+
+```yaml
+paper_urls: [https://arxiv.org/abs/2408.11894]
+```
+
+Run: `npm run validate:yaml`
+Expected: FAIL with `tools/mqt-qecc.yaml: unknown field "paper_urls"` (proves the validator actually checks this; leave the YAML line in place — Task 6 keeps it).
+
+- [ ] **Step 2: Extend the validator**
+
+In `scripts/validate-yaml.mjs`, add to the `tools` schema's `optional` block:
+
+```js
+  tools: {
+    required: { name: "string" },
+    optional: {
+      description: "string",
+      homepage_url: "string",
+      github_url: "string",
+      paper_urls: "urls",
+      tags: "tags",
+    },
+  },
+```
+
+And add a `urls` type to `checkType` (after the `tags` case):
+
+```js
+  if (type === "urls")
+    return (
+      Array.isArray(value) && value.every((v) => typeof v === "string" && /^https?:\/\//.test(v))
+    );
+```
+
+Run: `npm run validate:yaml`
+Expected: PASS (exit 0, no output about tools).
+
+- [ ] **Step 3: Create the migration**
+
+Create `data/migrations/013_tool_paper_urls.sql`:
+
+```sql
+-- Migration: Add paper_urls (JSON-encoded array of paper URLs) to tools
+
+ALTER TABLE tools ADD COLUMN paper_urls TEXT;
+```
+
+- [ ] **Step 4: Write the column in the DB build**
+
+In `scripts/db/create_database.mjs`, change the `insertTool` prepared statement:
+
+```js
+  insertTool: db.prepare(`
+    INSERT INTO tools (name, slug, description, homepage_url, github_url, paper_urls)
+    VALUES (?, ?, ?, ?, ?, ?)`),
+```
+
+and the tool insert call in the tools loop:
+
+```js
+      const { lastInsertRowid } = stmts.insertTool.run(
+        data.name,
+        slug,
+        data.description || "",
+        data.homepage_url || null,
+        data.github_url || null,
+        Array.isArray(data.paper_urls) && data.paper_urls.length > 0
+          ? JSON.stringify(data.paper_urls)
+          : null,
+      );
+```
+
+Run: `npm run db:create`
+Expected: PASS — output lists all tools/codes/circuits, exit 0. Then check the column landed:
+
+Run: `sqlite3 data/qecirc.db "SELECT slug, paper_urls FROM tools WHERE slug='mqt-qecc'"`
+Expected: `mqt-qecc|["https://arxiv.org/abs/2408.11894"]`
+
+- [ ] **Step 5: Update docs**
+
+In `docs/adding-circuits.md`, extend the tool YAML example (~line 316) to:
+
+```yaml
+name: MQT QECC
+description: Tools for quantum error correcting codes.
+homepage_url: https://mqt.readthedocs.io/projects/qecc/en/latest/
+github_url: https://github.com/munich-quantum-toolkit/qecc
+paper_urls: [https://arxiv.org/abs/2408.11894]
+tags: [Python, encoding, state-preparation]
+```
+
+In `CLAUDE.md`, Database Schema section, change the tools line to:
+
+```
+tools
+  id, name, slug, description, homepage_url, github_url, paper_urls, created_at
+  -- software tools used to create circuits
+  -- paper_urls: JSON-encoded array of associated paper URLs
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/validate-yaml.mjs data/migrations/013_tool_paper_urls.sql scripts/db/create_database.mjs docs/adding-circuits.md CLAUDE.md data_yaml/tools/mqt-qecc.yaml
+git commit -m "feat(tools): add paper_urls field to tool schema"
+```
+
+---
+
+### Task 2: Type + query layer parsing
+
+**Files:**
+- Modify: `src/types/index.ts` (`Tool` interface ~line 42)
+- Modify: `src/lib/queries/tools.ts`
+
+- [ ] **Step 1: Extend the `Tool` type**
+
+In `src/types/index.ts`:
+
+```ts
+export interface Tool {
+  id: number;
+  name: string;
+  slug: string;
+  description: string | null;
+  homepage_url: string | null;
+  github_url: string | null;
+  paper_urls: string[] | null;
+}
+```
+
+- [ ] **Step 2: Parse JSON in the query layer**
+
+In `src/lib/queries/tools.ts`, add a row type + parser near the top (after imports):
+
+```ts
+type ToolRow = Omit<Tool, "paper_urls"> & { paper_urls: string | null };
+
+function parseToolRow(row: ToolRow): Tool {
+  return { ...row, paper_urls: row.paper_urls ? (JSON.parse(row.paper_urls) as string[]) : null };
+}
+```
+
+Update the four query functions:
+
+```ts
+function enrichTools(rows: ToolRow[]): ToolWithMeta[] {
+  return withCircuitCounts(withTags(rows.map(parseToolRow), "tool"), "tool_id");
+}
+
+export function getAllTools(): ToolWithMeta[] {
+  const db = getDb();
+  const tools = db
+    .prepare(
+      `SELECT t.* FROM tools t
+       LEFT JOIN circuits c ON c.tool_id = t.id
+       GROUP BY t.id
+       ORDER BY COUNT(c.id) DESC, t.name`,
+    )
+    .all() as ToolRow[];
+  return enrichTools(tools);
+}
+
+export function getToolById(id: number): Tool | undefined {
+  const db = getDb();
+  const row = db.prepare("SELECT * FROM tools WHERE id = ?").get(id) as ToolRow | undefined;
+  return row ? parseToolRow(row) : undefined;
+}
+```
+
+In `filterTools`, change the cast and keep `enrichTools`:
+
+```ts
+    .all(...params) as ToolRow[];
+  return enrichTools(tools);
+```
+
+In `getToolsForCircuits`, change the rows cast to `(ToolRow & { circuit_id: number })[]` and the map construction to:
+
+```ts
+  for (const row of rows) {
+    result.set(row.circuit_id, {
+      id: row.id,
+      name: row.name,
+      slug: row.slug,
+      description: row.description,
+      homepage_url: row.homepage_url,
+      github_url: row.github_url,
+      paper_urls: row.paper_urls ? (JSON.parse(row.paper_urls) as string[]) : null,
+    });
+  }
+```
+
+- [ ] **Step 3: Verify types compile and site builds**
+
+Run: `npm run lint`
+Expected: PASS (no errors; warnings unrelated to tools are acceptable if pre-existing).
+
+Run: `npm run build`
+Expected: PASS (astro build completes; this type-checks the .astro/.ts files that consume `Tool`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/types/index.ts src/lib/queries/tools.ts
+git commit -m "feat(tools): parse paper_urls into Tool objects in query layer"
+```
+
+---
+
+### Task 3: ToolCard — paper links and "no circuits yet"
+
+**Files:**
+- Modify: `src/components/ToolCard.astro`
+
+- [ ] **Step 1: Update the circuit-count label**
+
+Replace the count `<span>` (lines 16–18) with:
+
+```astro
+    <span class="text-xs text-gray-400 dark:text-gray-500">
+      {tool.circuit_count === 0
+        ? "no circuits yet"
+        : `${tool.circuit_count} circuit${tool.circuit_count !== 1 ? "s" : ""}`}
+    </span>
+```
+
+- [ ] **Step 2: Render paper links**
+
+In the links `<div>` at the bottom, after the GitHub link block, add:
+
+```astro
+    {(tool.paper_urls ?? []).map((url, i) => (
+      <a href={url} class="underline text-gray-500 hover:text-gray-900 dark:hover:text-gray-100" target="_blank" rel="noopener">
+        {(tool.paper_urls ?? []).length > 1 ? `Paper ${i + 1}` : "Paper"} &#x2197;
+      </a>
+    ))}
+```
+
+- [ ] **Step 3: Verify in dev server**
+
+Run: `npm run db:create && npm run dev` (background) and open `http://localhost:4321/tools`.
+Expected: MQT QECC card shows a "Paper ↗" link (from the YAML line added in Task 1); CliffordOpt and Flag at Origin cards show "no circuits yet" instead of "0 circuits".
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/ToolCard.astro
+git commit -m "feat(tools): show paper links and friendlier zero-circuit label on tool cards"
+```
+
+---
+
+### Task 4: Two-section /tools page with contribute CTA
+
+**Files:**
+- Modify: `src/pages/tools/index.astro`
+
+- [ ] **Step 1: Split the tool list**
+
+In the frontmatter, after `const tools = ...`, add:
+
+```ts
+const contributed = tools.filter((t) => t.circuit_count > 0);
+const others = tools
+  .filter((t) => t.circuit_count === 0)
+  .sort((a, b) => a.name.localeCompare(b.name));
+```
+
+- [ ] **Step 2: Render two sections + CTA**
+
+Replace the existing `{tools.length === 0 ? ... : <div class="grid gap-3">...</div>}` block with:
+
+```astro
+  {tools.length === 0 ? (
+    <div class="text-center py-8">
+      <p class="text-gray-500 dark:text-gray-400 mb-2">No tools match your filters.</p>
+      <a href="/tools" class="text-sm underline text-gray-500 hover:text-gray-900 dark:hover:text-gray-100">Clear filters</a>
+    </div>
+  ) : (
+    <>
+      {contributed.length > 0 && (
+        <section class="mb-8">
+          <h2 class="text-lg font-semibold mb-3">Tools contributed to QECirc</h2>
+          <div class="grid gap-3">
+            {contributed.map((tool) => (
+              <ToolCard tool={tool} baseUrl={Astro.url} />
+            ))}
+          </div>
+        </section>
+      )}
+      {others.length > 0 && (
+        <section>
+          <h2 class="text-lg font-semibold mb-3">More circuit-synthesis tools</h2>
+          <div class="grid gap-3">
+            {others.map((tool) => (
+              <ToolCard tool={tool} baseUrl={Astro.url} />
+            ))}
+          </div>
+        </section>
+      )}
+    </>
+  )}
+
+  <p class="mt-8 text-sm text-gray-500 dark:text-gray-400">
+    Built a tool that generates QEC circuits? We'd love to include your circuits —
+    <a href="/contribute" class="underline hover:text-gray-900 dark:hover:text-gray-100">see how to contribute</a>.
+  </p>
+```
+
+- [ ] **Step 3: Verify in dev server**
+
+Open `http://localhost:4321/tools`.
+Expected: "Tools contributed to QECirc" lists Circuit-Synth (112) and MQT QECC (37); "More circuit-synthesis tools" lists CliffordOpt and Flag at Origin alphabetically; CTA line at the bottom links to `/contribute`.
+
+Open `http://localhost:4321/tools?tag=Clifford`.
+Expected: only matching tools shown, sections with no matches hide their headings; empty-state message when a bogus tag (`?tag=nope`) yields nothing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/pages/tools/index.astro
+git commit -m "feat(tools): split tools page into contributed and other tools, add contribute CTA"
+```
+
+---
+
+### Task 5: Update existing tool YAMLs (verified facts)
+
+**Files:**
+- Modify: `data_yaml/tools/circuit-synth.yaml`
+- Modify: `data_yaml/tools/cliffordopt.yaml`
+- Modify: `data_yaml/tools/flag-at-origin.yaml`
+- Modify: `data_yaml/tools/mqt-qecc.yaml`
+
+- [ ] **Step 1: circuit-synth.yaml** — no public repository or paper exists, so it keeps no links; description unchanged:
+
+```yaml
+name: Circuit-Synth
+description: Clifford and CNOT circuit synthesis via greedy elimination with rollout search, minimizing two-qubit gate count or depth.
+tags: [Python, Rust, encoding, state-preparation]
+```
+
+(No change unless the file differs from the above — verify with `cat`.)
+
+- [ ] **Step 2: cliffordopt.yaml** — add paper, sharpen description:
+
+```yaml
+name: CliffordOpt
+description: Heuristic and optimal synthesis of CNOT and Clifford circuits from parity-check or symplectic matrices, minimizing two-qubit gate count or circuit depth.
+github_url: https://github.com/m-webster/CliffordOpt
+paper_urls: [https://arxiv.org/abs/2503.14660]
+tags: [Python, optimization, Clifford, encoding]
+```
+
+- [ ] **Step 3: flag-at-origin.yaml** — **correct the description** (the paper is about FT state preparation, not syndrome extraction) and retag:
+
+```yaml
+name: Flag at Origin
+description: Code and circuits for modular fault-tolerant state preparation of CSS codes using flag gadgets, with results on Quantinuum H2-1.
+github_url: https://github.com/Quantinuum/flag_at_origin_paper
+paper_urls: [https://arxiv.org/abs/2508.14200]
+tags: [Python, fault-tolerant, state-preparation, flag]
+```
+
+- [ ] **Step 4: mqt-qecc.yaml** — add the three circuit-synthesis papers, extend description:
+
+```yaml
+name: MQT QECC
+description: Tools for quantum error correcting codes, including automated synthesis of fault-tolerant state-preparation and encoding circuits; part of the Munich Quantum Toolkit.
+homepage_url: https://mqt.readthedocs.io/projects/qecc/en/latest/
+github_url: https://github.com/munich-quantum-toolkit/qecc
+paper_urls:
+  [
+    https://arxiv.org/abs/2408.11894,
+    https://arxiv.org/abs/2501.05527,
+    https://arxiv.org/abs/2605.15266,
+  ]
+tags: [Python, encoding, state-preparation]
+```
+
+- [ ] **Step 5: Validate and rebuild**
+
+Run: `npm run validate:yaml && npm run db:create`
+Expected: both PASS; DB build lists all 4 tools.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add data_yaml/tools/
+git commit -m "fix(tools): correct flag-at-origin description, add verified paper links to existing tools"
+```
+
+---
+
+### Task 6: Add six new tool YAMLs (verified facts)
+
+**Files:**
+- Create: `data_yaml/tools/rlftqc.yaml`
+- Create: `data_yaml/tools/qldpc.yaml`
+- Create: `data_yaml/tools/quits.yaml`
+- Create: `data_yaml/tools/rustiq.yaml`
+- Create: `data_yaml/tools/autqec.yaml`
+- Create: `data_yaml/tools/stac.yaml`
+
+- [ ] **Step 1: rlftqc.yaml**
+
+```yaml
+name: rlftqc
+description: Reinforcement-learning discovery of fault-tolerant logical state preparation circuits for stabilizer codes, with customizable gate sets and qubit connectivity, producing Stim circuits.
+homepage_url: https://remmyzen.github.io/rlftqc/
+github_url: https://github.com/remmyzen/rlftqc
+paper_urls: [https://arxiv.org/abs/2402.17761]
+tags: [Python, state-preparation, fault-tolerant, reinforcement-learning]
+```
+
+- [ ] **Step 2: qldpc.yaml**
+
+```yaml
+name: qLDPC
+description: Library for constructing qLDPC, stabilizer, and subsystem codes that generates Stim circuits for encoding, memory experiments, and SWAP-transversal logical Clifford gates.
+homepage_url: https://qldpc.readthedocs.io/
+github_url: https://github.com/qLDPCOrg/qLDPC
+tags: [Python, encoding, syndrome-extraction, qLDPC]
+```
+
+(No `paper_urls` — verified: no standalone paper exists; the recommended citation is the repo.)
+
+- [ ] **Step 3: quits.yaml**
+
+```yaml
+name: QUITS
+description: Modular circuit-level simulator for qLDPC codes that constructs Stim syndrome-extraction circuits for hypergraph-product, lifted-product, balanced-product, and bivariate-bicycle codes.
+github_url: https://github.com/mkangquantum/quits
+paper_urls: [https://arxiv.org/abs/2504.02673]
+tags: [Python, syndrome-extraction, qLDPC]
+```
+
+- [ ] **Step 4: rustiq.yaml**
+
+```yaml
+name: Rustiq
+description: Rust-based synthesis engine for Clifford operators and isometries, stabilizer and graph states, and Pauli networks, producing gate-count- or depth-optimized circuits such as encoders from stabilizers.
+github_url: https://github.com/qiskit-community/rustiq
+paper_urls: [https://arxiv.org/abs/2212.06928, https://arxiv.org/abs/2404.03280]
+tags: [Rust, Python, encoding, state-preparation, Clifford]
+```
+
+- [ ] **Step 5: autqec.yaml**
+
+```yaml
+name: autqec
+description: Finds fault-tolerant logical Clifford gates of stabilizer codes from code automorphisms and converts them to physical Clifford circuits.
+github_url: https://github.com/hsayginel/autqec
+paper_urls: [https://arxiv.org/abs/2409.18175]
+tags: [Python, logical-gates, Clifford, fault-tolerant]
+```
+
+- [ ] **Step 6: stac.yaml**
+
+```yaml
+name: Stac
+description: Pedagogical library for constructing stabilizer codes that generates encoding, decoding, and syndrome-measurement circuits with export to QASM and Stim.
+homepage_url: https://abdullahkhalid.com/qecft/
+github_url: https://github.com/abdullahkhalids/stac
+tags: [Python, encoding, syndrome-extraction]
+```
+
+(No `paper_urls` — verified: no standalone paper; the homepage is the author's companion book.)
+
+- [ ] **Step 7: Validate, rebuild, visual check**
+
+Run: `npm run validate:yaml && npm run db:create`
+Expected: PASS; build output lists 10 tools.
+
+Open `http://localhost:4321/tools` (restart dev server — it caches the DB connection).
+Expected: section 2 now lists autqec, CliffordOpt, Flag at Origin, qLDPC, QUITS, rlftqc, Rustiq, Stac alphabetically, each with working links; paper links open arXiv pages.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add data_yaml/tools/
+git commit -m "feat(tools): add rlftqc, qLDPC, QUITS, Rustiq, autqec, and Stac tool entries"
+```
+
+---
+
+### Task 7: Version bump and final verification
+
+**Files:**
+- Modify: `package.json` (version 0.3.2 → 0.4.0)
+- Modify: `pyproject.toml` (version 0.3.2 → 0.4.0)
+- Modify: `uv.lock`, `package-lock.json` (regenerated)
+
+- [ ] **Step 1: Bump versions**
+
+In `package.json`: `"version": "0.4.0",`
+In `pyproject.toml`: `version = "0.4.0"`
+
+- [ ] **Step 2: Regenerate lockfiles**
+
+```bash
+UV_NO_CONFIG=1 uv lock
+npm install
+```
+
+Expected: `uv.lock` and (possibly) `package-lock.json` updated. **Never** let private-registry URLs into the lockfiles — `UV_NO_CONFIG=1` is required.
+
+- [ ] **Step 3: Full verification suite**
+
+```bash
+npm run validate:yaml && npm run db:create && npm run lint && npm run format:check && npm run build
+```
+
+Expected: all PASS. If `format:check` fails, run `npm run format` and re-check.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add package.json pyproject.toml uv.lock package-lock.json
+git commit -m "chore(release): bump version to 0.4.0 for tool paper_urls schema change"
+```
+
+---
+
+## Final state checklist (maps to spec)
+
+- `paper_urls` in validator, migration 013, DB build, `Tool` type, query parsing — Tasks 1–2
+- ToolCard paper links + "no circuits yet" — Task 3
+- Two-section page ("Tools contributed to QECirc" / "More circuit-synthesis tools") + CTA — Task 4
+- 4 existing entries rechecked/updated (incl. flag-at-origin correction; circuit-synth stays URL-less because the repo is internal) — Task 5
+- 6 new entries with verified facts — Task 6
+- Docs (adding-circuits.md, CLAUDE.md) — Task 1
+- Minor version bump — Task 7

--- a/docs/superpowers/specs/2026-07-04-tools-section-rework-design.md
+++ b/docs/superpowers/specs/2026-07-04-tools-section-rework-design.md
@@ -46,14 +46,14 @@ document.
 
 ### New tool YAMLs (6)
 
-| Tool   | Repo                                   | Notes |
-| ------ | -------------------------------------- | ----- |
-| rlftqc | github.com/remmyzen/rlftqc             | RL-based FT logical state prep; Stim-native; circuits already in `data-imports/rlftqc/` |
-| qLDPC  | github.com/qLDPCOrg/qLDPC              | Encoding/SE/memory circuits from code objects; Stim-native |
-| QUITS  | github.com/mkangquantum/quits          | SE circuits for HGP/QLP/BPC qLDPC families; Stim-based |
-| Rustiq | github.com/smartiel/rustiq             | Clifford/stabilizer synthesis engine (Rust, Qiskit plugin) |
-| autqec | github.com/hsayginel/autqec            | Logical Cliffords from code automorphisms |
-| Stac   | github.com/abdullahkhalids/stac        | Pedagogical stabilizer-code circuits |
+| Tool   | Repo                            | Notes                                                                                   |
+| ------ | ------------------------------- | --------------------------------------------------------------------------------------- |
+| rlftqc | github.com/remmyzen/rlftqc      | RL-based FT logical state prep; Stim-native; circuits already in `data-imports/rlftqc/` |
+| qLDPC  | github.com/qLDPCOrg/qLDPC       | Encoding/SE/memory circuits from code objects; Stim-native                              |
+| QUITS  | github.com/mkangquantum/quits   | SE circuits for HGP/QLP/BPC qLDPC families; Stim-based                                  |
+| Rustiq | github.com/smartiel/rustiq      | Clifford/stabilizer synthesis engine (Rust, Qiskit plugin)                              |
+| autqec | github.com/hsayginel/autqec     | Logical Cliffords from code automorphisms                                               |
+| Stac   | github.com/abdullahkhalids/stac | Pedagogical stabilizer-code circuits                                                    |
 
 Each entry gets: `name`, `description` (what it produces), `homepage_url` where one
 exists, `github_url`, `paper_urls`, and tags following existing conventions
@@ -77,8 +77,8 @@ exists, `github_url`, `paper_urls`, and tags following existing conventions
 - **Section 2: "More circuit-synthesis tools"** — tools with `circuit_count === 0`,
   sorted alphabetically. Their cards show "no circuits yet" instead of "0 circuits".
 - Tag filters apply across both sections. A section with no tools hides its heading.
-- CTA under section 2: *"Built a tool that generates QEC circuits? We'd love to include
-  your circuits — see how to contribute."* linking to `/contribute`.
+- CTA under section 2: _"Built a tool that generates QEC circuits? We'd love to include
+  your circuits — see how to contribute."_ linking to `/contribute`.
 
 `src/components/ToolCard.astro`:
 

--- a/docs/superpowers/specs/2026-07-04-tools-section-rework-design.md
+++ b/docs/superpowers/specs/2026-07-04-tools-section-rework-design.md
@@ -1,0 +1,104 @@
+# Tools Section Rework — Design
+
+**Date:** 2026-07-04
+**Status:** Approved design, pending implementation
+
+## Goal
+
+Extend the `/tools` section to list circuit-synthesis software tools even if they have
+not (yet) contributed circuits to the database, add paper links to tool entries, and
+recheck/update the four existing entries. The underlying motive is outreach: the page
+should double as an implicit invitation for tool authors to contribute circuits.
+
+## Scope decisions (agreed with maintainer)
+
+- **Strictly software tools** — no papers-without-code, datasets, or benchmarks as entries.
+- **Only circuit-producing tools** — tools that create (or could create) circuits of the
+  kind stored in the database. QEC frameworks/simulators that merely consume circuits
+  (qiskit-qec, CUDA-Q QEC, PECOS, qecsim) are excluded. Stim itself is excluded
+  (primarily a simulator).
+- **Paper links as a list field** (`paper_urls`), not prose — tools can have multiple
+  papers; links must be clickable.
+- **No `license` field** — visible on GitHub, only relevant at ingestion time.
+- **Two-section page layout** — contributed tools on top, other tools below.
+- **One-line contribute CTA** under the second section.
+
+## 1. Schema extension: `paper_urls`
+
+- Tool YAML gains an optional `paper_urls` field: a list of URL strings
+  (arXiv/DOI/journal links).
+- `scripts/validate-yaml.mjs`: add `paper_urls` to the tools schema as an optional
+  list-of-strings field.
+- New SQL migration in `data/migrations/`: `ALTER TABLE tools ADD COLUMN paper_urls TEXT`
+  (JSON-encoded array, same convention as `codes.h`).
+- `scripts/db/create_database.mjs`: write `paper_urls` (JSON-encoded) on insert.
+- `src/types/index.ts`: `Tool` gains `paper_urls: string[] | null`; JSON parsing happens
+  in the query layer (`src/lib/queries/tools.ts`) so components receive a parsed array.
+- **Versioning:** YAML schema change → minor version bump (`0.x.0 → 0.(x+1).0`) in
+  `package.json`, `pyproject.toml`, `uv.lock` (`UV_NO_CONFIG=1 uv lock`), and
+  `package-lock.json`.
+
+## 2. Data: new and updated tool entries
+
+All facts (URLs, descriptions, paper references) are verified against the live GitHub
+repos and papers during implementation — not copied blindly from the outreach research
+document.
+
+### New tool YAMLs (6)
+
+| Tool   | Repo                                   | Notes |
+| ------ | -------------------------------------- | ----- |
+| rlftqc | github.com/remmyzen/rlftqc             | RL-based FT logical state prep; Stim-native; circuits already in `data-imports/rlftqc/` |
+| qLDPC  | github.com/qLDPCOrg/qLDPC              | Encoding/SE/memory circuits from code objects; Stim-native |
+| QUITS  | github.com/mkangquantum/quits          | SE circuits for HGP/QLP/BPC qLDPC families; Stim-based |
+| Rustiq | github.com/smartiel/rustiq             | Clifford/stabilizer synthesis engine (Rust, Qiskit plugin) |
+| autqec | github.com/hsayginel/autqec            | Logical Cliffords from code automorphisms |
+| Stac   | github.com/abdullahkhalids/stac        | Pedagogical stabilizer-code circuits |
+
+Each entry gets: `name`, `description` (what it produces), `homepage_url` where one
+exists, `github_url`, `paper_urls`, and tags following existing conventions
+(language tags such as `Python`/`Rust`, task tags such as `state-preparation`,
+`syndrome-extraction`, `encoding`).
+
+### Updated existing YAMLs (4)
+
+- **Circuit-Synth** — currently has no URLs at all; research and add
+  `github_url`/`homepage_url`/`paper_urls`.
+- **CliffordOpt**, **Flag at Origin**, **MQT QECC** — add `paper_urls`, recheck
+  descriptions, URLs, and tags.
+
+## 3. UI: two-section /tools page
+
+`src/pages/tools/index.astro` splits the existing single query result (no new query;
+`circuit_count` is already returned by `getAllTools`/`filterTools`):
+
+- **Section 1: "Tools contributed to QECirc"** — tools with `circuit_count > 0`,
+  sorted by circuit count descending (current behaviour).
+- **Section 2: "More circuit-synthesis tools"** — tools with `circuit_count === 0`,
+  sorted alphabetically. Their cards show "no circuits yet" instead of "0 circuits".
+- Tag filters apply across both sections. A section with no tools hides its heading.
+- CTA under section 2: *"Built a tool that generates QEC circuits? We'd love to include
+  your circuits — see how to contribute."* linking to `/contribute`.
+
+`src/components/ToolCard.astro`:
+
+- Render paper links alongside Homepage/GitHub: one paper → "Paper ↗"; several →
+  "Paper 1 ↗ Paper 2 ↗ …".
+- Circuit-count label: `circuit_count === 0` → "no circuits yet".
+
+## 4. Verification
+
+- `npm run validate:yaml`
+- `npm run db:create` (rebuild from YAML)
+- `npm run lint`, `npm run format:check`
+- Visual check of `/tools` in the dev server: both sections render, paper links work,
+  tag filtering works across sections, CTA links to `/contribute`.
+
+## Out of scope
+
+- Per-tool detail pages.
+- A `license` field.
+- Papers, datasets, benchmarks, or simulator frameworks as tool entries.
+- Changes to circuit↔tool linking or ingestion scripts.
+- Ingesting the `data-imports/rlftqc/` circuits (separate task; once ingested, rlftqc
+  moves to section 1 automatically).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qecirc-website",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qecirc-website",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@astrojs/node": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qecirc-website",
   "type": "module",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "license": "MIT",
   "scripts": {
     "dev": "astro dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qecirc-website"
-version = "0.3.2"
+version = "0.4.0"
 description = "QECirc — quantum error correction circuit library"
 license = "MIT"
 requires-python = ">=3.13"

--- a/scripts/db/create_database.mjs
+++ b/scripts/db/create_database.mjs
@@ -32,8 +32,8 @@ db.pragma("foreign_keys = ON");
 // Prepared statements
 const stmts = {
   insertTool: db.prepare(`
-    INSERT INTO tools (name, slug, description, homepage_url, github_url)
-    VALUES (?, ?, ?, ?, ?)`),
+    INSERT INTO tools (name, slug, description, homepage_url, github_url, paper_urls)
+    VALUES (?, ?, ?, ?, ?, ?)`),
   insertCode: db.prepare(`
     INSERT INTO codes (name, slug, n, k, d, zoo_url, h, logical, canonical_hash)
     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`),
@@ -102,6 +102,9 @@ try {
         data.description || "",
         data.homepage_url || null,
         data.github_url || null,
+        Array.isArray(data.paper_urls) && data.paper_urls.length > 0
+          ? JSON.stringify(data.paper_urls)
+          : null,
       );
       toolSlugToId.set(slug, Number(lastInsertRowid));
 

--- a/scripts/validate-yaml.mjs
+++ b/scripts/validate-yaml.mjs
@@ -44,6 +44,7 @@ const SCHEMAS = {
       description: "string",
       homepage_url: "string",
       github_url: "string",
+      paper_urls: "urls",
       tags: "tags",
     },
   },
@@ -55,6 +56,10 @@ function checkType(value, type) {
   if (type === "string") return typeof value === "string";
   if (type === "number") return typeof value === "number" && Number.isFinite(value);
   if (type === "tags") return Array.isArray(value) && value.every((v) => typeof v === "string");
+  if (type === "urls")
+    return (
+      Array.isArray(value) && value.every((v) => typeof v === "string" && /^https?:\/\//.test(v))
+    );
   if (type === "matrix")
     return (
       Array.isArray(value) &&

--- a/src/components/CircuitRow.astro
+++ b/src/components/CircuitRow.astro
@@ -145,13 +145,9 @@ const stimFilename = buildStimFilename({
         {tool && (
           <div>
             <span class="text-gray-500 dark:text-gray-400">Tool:</span>{" "}
-            {tool.homepage_url ? (
-              <a href={tool.homepage_url} class="underline hover:text-gray-900 dark:hover:text-gray-100" target="_blank" rel="noopener">
-                {tool.name} &#x2197;
-              </a>
-            ) : (
-              <span>{tool.name}</span>
-            )}
+            <a href={`/tools#${tool.slug}`} class="underline hover:text-gray-900 dark:hover:text-gray-100">
+              {tool.name}
+            </a>
           </div>
         )}
         {(circuit.crumble_url || circuit.quirk_url) && (

--- a/src/components/ToolCard.astro
+++ b/src/components/ToolCard.astro
@@ -14,7 +14,9 @@ const { tool, baseUrl } = Astro.props;
   <div class="flex flex-wrap items-baseline gap-x-2 gap-y-1 mb-1">
     <h3 class="font-medium">{tool.name}</h3>
     <span class="text-xs text-gray-400 dark:text-gray-500">
-      {tool.circuit_count} circuit{tool.circuit_count !== 1 ? "s" : ""}
+      {tool.circuit_count === 0
+        ? "no circuits yet"
+        : `${tool.circuit_count} circuit${tool.circuit_count !== 1 ? "s" : ""}`}
     </span>
     <div class="ml-auto">
       <TagList tags={tool.tags} baseUrl={baseUrl} basePath="/tools" />
@@ -36,5 +38,10 @@ const { tool, baseUrl } = Astro.props;
         GitHub &#x2197;
       </a>
     )}
+    {(tool.paper_urls ?? []).map((url, i) => (
+      <a href={url} class="underline text-gray-500 hover:text-gray-900 dark:hover:text-gray-100" target="_blank" rel="noopener">
+        {(tool.paper_urls ?? []).length > 1 ? `Paper ${i + 1}` : "Paper"} &#x2197;
+      </a>
+    ))}
   </div>
 </div>

--- a/src/components/ToolCard.astro
+++ b/src/components/ToolCard.astro
@@ -10,7 +10,7 @@ interface Props {
 const { tool, baseUrl } = Astro.props;
 ---
 
-<div class="rounded border border-gray-200 dark:border-gray-800 p-4">
+<div id={tool.slug} class="scroll-mt-4 rounded border border-gray-200 dark:border-gray-800 p-4">
   <div class="flex flex-wrap items-baseline gap-x-2 gap-y-1 mb-1">
     <h3 class="font-medium">{tool.name}</h3>
     <span class="text-xs text-gray-400 dark:text-gray-500">

--- a/src/lib/queries/tools.ts
+++ b/src/lib/queries/tools.ts
@@ -2,8 +2,14 @@ import { getDb } from "../db";
 import type { Tool, ToolFilters, ToolWithMeta } from "../../types";
 import { withTags, withCircuitCounts, addTagConditions } from "./shared";
 
-function enrichTools(tools: Tool[]): ToolWithMeta[] {
-  return withCircuitCounts(withTags(tools, "tool"), "tool_id");
+type ToolRow = Omit<Tool, "paper_urls"> & { paper_urls: string | null };
+
+function parseToolRow(row: ToolRow): Tool {
+  return { ...row, paper_urls: row.paper_urls ? (JSON.parse(row.paper_urls) as string[]) : null };
+}
+
+function enrichTools(rows: ToolRow[]): ToolWithMeta[] {
+  return withCircuitCounts(withTags(rows.map(parseToolRow), "tool"), "tool_id");
 }
 
 export function getAllTools(): ToolWithMeta[] {
@@ -15,13 +21,14 @@ export function getAllTools(): ToolWithMeta[] {
        GROUP BY t.id
        ORDER BY COUNT(c.id) DESC, t.name`,
     )
-    .all() as Tool[];
+    .all() as ToolRow[];
   return enrichTools(tools);
 }
 
 export function getToolById(id: number): Tool | undefined {
   const db = getDb();
-  return db.prepare("SELECT * FROM tools WHERE id = ?").get(id) as Tool | undefined;
+  const row = db.prepare("SELECT * FROM tools WHERE id = ?").get(id) as ToolRow | undefined;
+  return row ? parseToolRow(row) : undefined;
 }
 
 export function filterTools(filters: ToolFilters): ToolWithMeta[] {
@@ -40,7 +47,7 @@ export function filterTools(filters: ToolFilters): ToolWithMeta[] {
        GROUP BY c.id
        ORDER BY COUNT(ci.id) DESC, c.name`,
     )
-    .all(...params) as Tool[];
+    .all(...params) as ToolRow[];
   return enrichTools(tools);
 }
 
@@ -56,7 +63,7 @@ export function getToolsForCircuits(circuitIds: number[]): Map<number, Tool> {
        JOIN tools t ON t.id = c.tool_id
        WHERE c.id IN (${placeholders}) AND c.tool_id IS NOT NULL`,
     )
-    .all(...circuitIds) as (Tool & { circuit_id: number })[];
+    .all(...circuitIds) as (ToolRow & { circuit_id: number })[];
 
   for (const row of rows) {
     result.set(row.circuit_id, {
@@ -66,6 +73,7 @@ export function getToolsForCircuits(circuitIds: number[]): Map<number, Tool> {
       description: row.description,
       homepage_url: row.homepage_url,
       github_url: row.github_url,
+      paper_urls: row.paper_urls ? (JSON.parse(row.paper_urls) as string[]) : null,
     });
   }
   return result;

--- a/src/pages/circuits/[qec_id].astro
+++ b/src/pages/circuits/[qec_id].astro
@@ -103,13 +103,9 @@ const originalsUrl = `/api/circuits/${qecId}/originals`;
     {tool && (
       <div>
         <span class="text-gray-500 dark:text-gray-400">Tool:</span>{" "}
-        {tool.homepage_url ? (
-          <a href={tool.homepage_url} class="underline hover:text-gray-900 dark:hover:text-gray-100" target="_blank" rel="noopener">
-            {tool.name} &#x2197;
-          </a>
-        ) : (
-          <span>{tool.name}</span>
-        )}
+        <a href={`/tools#${tool.slug}`} class="underline hover:text-gray-900 dark:hover:text-gray-100">
+          {tool.name}
+        </a>
       </div>
     )}
     {(circuit.crumble_url || circuit.quirk_url) && (

--- a/src/pages/tools/index.astro
+++ b/src/pages/tools/index.astro
@@ -21,6 +21,11 @@ const filters: ToolFilters = {
 const hasFilters = hasActiveFilters(filters);
 const tools = hasFilters ? filterTools(filters) : getAllTools();
 const allTags = getTagsWithCount("tool");
+
+const contributed = tools.filter((t) => t.circuit_count > 0);
+const others = tools
+  .filter((t) => t.circuit_count === 0)
+  .sort((a, b) => a.name.localeCompare(b.name));
 ---
 
 <Layout title="Tools" description="Software tools used to create QEC circuits">
@@ -38,10 +43,32 @@ const allTags = getTagsWithCount("tool");
       <a href="/tools" class="text-sm underline text-gray-500 hover:text-gray-900 dark:hover:text-gray-100">Clear filters</a>
     </div>
   ) : (
-    <div class="grid gap-3">
-      {tools.map((tool) => (
-        <ToolCard tool={tool} baseUrl={Astro.url} />
-      ))}
-    </div>
+    <>
+      {contributed.length > 0 && (
+        <section class="mb-8">
+          <h2 class="text-lg font-semibold mb-3">Tools contributed to QECirc</h2>
+          <div class="grid gap-3">
+            {contributed.map((tool) => (
+              <ToolCard tool={tool} baseUrl={Astro.url} />
+            ))}
+          </div>
+        </section>
+      )}
+      {others.length > 0 && (
+        <section>
+          <h2 class="text-lg font-semibold mb-3">More circuit-synthesis tools</h2>
+          <div class="grid gap-3">
+            {others.map((tool) => (
+              <ToolCard tool={tool} baseUrl={Astro.url} />
+            ))}
+          </div>
+        </section>
+      )}
+    </>
   )}
+
+  <p class="mt-8 text-sm text-gray-500 dark:text-gray-400">
+    Built a tool that generates QEC circuits? We'd love to include your circuits —
+    <a href="/contribute" class="underline hover:text-gray-900 dark:hover:text-gray-100">see how to contribute</a>.
+  </p>
 </Layout>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -46,6 +46,7 @@ export interface Tool {
   description: string | null;
   homepage_url: string | null;
   github_url: string | null;
+  paper_urls: string[] | null;
 }
 
 export interface ToolFilters {

--- a/uv.lock
+++ b/uv.lock
@@ -829,7 +829,7 @@ wheels = [
 
 [[package]]
 name = "qecirc-website"
-version = "0.3.2"
+version = "0.4.0"
 source = { virtual = "." }
 dependencies = [
     { name = "mqt-qecc" },


### PR DESCRIPTION
## Summary

- Add an optional `paper_urls` field to tool YAMLs (validated list of URLs, migration 013, JSON-encoded in SQLite, rendered as "Paper ↗" links on tool cards)
- Split `/tools` into two sections: **Tools contributed to QECirc** (sorted by circuit count) and **More circuit-synthesis tools** (alphabetical, "no circuits yet"), with a contribute CTA at the bottom
- Add six new tool entries with facts verified against live repos/arXiv: **rlftqc, qLDPC, QUITS, Rustiq, autqec, Stac**
- Recheck existing entries: correct the **Flag at Origin** description (FT state preparation, not syndrome extraction) and add verified paper links to CliffordOpt, Flag at Origin, and MQT QECC
- Link the 238 already-ingested RLFTQC circuits (arXiv:2402.17761) to the new rlftqc tool entry
- Bump version to 0.4.0 (YAML schema change per versioning convention)

No new dependencies.

## Test Plan

- [x] `npm run validate:yaml`, `npm run db:create`, `npm run lint`, `npm run format:check`, `npm run build` all pass
- [x] `uv run pytest` — 160 passed
- [x] Manual check of `/tools`: both sections render, paper links resolve, tag filtering works across sections, empty state intact, CTA links to `/contribute`

🤖 Generated with [Claude Code](https://claude.com/claude-code)