### PR TITLE
feat(seo): schema.org JSON-LD + llms.txt for AI discoverability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,12 @@ A maintainer reviews the issue, then uses the ingestion pipeline to add the circ
 
 This keeps the site fast and simple while scaling comfortably to thousands of circuits.
 
+**SEO & AI discoverability** (goal: be cited/linked by search and AI answer engines, without inviting training crawlers):
+
+- **Structured data** — schema.org JSON-LD. `Layout.astro` emits a site-wide graph (`Organization` + `WebSite`) on every page and takes a `jsonLd` prop for per-page entities. Circuit pages pass `SoftwareSourceCode` + `BreadcrumbList`; code pages pass `CollectionPage` (+ an `ItemList` of circuits) + `BreadcrumbList`. **When adding a new entity page type, pass matching `jsonLd`.**
+- **Machine-facing routes, all `prerender = false` and generated from the live DB** (no manual upkeep — new codes/circuits appear automatically): `sitemap.xml`, `llms.txt` (see [llmstxt.org](https://llmstxt.org/)), and `robots.txt`.
+- **`robots.txt` policy** — allow search/answer bots (Googlebot, OAI-SearchBot, PerplexityBot, Claude-User/SearchBot, …) but `Disallow: /` the AI-**training** crawlers (GPTBot, ClaudeBot, CCBot, Google-Extended, …). Keep new AI-training user-agents out; leave search/answer agents in.
+
 ---
 
 ## Repository Structure

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qecirc-website",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qecirc-website",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "license": "MIT",
       "dependencies": {
         "@astrojs/node": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qecirc-website",
   "type": "module",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "license": "MIT",
   "scripts": {
     "dev": "astro dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qecirc-website"
-version = "0.4.4"
+version = "0.4.5"
 description = "QECirc — quantum error correction circuit library"
 license = "MIT"
 requires-python = ">=3.13"

--- a/src/components/Layout.astro
+++ b/src/components/Layout.astro
@@ -10,12 +10,44 @@ import pkg from "../../package.json";
 interface Props {
   title: string;
   description?: string;
+  /** Page-specific schema.org JSON-LD, emitted alongside the site-wide graph. */
+  jsonLd?: Record<string, unknown> | Record<string, unknown>[];
 }
 
 const DEFAULT_DESCRIPTION = "QECirc — a community-driven library for quantum error correction circuits";
-const { title, description = DEFAULT_DESCRIPTION } = Astro.props;
+const { title, description = DEFAULT_DESCRIPTION, jsonLd } = Astro.props;
 const canonicalUrl = new URL(Astro.url.pathname, Astro.site ?? Astro.url.origin).href;
 const fullTitle = `${title} - QECirc`;
+
+// Site-wide structured data (schema.org), emitted on every page. Entity-level
+// JSON-LD (a circuit, a code) is passed per page via the `jsonLd` prop and
+// references these @ids.
+const siteUrl = (Astro.site ?? new URL(Astro.url.origin)).href.replace(/\/$/, "");
+const siteGraph = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      "@id": `${siteUrl}/#organization`,
+      name: "QECirc",
+      url: `${siteUrl}/`,
+      description: "A community-driven library for quantum error correction circuits.",
+      sameAs: ["https://github.com/qecirc/qecirc-website"],
+    },
+    {
+      "@type": "WebSite",
+      "@id": `${siteUrl}/#website`,
+      name: "QECirc",
+      url: `${siteUrl}/`,
+      description: DEFAULT_DESCRIPTION,
+      inLanguage: "en",
+      publisher: { "@id": `${siteUrl}/#organization` },
+    },
+  ],
+};
+const extraJsonLd = jsonLd == null ? [] : Array.isArray(jsonLd) ? jsonLd : [jsonLd];
+// Escape "<" so no string value can prematurely terminate the <script> element.
+const serializeLd = (o: unknown) => JSON.stringify(o).replace(/</g, "\\u003c");
 
 const version = pkg.version;
 const totalCircuits = countAllCircuits();
@@ -53,6 +85,8 @@ const sunIconSvg = `<svg class="w-4 h-4 hidden dark:block" viewBox="0 0 24 24" f
     <meta name="twitter:title" content={fullTitle} />
     <meta name="twitter:description" content={description} />
     <title>{fullTitle}</title>
+    <script type="application/ld+json" set:html={serializeLd(siteGraph)} />
+    {extraJsonLd.map((obj) => <script type="application/ld+json" set:html={serializeLd(obj)} />)}
     <script is:inline>
       (function () {
         const stored = localStorage.getItem("theme");

--- a/src/pages/circuits/[qec_id].astro
+++ b/src/pages/circuits/[qec_id].astro
@@ -46,9 +46,42 @@ const stimFilename = buildStimFilename({
 
 const hasOriginalMatrices = original?.has_original_matrices === 1;
 const originalsUrl = `/api/circuits/${qecId}/originals`;
+
+const siteUrl = (Astro.site ?? new URL(Astro.url.origin)).href.replace(/\/$/, "");
+const pageUrl = `${siteUrl}/circuits/${circuit.qec_id}`;
+const jsonLd = [
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareSourceCode",
+    "@id": `${pageUrl}#circuit`,
+    name: `${circuit.name} ${displayId}`,
+    url: pageUrl,
+    description: `Quantum error correction circuit ${displayId} for the ${circuit.code_name}, in STIM format.`,
+    programmingLanguage: "STIM",
+    codeRepository: "https://github.com/qecirc/qecirc-website",
+    isPartOf: { "@id": `${siteUrl}/#website` },
+    about: {
+      "@type": "DefinedTerm",
+      name: circuit.code_name,
+      url: `${siteUrl}/codes/${circuit.code_slug}`,
+    },
+    license: "https://creativecommons.org/licenses/by-sa/4.0/",
+    ...(circuit.tags.length ? { keywords: circuit.tags.join(", ") } : {}),
+    ...(circuit.source.startsWith("http") ? { citation: circuit.source } : {}),
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "Codes", item: `${siteUrl}/` },
+      { "@type": "ListItem", position: 2, name: circuit.code_name, item: `${siteUrl}/codes/${circuit.code_slug}` },
+      { "@type": "ListItem", position: 3, name: `${circuit.name} ${displayId}`, item: pageUrl },
+    ],
+  },
+];
 ---
 
