### PR TITLE
feat(browse): derive tool tags + add Tools filter category

### DIFF
--- a/docs/adding-circuits.md
+++ b/docs/adding-circuits.md
@@ -209,6 +209,14 @@ Add a `tags:` list. Common circuit tags:
 | Fault tolerance | `ft`, `non-ft`, `flag`, `deterministic`                                                        |
 | Hardware        | `connectivity:2d-grid`, `device:tokyo`, `1D-AOD` (full connectivity is the default — untagged) |
 | Method          | `prep:opt`, `prep:heuristic`, `verification:opt`                                               |
+| Tools           | `tool:mqt-qecc` — **derived automatically, do not add** (see below)                            |
+
+> **Tool tags are derived, not stored.** Every circuit with a `tool:` field is
+> tagged `tool:<slug>` automatically when the database is built (see
+> `scripts/db/create_database.mjs`), which powers the **Tools** filter category
+> (e.g. all MQT QECC circuits at once). The `tool` field is the single source of
+> truth, so never add a `tool:*` tag to a YAML `tags:` list — set `tool:` and the
+> tag follows for every current and future circuit.
 
 Check existing tags with:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qecirc-website",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qecirc-website",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "MIT",
       "dependencies": {
         "@astrojs/node": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qecirc-website",
   "type": "module",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "license": "MIT",
   "scripts": {
     "dev": "astro dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qecirc-website"
-version = "0.4.2"
+version = "0.4.3"
 description = "QECirc — quantum error correction circuit library"
 license = "MIT"
 requires-python = ">=3.13"

--- a/scripts/db/create_database.mjs
+++ b/scripts/db/create_database.mjs
@@ -268,6 +268,14 @@ try {
       for (const tag of data.tags || []) {
         addTag(tag, circuitId, "circuit");
       }
+      // Derived tag: every circuit with a tool is tagged `tool:<slug>` so it is
+      // filterable in the Tools category (e.g. all MQT QECC circuits at once).
+      // The `tool` field is the single source of truth — the tag is derived here
+      // rather than stored in YAML, so it stays in sync with tool_id by
+      // construction and applies to every current and future circuit.
+      if (data.tool) {
+        addTag(`tool:${data.tool}`, circuitId, "circuit");
+      }
 
       const bodyFormats = Object.keys(bodies).join(", ") || "none";
       const hasOriginals = fs.existsSync(origStimPath) && fs.existsSync(origYamlPath);

--- a/src/lib/tag-categories.ts
+++ b/src/lib/tag-categories.ts
@@ -4,13 +4,14 @@
  * free for new values; only genuinely new free-form tags may need a new entry.
  */
 
-export type TagCategoryKey = "type" | "ft" | "hardware" | "method" | "other";
+export type TagCategoryKey = "type" | "ft" | "hardware" | "method" | "tools" | "other";
 
 export const TAG_CATEGORIES: readonly { key: TagCategoryKey; label: string }[] = [
   { key: "type", label: "Type" },
   { key: "ft", label: "Fault tolerance" },
   { key: "hardware", label: "Hardware" },
   { key: "method", label: "Method" },
+  { key: "tools", label: "Tools" },
   { key: "other", label: "Other" },
 ];
 
@@ -24,6 +25,8 @@ export function categorizeTag(name: string): TagCategoryKey {
   if (HARDWARE_TAGS.has(name) || name.startsWith("connectivity:") || name.startsWith("device:"))
     return "hardware";
   if (name.startsWith("prep:") || name.startsWith("verification:")) return "method";
+  // `tool:<slug>` tags are derived from each circuit's tool at DB-build time.
+  if (name.startsWith("tool:")) return "tools";
   return "other";
 }
 

--- a/uv.lock
+++ b/uv.lock
@@ -829,7 +829,7 @@ wheels = [
 
 [[package]]
 name = "qecirc-website"
-version = "0.4.2"
+version = "0.4.3"
 source = { virtual = "." }
 dependencies = [
     { name = "mqt-qecc" },


### PR DESCRIPTION
Adds a per-circuit **tool tag** and a **Tools** filter category, so you can pull up e.g. all MQT QECC circuits at once.

## What & how

- **`tool:<slug>` tag derived at DB-build time** from each circuit's existing `tool` field (`scripts/db/create_database.mjs`). The `tool` field (which already backs the `tool_id` column) is the single source of truth, so the tag stays in sync **by construction** and applies to **every current and future circuit** — no per-circuit tagging, nothing the add-circuit pipeline has to remember to do.
- **New "Tools" tag category** (`src/lib/tag-categories.ts`, `tool:` prefix) — appears as a dropdown in the circuit filter, right before "Other". Fully data-driven, so no component changes were needed.
- **Docs**: `docs/adding-circuits.md` notes tool tags are derived, not stored in YAML (don't add them by hand).

### Why derive instead of writing into the 424 YAMLs
The tag is a pure projection of the `tool` field — materializing it would duplicate data that can drift (change `tool` but forget the tag). Deriving keeps them consistent, needs zero data churn, and can't be forgotten for future circuits. (This is unlike `logical-state:`/`connectivity:` tags, which are materialized because they have no other representation.)

## Verification

- All **424** circuits tagged: `tool:circuit-synth` ×110, `tool:mqt-qecc` ×107, `tool:rlftqc` ×207 (matches the YAML `tool:` counts exactly).
- Server-side filter composes with other tags: on Steane, `tool:mqt-qecc` → 12, `tool:rlftqc` → 51, `tool:circuit-synth` → 7 (= 70 total); `tool:mqt-qecc` + `ft` → 7.
- Renders and deep-links on circuit rows and the circuit detail page (`/codes/steane-code?tag=tool:mqt-qecc`).
- `validate:yaml` ✓ · `validate:circuits` 362/362 ✓ · `pytest` 167 ✓ · `eslint` + `prettier` clean.
- Version bumped 0.4.2 → 0.4.3 (package.json, pyproject.toml, uv.lock, package-lock.json).

🤖 Generated with [Claude Code](https://claude.com/claude-code)