### PR TITLE
docs: expand circuit-ingestion guide and link it from README/site

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,5 @@
 blank_issues_enabled: false
+contact_links:
+  - name: Adding circuits yourself (docs)
+    url: https://github.com/qecirc/qecirc-website/blob/main/docs/adding-circuits.md
+    about: Prefer to prepare circuits yourself or import a whole dataset? See the ingestion guide (helper functions, APIs, bulk imports, FAQ).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+<!--
+Thanks for contributing! Keep this short — a couple of sentences is fine.
+See CONTRIBUTING.md for setup and conventions.
+-->
+
+## What & why
+
+<!-- What does this change, and why? Link any related issue (e.g. "Closes #123"). -->
+
+## Checklist
+
+- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, …)
+- [ ] `npm run format` and `npm run lint` pass
+- [ ] `npm run validate:yaml && npm run validate:circuits` pass _(if `data_yaml/` changed)_
+- [ ] Version bumped when needed — see [CLAUDE.md](../CLAUDE.md#versioning)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,75 @@
+# Contributing to QECirc
+
+Thanks for helping grow the library! There are a few ways to contribute, from
+"here's a circuit" to a full pull request. Pick the one that fits.
+
+## Contribute a circuit
+
+**The easiest way — no setup needed.** Open a
+[Circuit Submission issue](https://github.com/qecirc/qecirc-website/issues/new/choose)
+and paste your STIM circuit, its distance, and a source. Check matrices are
+optional for encoding circuits (we can derive them). A maintainer takes it from
+there.
+
+Have circuits but no time to file them one by one? Email
+[contribute@qecirc.com](mailto:contribute@qecirc.com) and we're happy to do the
+ingestion for you.
+
+## Report bad data, bugs, or ideas
+
+Use the matching [issue template](https://github.com/qecirc/qecirc-website/issues/new/choose):
+
+- **Data Correction** — something wrong in an existing circuit or code.
+- **Bug Report** — the site misbehaves.
+- **Feature Request** — an idea for the library.
+
+## Add circuits yourself
+
+Want to run the ingestion pipeline directly, or import a whole dataset? The
+scripts and their helpers are documented in:
+
+- **[docs/adding-circuits.md](docs/adding-circuits.md)** — the manual workflow:
+  helper functions, the `add_circuit` / `import_state_prep` APIs, fitting to
+  existing codes, bulk/dataset imports, and an FAQ.
+- **[docs/adding-circuits-agent.md](docs/adding-circuits-agent.md)** — the
+  `/add-circuit` agent-assisted workflow.
+
+## Code contributions
+
+### Setup
+
+```bash
+npm install      # Node dependencies
+uv sync          # Python dependencies
+npm run db:create
+npm run dev      # http://localhost:4321
+```
+
+`data_yaml/` is the source of truth; the SQLite database is built from it. After
+editing any YAML, run `npm run db:create` and **restart the dev server** (it
+caches the DB connection).
+
+### Before you open a PR
+
+```bash
+npm run format          # Prettier (CI fails on unformatted files)
+npm run lint            # ESLint
+npm run validate:yaml   # only if you touched data_yaml/
+npm run validate:circuits
+```
+
+### Conventions
+
+- **Pull requests only** — no direct commits to `main`.
+- **[Conventional Commits](https://www.conventionalcommits.org/)** —
+  `feat(browse): …`, `fix(parser): …`, `docs: …`, etc.
+- **Bump the version** in the same PR that ships the change — see the
+  [versioning table in CLAUDE.md](CLAUDE.md#versioning).
+- Prefer built-ins and the standard library; justify any new dependency in the
+  PR description.
+
+## Licensing
+
+By contributing you agree that your contributions are licensed under the
+project's dual license: code under [MIT](LICENSE) and data (`data_yaml/`) under
+[CC BY-SA 4.0](LICENSE-DATA).

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ npm run dev
 
 ## Contributing
 
+See [CONTRIBUTING.md](CONTRIBUTING.md) for all the ways to help.
+
 Most circuits are submitted by opening a [GitHub Issue](https://github.com/qecirc/qecirc-website/issues/new/choose) using the provided templates — a maintainer then ingests them.
 
 To add circuits yourself, or import a whole dataset, see the ingestion guides:

--- a/README.md
+++ b/README.md
@@ -47,7 +47,12 @@ npm run dev
 
 ## Contributing
 
-Circuits are submitted by opening a [GitHub Issue](https://github.com/qecirc/qecirc-website/issues/new/choose) using the provided templates.
+Most circuits are submitted by opening a [GitHub Issue](https://github.com/qecirc/qecirc-website/issues/new/choose) using the provided templates — a maintainer then ingests them.
+
+To add circuits yourself, or import a whole dataset, see the ingestion guides:
+
+- [docs/adding-circuits.md](docs/adding-circuits.md) — manual workflow: the helper functions, the `add_circuit` / `import_state_prep` APIs, fitting to existing codes, bulk imports, and an FAQ.
+- [docs/adding-circuits-agent.md](docs/adding-circuits-agent.md) — the `/add-circuit` agent-assisted workflow.
 
 ## License
 

--- a/docs/adding-circuits-agent.md
+++ b/docs/adding-circuits-agent.md
@@ -73,9 +73,9 @@ The pipeline also preserves the original (pre-canonicalization) STIM circuit and
 
 The agent only uses tags that already exist in the library. Current tags:
 
-| Level   | Tags                                                                           |
-| ------- | ------------------------------------------------------------------------------ |
-| Code    | `CSS`, `stabilizer`, `self-dual`, `color-code`, `concatenated`                 |
-| Circuit | `encoding`, `state-preparation`, `syndrome-extraction`, `ft`, `non-ft`, `flag` |
+| Level   | Tags                                                                                                                                                                                              |
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Code    | `CSS`, `stabilizer`, `self-dual`, `color-code`, `surface-code`, `concatenated`                                                                                                                    |
+| Circuit | `encoding`, `state-preparation`, `syndrome-extraction`, `ft`, `non-ft`, `flag`, `deterministic`, plus structured tags `logical-state:*`, `connectivity:*`, `device:*`, `prep:*`, `verification:*` |
 
-If the Zoo or user suggests a tag not in this list, the agent will ask before adding it.
+`tool:*` tags are **not** set by hand — they are derived from a circuit's `tool` field when the database is built. If the Zoo or user suggests any other tag not already in the library, the agent will ask before adding it.

--- a/docs/adding-circuits.md
+++ b/docs/adding-circuits.md
@@ -12,12 +12,25 @@ uv sync                # install Python dependencies
 
 ## What You Need
 
-- **Stabilizer matrices** — provide either:
+- **Stabilizer matrices** — provide either, _or_ derive them from the circuit (see [Which workflow?](#which-workflow)):
   - **`Hx, Hz`** — separate X-check and Z-check matrices. The pipeline rejects these unless they describe a CSS code (`Hx · Hzᵀ = 0 mod 2`); CSS detection is automatic and adds the `CSS` tag.
   - **`H, n`** — a single symplectic stabilizer matrix of shape `(n−k) × 2n` (X-half on the left, Z-half on the right) plus the qubit count `n`. CSS-decomposable `H` is auto-detected and routed through the CSS path so the `Hx`/`Hz` view and `CSS` tag are filled in automatically.
 - **STIM circuit** — file path or string
 - **Code distance `d`** — integer
 - **Source** — DOI, URL, or citation
+
+## Which workflow?
+
+Pick the path that matches what you have — they all end at the same YAML files and the same `npm run db:create`.
+
+| You have…                                                   | Use                   | Section                                                           |
+| ----------------------------------------------------------- | --------------------- | ----------------------------------------------------------------- |
+| An **encoding** circuit + check matrices (`Hx/Hz` or `H`)   | `add_circuit()`       | [Steps 1–4](#step-1-inspect)                                      |
+| A **state-preparation** circuit (matrices optional)         | `import_state_prep()` | [State-preparation circuits](#adding-a-state-preparation-circuit) |
+| A circuit whose qubit labeling differs from the stored code | either, with a _fit_  | [Fitting to an existing code](#fitting-to-an-existing-code)       |
+| **Many** circuits from one source/paper                     | a dataset importer    | [Bulk / dataset imports](#bulk--dataset-imports)                  |
+
+Only have a circuit? That's fine: [`extract_code`](#extract-code-from-circuit-optional) recovers `Hx/Hz` from an encoding circuit, and the [state-prep helpers](#get-the-check-matrices-from-the-circuit) derive them from a prep circuit. New here? See the [FAQ](#faq).
 
 ## Overview
 
@@ -242,6 +255,83 @@ npm run db:create && npm run dev  # Rebuild database and restart
 
 ---
 
+## Adding a state-preparation circuit
+
+State-preparation circuits — the bulk of the library (e.g. the MQT QECC and RLFTQC imports) — prepare a logical basis state such as `|0⟩_L` or `|+⟩_L`. You usually **don't** have check matrices for them, and the circuit often includes flag/routing ancillas. `import_state_prep()` handles all of it: it derives (or is handed) the code, fits the circuit to it, validates codespace membership, and writes the same YAML as `add_circuit()`.
+
+### Get the check matrices from the circuit
+
+If you don't have `Hx/Hz`, derive them from the prep circuit itself:
+
+```python
+from scripts.add_circuit import (
+    derive_matrices_self_dual, derive_matrices_two_circuit,
+    strip_flags, symplectic_validate, logical_state_of,
+)
+
+# Self-dual CSS code (Hz == Hx) from a single |0⟩_L circuit:
+Hx, Hz = derive_matrices_self_dual(zero_circuit, n)
+
+# Or two circuits sharing a qubit labeling — Hx from |0⟩_L, Hz from |+⟩_L:
+Hx, Hz = derive_matrices_two_circuit(zero_circuit, plus_circuit, n)
+```
+
+`n` is the number of **data** qubits; flag/ancilla qubits live at indices `≥ n` and are handled automatically (`strip_flags(circuit, n)` exposes the data-only sub-circuit if you need it). `logical_state_of(circuit, n, d, Hx=Hx, Hz=Hz)` reports which basis state the circuit prepares (`'zero'` / `'one'` / `'plus'` / `'minus'`), and `symplectic_validate(circuit, H, n)` checks the prepared state is a `+1` eigenstate of every stabilizer (the non-CSS counterpart of `validate_state_prep`).
+
+### Import
+
+```python
+from scripts.add_circuit import import_state_prep
+
+result = import_state_prep(
+    circuit=zero_circuit, n=7, d=3,
+    method="self_dual",                  # or "two_circuit" / "anchor"
+    code_name="Steane Code",
+    circuit_name="FT |0⟩ prep (flag)",
+    source="https://arxiv.org/abs/...", tool="mqt-qecc",
+    tags=["state-preparation", "ft", "flag"],
+    logical_state="zero",                # provenance → note + logical-state:zero tag
+)
+print(result.summary())
+```
+
+`method` picks how the code is obtained _in the circuit's own labeling_:
+
+| `method`        | When                                                                                          |
+| --------------- | --------------------------------------------------------------------------------------------- |
+| `"self_dual"`   | Self-dual CSS code, from a single `\|0⟩_L` circuit                                            |
+| `"two_circuit"` | CSS code, `Hx` from `\|0⟩_L` and `Hz` from `\|+⟩_L` (pass `plus_circuit=`)                    |
+| `"anchor"`      | Non-CSS / non-self-dual, or a non-`\|0⟩` state — fit against a trusted symplectic `anchor_H=` |
+
+The full circuit (flags included) is what gets stored; the pipeline dedups it to the canonical code, applies any qubit permutation, and preserves the original in `originals/`. Provenance you pass (`source_file`, `logical_state`, `connectivity`, `gate_set`, `device`, `qubit_placement`) is folded into the circuit notes, and the categorical ones also become `key:value` tags — nothing is dropped.
+
+## Fitting to an existing code
+
+Published circuits rarely use the same qubit labeling as the stored code, so the circuit must be **fitted** by a qubit permutation (convention `σ[new] = old`). Both `add_circuit()` and `import_state_prep()` resolve this for you, trying in order:
+
+1. **Identity** — small codes (e.g. `[[5,1,3]]`, `[[7,1,3]]`) often match as-is.
+2. **Automatic dedup** — `find_existing_code_full()` / the canonical-hash search resolves the permutation for most codes (`n ≤ 9` is brute-forced).
+3. **Structural finder** — `find_code_permutation()` recovers `σ` from the two codes' check matrices when the hash search can't (automorphism-rich codes, or `n` too large to brute-force).
+4. **Explicit** — pass `qubit_permutation=σ` (`add_circuit`) or `permutation=σ` (`import_state_prep`). It is verified by row-space equality against the stored code — no search — so it works even where the canonical hash isn't a true permutation invariant.
+
+If a submission's invariants match a stored code but no permutation can be confirmed within the search budget, `add_circuit` raises `UncertainDedupError`. Either supply `σ`, or pass `assume_new=True` to add it as a genuinely new code.
+
+## Bulk / dataset imports
+
+Importing a whole dataset (a paper's circuits, a tool's output) is a repeatable job, so it lives in its own script rather than the general pipeline. The split:
+
+- **Reusable logic** — deriving/validating/fitting a code, capturing provenance — lives in `scripts/add_circuit/` and is imported.
+- **Dataset-specific knowledge** — folder layout, which stored code each folder maps to, hardware metadata — lives in `data-imports/<dataset>/rebuild_all.py` with a README recording the decisions.
+
+Two worked examples to copy from:
+
+- [`data-imports/mqt-ftsp/`](../data-imports/mqt-ftsp/README.md) — MQT QECC fault-tolerant state-prep circuits.
+- [`data-imports/rlftqc/`](../data-imports/rlftqc/README.md) — RL-discovered fault-tolerant state-prep circuits.
+
+Each `rebuild_all.py` classifies without writing by default and imports with `--write`, then you run the standard `npm run format && npm run validate:yaml && npm run validate:circuits && npm run db:create`.
+
+---
+
 ## What the pipeline computes
 
 - Code parameters [[n,k,d]], CSS detection, self-dual detection
@@ -340,3 +430,29 @@ Tools must be added manually before circuits can reference them.
 - To edit existing data, modify the YAML files directly and run `npm run db:create`.
 - **Existing codes: omit `code_name`.** On a dedup match the circuit files under the code's _stored_ slug (e.g. `23-1-7`); any `code_name` you pass is ignored for the slug. Passing a name that _doesn't_ resolve to the stored slug would otherwise orphan the circuit.
 - **Overwrites are refused by default.** If a circuit with the same `<code>--<circuit>` slug already exists, `add_circuit` raises `FileExistsError`. Pass `overwrite=True` to replace it in place (the existing `qec_id` is preserved), or choose a distinct `circuit_name`.
+
+## FAQ
+
+**I only have a circuit, no check matrices. Can I still add it?**
+Yes. For an encoding circuit use [`extract_code`](#extract-code-from-circuit-optional); for a state-prep circuit use the [derive-matrices helpers](#get-the-check-matrices-from-the-circuit). Both recover the code from the circuit.
+
+**Encoding vs state-preparation — which is my circuit?**
+An _encoding_ circuit maps `k` data qubits (plus ancillas) into the codespace; the first `k` qubits carry the logical input. A _state-preparation_ circuit starts from `|0…0⟩` and outputs a fixed logical state (`|0⟩_L`, `|+⟩_L`, …). Most library circuits are state-prep. The choice sets the `encoding` / `state-preparation` tag, which routes `validate:circuits`.
+
+**My circuit uses different qubit indices than the stored code.**
+Expected — see [Fitting to an existing code](#fitting-to-an-existing-code). You rarely need to work out the permutation by hand.
+
+**How do I mark a circuit fault-tolerant?**
+Explicitly, with the `ft` (or `non-ft`) tag — it is **never** inferred. Add `flag` if it uses flag qubits.
+
+**Do I need to add a `tool:` tag?**
+No. Set the circuit's `tool` field; the `tool:<slug>` tag is derived at build time (see [Step 3](#step-3-add-tags)).
+
+**`add_circuit` raised `UncertainDedupError` or `FileExistsError`.**
+`UncertainDedupError` — the code looks like a stored one but the permutation couldn't be confirmed; supply `qubit_permutation=σ` or `assume_new=True`. `FileExistsError` — a circuit with that `<code>--<circuit>` slug exists; pass `overwrite=True` (keeps the `qec_id`) or use a distinct `circuit_name`.
+
+**The website didn't change after I rebuilt.**
+Restart the dev server after `npm run db:create` — Astro caches the DB connection.
+
+**I have many circuits from one paper/tool.**
+See [Bulk / dataset imports](#bulk--dataset-imports).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qecirc-website",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qecirc-website",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "MIT",
       "dependencies": {
         "@astrojs/node": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qecirc-website",
   "type": "module",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "license": "MIT",
   "scripts": {
     "dev": "astro dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qecirc-website"
-version = "0.4.3"
+version = "0.4.4"
 description = "QECirc — quantum error correction circuit library"
 license = "MIT"
 requires-python = ">=3.13"

--- a/src/pages/contribute.astro
+++ b/src/pages/contribute.astro
@@ -16,9 +16,14 @@ import Layout from "../components/Layout.astro";
       <a href="mailto:contribute@qecirc.com" class="prose-link">contribute@qecirc.com</a>.
     </p>
     <p>
-      If you'd like to contribute many circuits at once, the
-      <a href="https://github.com/qecirc/qecirc-website" class="prose-link" target="_blank" rel="noopener">GitHub repository</a>
-      includes Python scripts to help prepare and submit circuits.
+      If you'd like to add circuits yourself — or import a whole dataset at once — the repository includes a
+      documented Python ingestion pipeline. See the
+      <a
+        href="https://github.com/qecirc/qecirc-website/blob/main/docs/adding-circuits.md"
+        class="prose-link"
+        target="_blank"
+        rel="noopener">Adding Circuits guide</a
+      >.
     </p>
     <p>
       Have circuits but no time to submit them yourself? No problem — just send them our way and we're happy to take care of the rest.

--- a/src/pages/contribute.astro
+++ b/src/pages/contribute.astro
@@ -10,14 +10,16 @@ import Layout from "../components/Layout.astro";
       QECirc is a community-driven library. We welcome contributions of new quantum error correction circuits.
     </p>
     <p>
-      To submit a circuit, open a
-      <a href="https://github.com/qecirc/qecirc-website/issues/new/choose" class="prose-link" target="_blank" rel="noopener">GitHub Issue</a>
-      using one of the provided templates. Alternatively, reach out via email at
+      To submit a circuit, open a{" "}
+      <a href="https://github.com/qecirc/qecirc-website/issues/new/choose" class="prose-link" target="_blank" rel="noopener"
+        >GitHub Issue</a
+      >{" "}
+      using one of the provided templates. Alternatively, reach out via email at{" "}
       <a href="mailto:contribute@qecirc.com" class="prose-link">contribute@qecirc.com</a>.
     </p>
     <p>
-      If you'd like to add circuits yourself — or import a whole dataset at once — the repository includes a
-      documented Python ingestion pipeline. See the
+      If you'd like to add circuits yourself — or import a whole dataset at once — the repository includes a documented
+      Python ingestion pipeline. See the{" "}
       <a
         href="https://github.com/qecirc/qecirc-website/blob/main/docs/adding-circuits.md"
         class="prose-link"

--- a/uv.lock
+++ b/uv.lock
@@ -829,7 +829,7 @@ wheels = [
 
 [[package]]
 name = "qecirc-website"
-version = "0.4.3"
+version = "0.4.4"
 source = { virtual = "." }
 dependencies = [
     { name = "mqt-qecc" },


### PR DESCRIPTION
## Why

The manual ingestion guide (`docs/adding-circuits.md`) only documented **one** path — a single *encoding* circuit with `Hx/Hz` in hand. That's the path *neither* real import used: both the MQT QECC and RLFTQC imports were **state-preparation** circuits with **no check matrices**, fitted to existing codes by **qubit permutation**. That entire workflow was undocumented, and the docs had **zero** inbound links (not from the README, the website, or the issue templates).

## What changed

**`docs/adding-circuits.md`**
- **"Which workflow?"** decision table up front — encoding vs state-prep vs fit-to-existing vs bulk.
- **"Adding a state-preparation circuit"** — `derive_matrices_self_dual` / `_two_circuit`, `strip_flags`, `logical_state_of`, `symplectic_validate`, and the `import_state_prep` `method` table.
- **"Fitting to an existing code"** — the identity → auto-dedup → `find_code_permutation` → explicit-`σ` ladder, plus `UncertainDedupError` / `assume_new`.
- **"Bulk / dataset imports"** — the reusable-vs-dataset split and pointers to the two worked `data-imports/` examples.
- **FAQ** section.

**Discoverability**
- `README.md` Contributing section now links both ingestion guides.
- `src/pages/contribute.astro` points the "add circuits yourself" paragraph at the guide (was linking only to the repo root).
- Issue chooser (`config.yml`) gets a `contact_link` to the guide.

**Housekeeping**
- Refresh the agent doc's stale tag-vocabulary table (structured tags; note `tool:` is derived).
- Patch bump `0.4.3` → `0.4.4` (docs/text only) across `package.json`, `pyproject.toml`, `uv.lock`, `package-lock.json`.

## Notes

Docs + one static text/link swap + a template file. `npm run format:check` and `npm run lint` pass. No `data_yaml/` or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)