-<Layout title={`${circuit.name} ${displayId}`} description={`Circuit ${displayId} for ${circuit.code_name}`}>
+<Layout title={`${circuit.name} ${displayId}`} description={`Circuit ${displayId} for ${circuit.code_name}`} jsonLd={jsonLd}>
   <a
     href={`/codes/${circuit.code_slug}`}
     class="inline-flex items-center gap-1.5 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 mb-4"

--- a/src/pages/codes/[code].astro
+++ b/src/pages/codes/[code].astro
@@ -50,9 +50,58 @@ const countLabel = hasFilters
 const basePath = `/codes/${codeSlug}`;
 const sortHref = (field: "gate_count" | "two_qubit_gate_count" | "depth" | "qubit_count") =>
   circuitSortToggleUrl(Astro.url, sort, field, basePath);
+
+const siteUrl = (Astro.site ?? new URL(Astro.url.origin)).href.replace(/\/$/, "");
+const pageUrl = `${siteUrl}/codes/${codeSlug}`;
+const codeTitle = params && code.name !== params ? `${code.name} ${params}` : code.name;
+const collection: Record<string, unknown> = {
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "@id": `${pageUrl}#code`,
+  url: pageUrl,
+  name: codeTitle,
+  description: `Quantum error correction circuits for the ${codeTitle}.`,
+  isPartOf: { "@id": `${siteUrl}/#website` },
+  about: {
+    "@type": "DefinedTerm",
+    name: code.name,
+    url: pageUrl,
+    ...(params ? { termCode: params } : {}),
+    ...(code.zoo_url ? { sameAs: code.zoo_url } : {}),
+  },
+};
+// Enumerate circuits only on the canonical (unfiltered) view — the canonical
+// URL drops the query string, so a filtered subset would misrepresent it.
+if (!hasFilters) {
+  collection.mainEntity = {
+    "@type": "ItemList",
+    numberOfItems: totalCount,
+    itemListElement: circuits.map((c, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      name: c.name,
+      url: `${siteUrl}/circuits/${c.qec_id}`,
+    })),
+  };
+}
+const jsonLd = [
+  collection,
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "Codes", item: `${siteUrl}/` },
+      { "@type": "ListItem", position: 2, name: codeTitle, item: pageUrl },
+    ],
+  },
+];
 ---
 
