### PR TITLE
docs: add Contributors section to README and About page

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ QECirc was created and is maintained by Ludwig Schmid and Tom Peham.
 
 The project is funded by the [Unitary Foundation](https://unitary.foundation) and supported by the [Chair for Design Automation](https://www.cda.cit.tum.de/) at the Technical University of Munich.
 
+## Contributors
+
+<!-- Maintained by hand — keep in sync with the repository's human contributors,
+     excluding bots (Claude, Renovate) and the `qecirc` service account. Mirror
+     any change here in src/pages/about.astro. -->
+
+[Ludwig Schmid](https://github.com/lsschmid), [Tom Peham](https://github.com/pehamTom), [Remmy Zen](https://github.com/remmyzen)
+
 ## Quick Start
 
 ```bash

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -68,6 +68,14 @@ const kbdCls =
       />
     </a>
 
+    {/* Maintained by hand — keep in sync with the repository's human
+        contributors, excluding bots (Claude, Renovate) and the `qecirc` service
+        account. Mirror any change here in README.md. */}
+    <h2 class="text-xl font-semibold mb-3">Contributors</h2>
+    <p class="text-gray-600 dark:text-gray-400 mb-6">
+      <a href="https://github.com/lsschmid" class="prose-link" target="_blank" rel="noopener">Ludwig Schmid</a>, <a href="https://github.com/pehamTom" class="prose-link" target="_blank" rel="noopener">Tom Peham</a>, <a href="https://github.com/remmyzen" class="prose-link" target="_blank" rel="noopener">Remmy Zen</a>
+    </p>
+
     <h2 class="text-xl font-semibold mb-3">License</h2>
     <p class="text-gray-600 dark:text-gray-400 mb-2">
       The source code is licensed under the


### PR DESCRIPTION
Adds a hand-maintained **Contributors** list to both the README and the `/about` page.

- Single comma-separated line (no bullets): [Ludwig Schmid](https://github.com/lsschmid), [Tom Peham](https://github.com/pehamTom), [Remmy Zen](https://github.com/remmyzen) — each linked to their GitHub profile.
- Human contributors only; a maintainer comment in each file notes to keep the two in sync and to exclude the Claude/Renovate bots and the `qecirc` service account.

**Co-authorship:** this commit adds `Co-authored-by: remmyzen` to credit Remmy Zen for the RLFTQC state-preparation circuits he authored, which were imported in `39d81d0` (#81) — that squash-merged commit didn't carry his co-authorship.

> When merging, please keep the `Co-authored-by:` trailer in the squash commit message so the attribution sticks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)