-<Layout title={code.name} description={`Circuits for ${code.name}${params && code.name !== params ? ` ${params}` : ""}`}>
+<Layout
+  title={code.name}
+  description={`Circuits for ${code.name}${params && code.name !== params ? ` ${params}` : ""}`}
+  jsonLd={jsonLd}
+>
   <a
     href="/"
     class="inline-flex items-center gap-1.5 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 mb-4"

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -1,0 +1,43 @@
+import type { APIRoute } from "astro";
+import { getAllCodes, formatCodeParams } from "../lib/queries";
+
+export const prerender = false;
+
+// https://llmstxt.org/ — a concise, LLM-friendly map of the site. Generated
+// from the live database (like sitemap.xml) so it never drifts. Codes are the
+// top-level entities; each code page enumerates its own circuits (and carries
+// schema.org JSON-LD), so listing all 400+ circuits here would only add noise.
+export const GET: APIRoute = ({ site }) => {
+  const base = site!.origin;
+  const codes = getAllCodes(); // ordered by name
+  const totalCircuits = codes.reduce((sum, c) => sum + c.circuit_count, 0);
+
+  const codeLines = codes.map((c) => {
+    const params = formatCodeParams(c);
+    const label = c.name === params ? params : `${c.name} ${params}`;
+    const n = c.circuit_count;
+    return `- [${label}](${base}/codes/${c.slug}): ${n} circuit${n !== 1 ? "s" : ""}`;
+  });
+
+  const body = `# QECirc
+
+> A community-driven library for quantum error correction (QEC) circuits. Browse and download reusable STIM circuits — encoding, state preparation, syndrome extraction, and more — organized by error-correcting code. ${codes.length} codes, ${totalCircuits} circuits.
+
+Circuits are stored in STIM format and also offered as QASM and Cirq. Each code page lists its circuits with metrics (gate count, two-qubit gate count, depth, qubit count) and links to the original source. Circuit data is licensed CC BY-SA 4.0; please cite the source of each circuit when using it.
+
+## Codes
+
+${codeLines.join("\n")}
+
+## About
+
+- [About](${base}/about): project goals, data model, and scope.
+- [Contribute](${base}/contribute): how to submit a circuit or import a dataset.
+- [Tools](${base}/tools): software tools used to create the circuits.
+- [Adding Circuits guide](https://github.com/qecirc/qecirc-website/blob/main/docs/adding-circuits.md): the ingestion pipeline and helper functions.
+`;
+
+  return new Response(body, {
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  });
+};

--- a/uv.lock
+++ b/uv.lock
@@ -829,7 +829,7 @@ wheels = [
 
 [[package]]
 name = "qecirc-website"
-version = "0.4.4"
+version = "0.4.5"
 source = { virtual = "." }
 dependencies = [
     { name = "mqt-qecc" },


### PR DESCRIPTION
## Why

Goal: get QECirc **cited and linked by AI search / answer engines** (Google AI Overviews, ChatGPT/Claude/Perplexity search) when someone looks for a circuit — while *not* inviting training crawlers (the `robots.txt` already blocks those). The site had solid basics (SSR content, titles/descriptions, canonical, OG, sitemap) but **no structured data** and **no `llms.txt`** — the two highest-leverage gaps for machine legibility.

## What changed

**schema.org JSON-LD (server-rendered):**
- `Layout.astro` emits a site-wide `@graph` (`Organization` + `WebSite`) on every page and accepts a `jsonLd` prop for per-page entities. `<` is escaped so no value can terminate the `<script>`.
- **Circuit pages** → `SoftwareSourceCode` (`programmingLanguage: STIM`, the QEC code as `about`, source DOI as `citation`, tags as `keywords`, CC BY-SA `license`) + `BreadcrumbList`.
- **Code pages** → `CollectionPage` (code as `DefinedTerm` with `termCode` + Zoo `sameAs`) with an `ItemList` of its circuits on the canonical unfiltered view + `BreadcrumbList`.

**`/llms.txt`** ([llmstxt.org](https://llmstxt.org/)):
- New route generated from the **live DB** (like `sitemap.xml`, so it never drifts): intro + every code with circuit counts and links + key pages. Codes are the entities; each code page already enumerates its own circuits, so 400+ circuit lines here would only be noise.

**Housekeeping:** patch bump `0.4.4` → `0.4.5` (`package.json`, `pyproject.toml`, `uv.lock`, `package-lock.json`).

## Verification

Ran the dev server and checked rendered output:
- Homepage: site `@graph` only. Circuit page: `SoftwareSourceCode` + `BreadcrumbList`. Code page: `CollectionPage` (ItemList n=14) + `BreadcrumbList`. All JSON-LD parses; absolute `qecirc.com` URLs.
- `/llms.txt` → `text/plain`, 23 codes / 424 circuits.
- No server errors; `eslint` and `prettier --check` pass.

## Deliberately skipped (from the isitagentready.com test)

Everything in the API/Auth/MCP/Commerce buckets (OAuth discovery, API catalog, MCP server card, WebMCP, DNS-AID, auth.md, agent-skills index) — those are for agent-transaction platforms, not a content library, and don't serve the citation goal. OG image and a `Link` header remain optional polish if wanted later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)