### PR TITLE
feat(browse): lazy-load circuit bodies on code pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ the source-of-truth `package.json` version.
 
 ### Changed
 
+- Code pages no longer embed circuit bodies in the initial HTML; bodies load
+  on first row expand via the new `/api/circuits/[qec_id]/bodies` endpoint.
+  Largest page (`/codes/flag-gadgets`) drops from ~15 MB to ~3 MB HTML and
+  from ~39k to ~20k DOM nodes.
 - **BREAKING:** `add_circuit()` matrix arguments (`Hx`, `Hz`, `H`, `n`) are now
   keyword-only. Migration: replace `add_circuit(Hx, Hz, circuit, name, d, ...)`
   with `add_circuit(circuit=circuit, circuit_name=name, d=d, Hx=Hx, Hz=Hz, ...)`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,7 @@ A maintainer reviews the issue, then uses the ingestion pipeline to add the circ
 
 - Static pages: landing page, 404 (pre-rendered at build time)
 - SSR pages (`prerender = false`): all `/codes/...` and `/circuits/...` routes, `/api/search` (rendered on request, read from SQLite)
-- Client-side JS: search bar (debounced fetch), circuit row expand/collapse, format switching, favorites (toggle/filter/export/import), CodeBlock copy/download, filter input validation + auto-submit
+- Client-side JS: search bar (debounced fetch), circuit row expand/collapse, format switching, favorites (toggle/filter/export/import), CodeBlock copy/download, filter input validation + auto-submit, lazy-loaded circuit bodies on code pages (fetched from `/api/circuits/[qec_id]/bodies` on first row expand)
 
 This keeps the site fast and simple while scaling comfortably to thousands of circuits.
 

--- a/docs/superpowers/plans/2026-07-08-lazy-circuit-bodies.md
+++ b/docs/superpowers/plans/2026-07-08-lazy-circuit-bodies.md
@@ -17,6 +17,7 @@
 ### Task 1: Bodies API endpoint
 
 **Files:**
+
 - Modify: `scripts/smoke.sh` (add endpoint check)
 - Modify: `src/lib/queries/circuits.ts` (add query helper)
 - Modify: `src/lib/queries/index.ts` (export it)
@@ -45,8 +46,7 @@ In `src/lib/queries/circuits.ts`, add after `getBodiesForCircuits` (keep `getBod
 export function getBodiesForCircuitByQecId(qecId: number): CircuitBody[] {
   const db = getDb();
   const row = db.prepare("SELECT id FROM circuits WHERE qec_id = ?").get(qecId) as
-    | { id: number }
-    | undefined;
+    { id: number } | undefined;
   if (!row) return [];
   return getBodiesForCircuits([row.id]).get(row.id) ?? [];
 }
@@ -92,6 +92,7 @@ Run: `./scripts/smoke.sh`
 Expected: all checks `OK`, including `OK   /api/circuits/<id>/bodies`.
 
 Also verify edge cases:
+
 - `curl -s -o /dev/null -w "%{http_code}" http://localhost:4321/api/circuits/999999/bodies` → `404`
 - `curl -s -o /dev/null -w "%{http_code}" http://localhost:4321/api/circuits/abc/bodies` → `400`
 
@@ -109,6 +110,7 @@ Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
 ### Task 2: Template component + client module (inert until Task 3 wires them up)
 
 **Files:**
+
 - Create: `src/components/CircuitBodiesTemplate.astro`
 - Create: `src/lib/circuit-bodies-client.ts`
 
@@ -213,9 +215,7 @@ const loaded = new WeakSet<HTMLElement>();
 function lineNumbered(code: string): string {
   const lines = code.trimEnd().split("\n");
   const gutterWidth = String(lines.length).length;
-  return lines
-    .map((line, i) => `${String(i + 1).padStart(gutterWidth, " ")}  ${line}`)
-    .join("\n");
+  return lines.map((line, i) => `${String(i + 1).padStart(gutterWidth, " ")}  ${line}`).join("\n");
 }
 
 /** Same cite-toast behavior as CodeBlock.astro's copy/download handlers. */
@@ -226,9 +226,7 @@ function citeNotice(source: string): void {
   } else if (source) {
     window.showCiteToast("Please cite the source when using this circuit: " + source);
   } else {
-    window.showCiteToast(
-      "Please check and cite the corresponding source when using this circuit.",
-    );
+    window.showCiteToast("Please check and cite the corresponding source when using this circuit.");
   }
 }
 
@@ -275,9 +273,7 @@ function buildSwitcher(
 
     const downloadBtn = bodyEl.querySelector<HTMLElement>(".download-btn");
     if (downloadBtn) {
-      const downloadName = stimFilename
-        ? stimFilename.replace(/\.stim$/, `.${entry.format}`)
-        : "";
+      const downloadName = stimFilename ? stimFilename.replace(/\.stim$/, `.${entry.format}`) : "";
       if (downloadName) {
         downloadBtn.title = `Download ${downloadName} (d)`;
         downloadBtn.addEventListener("click", function () {
@@ -330,10 +326,7 @@ function syncDetailHeight(container: HTMLElement): void {
   }
 }
 
-async function loadBodies(
-  container: HTMLElement,
-  template: HTMLTemplateElement,
-): Promise<void> {
+async function loadBodies(container: HTMLElement, template: HTMLTemplateElement): Promise<void> {
   if (loaded.has(container)) return;
   loaded.add(container);
   const qecId = container.dataset.qecId;
@@ -352,9 +345,7 @@ async function loadBodies(
 }
 
 export function initCircuitBodies(): void {
-  const template = document.getElementById(
-    "circuit-bodies-template",
-  ) as HTMLTemplateElement | null;
+  const template = document.getElementById("circuit-bodies-template") as HTMLTemplateElement | null;
   if (!template) return;
 
   document.addEventListener("circuit-expand", function (e) {
@@ -384,6 +375,7 @@ Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
 ### Task 3: Wire up — CircuitRow placeholder, event dispatch, code page
 
 **Files:**
+
 - Modify: `src/components/CircuitRow.astro`
 - Modify: `src/pages/codes/[code].astro`
 - Modify: `src/lib/queries/circuits.ts` (remove `getCircuitsWithBodies`)
@@ -399,6 +391,7 @@ In `src/components/CircuitRow.astro`:
 ```ts
 import type { Circuit, Tool } from "../types";
 ```
+
 ```ts
 interface Props {
   circuit: Circuit & { tags: string[] };
@@ -426,8 +419,8 @@ const { circuit, tool, codeSlug, currentUrl } = Astro.props;
 3. In the `<script>`, in the expand branch of the toggle click handler, add the event dispatch directly after `history.replaceState(null, "", "#" + qecId);`:
 
 ```ts
-          // Signal circuit-bodies-client (code pages) to lazy-load bodies.
-          detail.dispatchEvent(new CustomEvent("circuit-expand", { bubbles: true }));
+// Signal circuit-bodies-client (code pages) to lazy-load bodies.
+detail.dispatchEvent(new CustomEvent("circuit-expand", { bubbles: true }));
 ```
 
 - [ ] **Step 2: Code page — drop bodiesMap, render template, init client**
@@ -558,8 +551,10 @@ curl -s -o /dev/null -w "flag-gadgets: %{size_download} bytes\n" http://localhos
 In the browser console on `/codes/flag-gadgets`:
 
 ```js
-({ nodes: document.getElementsByTagName("*").length,
-   interactive: Math.round(performance.getEntriesByType("navigation")[0].domInteractive) })
+({
+  nodes: document.getElementsByTagName("*").length,
+  interactive: Math.round(performance.getEntriesByType("navigation")[0].domInteractive),
+});
 ```
 
 Expected: ~1–2 MB (was 15.2 MB), roughly 9k nodes (was 39,248). Record actual numbers for the PR description.
@@ -569,6 +564,7 @@ Expected: ~1–2 MB (was 15.2 MB), roughly 9k nodes (was 39,248). Record actual 
 ### Task 5: Housekeeping — changelog, version bump, docs
 
 **Files:**
+
 - Modify: `CHANGELOG.md`
 - Modify: `package.json`, `pyproject.toml`, `uv.lock`, `package-lock.json`
 - Modify: `CLAUDE.md`

--- a/docs/superpowers/plans/2026-07-08-lazy-circuit-bodies.md
+++ b/docs/superpowers/plans/2026-07-08-lazy-circuit-bodies.md
@@ -1,0 +1,637 @@
+# Lazy-Load Circuit Bodies Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Code pages (`/codes/[code]`) stop embedding circuit bodies in HTML; bodies are fetched on first row expand via a new JSON endpoint (15 MB → ~1–2 MB on the largest page).
+
+**Architecture:** New `/api/circuits/[qec_id]/bodies` endpoint (mirrors the existing `originals.ts`). `CircuitRow` renders a placeholder instead of `FormatSwitcher` and dispatches a `circuit-expand` CustomEvent on expand (same pattern as `toggle-client.ts`'s `collapsible-open`). A new client module clones a shared `<template>` and fills in tabs + line-numbered bodies, mirroring the `CodeMatrices` lazy-load pattern.
+
+**Tech Stack:** Astro v7, TypeScript, better-sqlite3, Tailwind. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-07-08-lazy-circuit-bodies-design.md`
+
+**Testing note:** This repo has no JS unit-test framework (Python `pytest` covers only ingestion scripts), and the minimal-dependencies rule rules out adding one for this change. Tests here are: `scripts/smoke.sh` (integration, curl-based — extended first, red/green style, in Task 1) plus a scripted browser-verification checklist (Task 4). Work on branch `feat/lazy-circuit-bodies` (already exists; spec is committed there). The dev server must be running for smoke checks: `npm run dev` (port 4321).
+
+---
+
+### Task 1: Bodies API endpoint
+
+**Files:**
+- Modify: `scripts/smoke.sh` (add endpoint check)
+- Modify: `src/lib/queries/circuits.ts` (add query helper)
+- Modify: `src/lib/queries/index.ts` (export it)
+- Create: `src/pages/api/circuits/[qec_id]/bodies.ts`
+
+- [ ] **Step 1: Add the failing smoke check**
+
+In `scripts/smoke.sh`, inside the `else` branch that already checks `/circuits/$qec_id`, add one line after `check "/api/circuits?ids=$qec_id" "qec_id"`:
+
+```bash
+  check "/api/circuits/$qec_id/bodies" '"format":"stim"'
+```
+
+- [ ] **Step 2: Run smoke to verify it fails**
+
+Run: `./scripts/smoke.sh`
+Expected: `FAIL /api/circuits/<id>/bodies: HTTP error` (404 — route doesn't exist yet). All other checks OK.
+
+- [ ] **Step 3: Add the query helper**
+
+In `src/lib/queries/circuits.ts`, add after `getBodiesForCircuits` (keep `getBodiesForCircuits` itself — `/api/download` and the circuit detail page still use it):
+
+```ts
+/** Bodies for a single circuit looked up by its public qec_id, in preferred
+ * format order. Returns [] when the circuit doesn't exist. */
+export function getBodiesForCircuitByQecId(qecId: number): CircuitBody[] {
+  const db = getDb();
+  const row = db.prepare("SELECT id FROM circuits WHERE qec_id = ?").get(qecId) as
+    | { id: number }
+    | undefined;
+  if (!row) return [];
+  return getBodiesForCircuits([row.id]).get(row.id) ?? [];
+}
+```
+
+In `src/lib/queries/index.ts`, add `getBodiesForCircuitByQecId,` to the `./circuits` export list (keep alphabetical-ish placement next to `getBodiesForCircuits`).
+
+- [ ] **Step 4: Create the endpoint**
+
+Create `src/pages/api/circuits/[qec_id]/bodies.ts`:
+
+```ts
+export const prerender = false;
+
+import type { APIRoute } from "astro";
+import { getBodiesForCircuitByQecId } from "../../../../lib/queries";
+
+export const GET: APIRoute = ({ params }) => {
+  const qecId = Number(params.qec_id);
+  if (!Number.isInteger(qecId) || qecId < 1) {
+    return new Response("Invalid qec_id", { status: 400 });
+  }
+
+  const bodies = getBodiesForCircuitByQecId(qecId);
+  if (bodies.length === 0) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  return new Response(JSON.stringify({ bodies }), {
+    headers: {
+      "Content-Type": "application/json",
+      // qec_ids are permanent and never reused; body edits between deploys
+      // tolerate <=1h of browser-cache staleness (matches originals.ts).
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
+};
+```
+
+- [ ] **Step 5: Run smoke to verify it passes**
+
+Run: `./scripts/smoke.sh`
+Expected: all checks `OK`, including `OK   /api/circuits/<id>/bodies`.
+
+Also verify edge cases:
+- `curl -s -o /dev/null -w "%{http_code}" http://localhost:4321/api/circuits/999999/bodies` → `404`
+- `curl -s -o /dev/null -w "%{http_code}" http://localhost:4321/api/circuits/abc/bodies` → `400`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/smoke.sh src/lib/queries/circuits.ts src/lib/queries/index.ts "src/pages/api/circuits/[qec_id]/bodies.ts"
+git commit -m "feat(api): add /api/circuits/[qec_id]/bodies endpoint
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Template component + client module (inert until Task 3 wires them up)
+
+**Files:**
+- Create: `src/components/CircuitBodiesTemplate.astro`
+- Create: `src/lib/circuit-bodies-client.ts`
+
+- [ ] **Step 1: Create the template component**
+
+Create `src/components/CircuitBodiesTemplate.astro`. The markup skeleton is a copy of `FormatSwitcher.astro` (tab bar) + `CodeBlock.astro` (code block) with the dynamic parts left empty — the client clones the `.format-tab` and `.format-body` prototypes once per format:
+
+```astro
+---
+// Markup skeleton cloned client-side by circuit-bodies-client.ts when a
+// circuit row is first expanded on a code page. Rendered once per code page.
+// KEEP THE TAB / CODE-BLOCK MARKUP IN SYNC with FormatSwitcher.astro and
+// CodeBlock.astro (server-rendered on circuit detail pages).
+import { TAB_INACTIVE_CLASS } from "../lib/constants";
+
+const TAB_BASE_CLASS =
+  "format-tab px-3 py-1.5 text-xs font-semibold rounded-md cursor-pointer transition-colors";
+---
+
+<template id="circuit-bodies-template">
+  <div class="format-switcher">
+    <div class="format-tabs flex gap-0.5 mb-2">
+      <button class={`${TAB_BASE_CLASS} ${TAB_INACTIVE_CLASS}`} data-format="">
+        <span class="tab-label"></span>
+        <kbd
+          class="ml-1.5 inline-block min-w-[1rem] text-center px-1 rounded border border-gray-300 dark:border-gray-700 bg-white/60 dark:bg-gray-900/60 text-[10px] text-gray-400 dark:text-gray-500 font-mono"
+        ></kbd>
+      </button>
+    </div>
+    <div class="format-body" data-format="">
+      <div
+        class="rounded border border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-900 overflow-hidden"
+        data-code-block
+      >
+        <div
+          class="border-b border-gray-200 dark:border-gray-800 px-4 py-2 text-xs text-gray-500 dark:text-gray-400 flex items-center justify-between"
+        >
+          <span class="block-label"></span>
+          <div class="flex items-center gap-3.5">
+            <button
+              class="download-btn flex items-center gap-1 text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 cursor-pointer"
+              aria-label="Download file"
+            >
+              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4M7 10l5 5 5-5M12 15V3" />
+              </svg>
+              <span>Download</span>
+              <kbd class="ml-0.5 inline-block min-w-[1rem] text-center px-1 rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-[10px] text-gray-400 dark:text-gray-500 font-mono">
+                d
+              </kbd>
+            </button>
+            <button
+              class="copy-btn flex items-center gap-1 text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 cursor-pointer"
+              aria-label="Copy to clipboard"
+              title="Copy to clipboard (c)"
+            >
+              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+              </svg>
+              <span class="copy-label">Copy</span>
+              <kbd class="ml-0.5 inline-block min-w-[1rem] text-center px-1 rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-[10px] text-gray-400 dark:text-gray-500 font-mono">
+                c
+              </kbd>
+            </button>
+          </div>
+        </div>
+        <pre class="overflow-x-auto p-4 text-sm leading-relaxed"><code></code></pre>
+      </div>
+    </div>
+  </div>
+</template>
+```
+
+- [ ] **Step 2: Create the client module**
+
+Create `src/lib/circuit-bodies-client.ts`:
+
+```ts
+// Lazy-loads circuit bodies on code pages. Circuit rows render without any
+// circuit text; on the first expand of a row (signalled by the
+// `circuit-expand` CustomEvent dispatched in CircuitRow.astro) this module
+// fetches /api/circuits/<qec_id>/bodies, clones #circuit-bodies-template and
+// fills in tabs + line-numbered bodies. Mirrors the CodeMatrices lazy-load
+// pattern: fetch-once guard, error text, retry on next expand.
+
+import { copyToClipboard } from "./dom-helpers";
+import { initFormatSwitchers } from "./format-switcher-client";
+import { TAB_ACTIVE_CLASS, TAB_INACTIVE_CLASS } from "./constants";
+
+interface BodyEntry {
+  format: string;
+  body: string;
+}
+
+// Keep in sync with FormatSwitcher.astro / format-switcher-client.ts.
+const TAB_BASE_CLASS =
+  "format-tab px-3 py-1.5 text-xs font-semibold rounded-md cursor-pointer transition-colors";
+
+const loaded = new WeakSet<HTMLElement>();
+
+/** Same line-number gutter format as CodeBlock.astro. */
+function lineNumbered(code: string): string {
+  const lines = code.trimEnd().split("\n");
+  const gutterWidth = String(lines.length).length;
+  return lines
+    .map((line, i) => `${String(i + 1).padStart(gutterWidth, " ")}  ${line}`)
+    .join("\n");
+}
+
+/** Same cite-toast behavior as CodeBlock.astro's copy/download handlers. */
+function citeNotice(source: string): void {
+  if (typeof window.showCiteToast !== "function") return;
+  if (source && source.startsWith("http")) {
+    window.showCiteToast("Please cite the source when using this circuit:", source);
+  } else if (source) {
+    window.showCiteToast("Please cite the source when using this circuit: " + source);
+  } else {
+    window.showCiteToast(
+      "Please check and cite the corresponding source when using this circuit.",
+    );
+  }
+}
+
+function buildSwitcher(
+  container: HTMLElement,
+  template: HTMLTemplateElement,
+  bodies: BodyEntry[],
+): void {
+  const fragment = template.content.cloneNode(true) as DocumentFragment;
+  const switcher = fragment.querySelector<HTMLElement>(".format-switcher");
+  const tabBar = switcher?.querySelector<HTMLElement>(".format-tabs");
+  const tabProto = tabBar?.querySelector<HTMLElement>(".format-tab");
+  const bodyProto = switcher?.querySelector<HTMLElement>(".format-body");
+  if (!switcher || !tabBar || !tabProto || !bodyProto) return;
+  tabProto.remove();
+  bodyProto.remove();
+
+  const stimFilename = container.dataset.stimFilename ?? "";
+  const source = container.dataset.source ?? "";
+
+  bodies.forEach(function (entry, i) {
+    const raw = entry.body.trimEnd();
+
+    const tab = tabProto.cloneNode(true) as HTMLElement;
+    tab.className = `${TAB_BASE_CLASS} ${i === 0 ? TAB_ACTIVE_CLASS : TAB_INACTIVE_CLASS}`;
+    tab.dataset.format = entry.format;
+    tab.title = `Switch to ${entry.format.toUpperCase()} (${i + 1})`;
+    const tabLabel = tab.querySelector<HTMLElement>(".tab-label");
+    if (tabLabel) tabLabel.textContent = entry.format.toUpperCase();
+    const kbd = tab.querySelector<HTMLElement>("kbd");
+    if (kbd) {
+      if (i < 3) kbd.textContent = String(i + 1);
+      else kbd.remove();
+    }
+    tabBar.appendChild(tab);
+
+    const bodyEl = bodyProto.cloneNode(true) as HTMLElement;
+    bodyEl.dataset.format = entry.format;
+    if (i !== 0) bodyEl.style.display = "none";
+    const blockLabel = bodyEl.querySelector<HTMLElement>(".block-label");
+    if (blockLabel) blockLabel.textContent = `${entry.format.toUpperCase()} Circuit`;
+    const codeEl = bodyEl.querySelector<HTMLElement>("pre code");
+    if (codeEl) codeEl.textContent = lineNumbered(entry.body);
+
+    const downloadBtn = bodyEl.querySelector<HTMLElement>(".download-btn");
+    if (downloadBtn) {
+      const downloadName = stimFilename
+        ? stimFilename.replace(/\.stim$/, `.${entry.format}`)
+        : "";
+      if (downloadName) {
+        downloadBtn.title = `Download ${downloadName} (d)`;
+        downloadBtn.addEventListener("click", function () {
+          const blob = new Blob([raw], { type: "text/plain" });
+          const url = URL.createObjectURL(blob);
+          const a = document.createElement("a");
+          a.href = url;
+          a.download = downloadName;
+          a.click();
+          URL.revokeObjectURL(url);
+          citeNotice(source);
+        });
+      } else {
+        downloadBtn.remove();
+      }
+    }
+
+    const copyBtn = bodyEl.querySelector<HTMLElement>(".copy-btn");
+    if (copyBtn) {
+      copyBtn.addEventListener("click", async function () {
+        const ok = await copyToClipboard(raw);
+        if (!ok) return;
+        const label = copyBtn.querySelector<HTMLElement>(".copy-label");
+        if (label) {
+          const original = label.textContent;
+          label.textContent = "Copied!";
+          setTimeout(function () {
+            label.textContent = original;
+          }, 1500);
+        }
+        citeNotice(source);
+      });
+    }
+
+    switcher.appendChild(bodyEl);
+  });
+
+  // Match FormatSwitcher.astro: no tab bar for single-format circuits.
+  if (bodies.length < 2) tabBar.remove();
+
+  container.replaceChildren(fragment);
+  initFormatSwitchers(container);
+}
+
+/** Re-sync the expand animation height after content changes. */
+function syncDetailHeight(container: HTMLElement): void {
+  const detail = container.closest<HTMLElement>(".circuit-detail");
+  if (detail && detail.style.maxHeight !== "0px") {
+    detail.style.maxHeight = detail.scrollHeight + "px";
+  }
+}
+
+async function loadBodies(
+  container: HTMLElement,
+  template: HTMLTemplateElement,
+): Promise<void> {
+  if (loaded.has(container)) return;
+  loaded.add(container);
+  const qecId = container.dataset.qecId;
+  if (!qecId) return;
+  try {
+    const res = await fetch(`/api/circuits/${qecId}/bodies`);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = (await res.json()) as { bodies: BodyEntry[] };
+    buildSwitcher(container, template, data.bodies);
+  } catch {
+    loaded.delete(container); // allow a fresh expand to retry
+    const status = container.querySelector<HTMLElement>(".circuit-bodies-status");
+    if (status) status.textContent = "Failed to load — collapse and expand to retry.";
+  }
+  syncDetailHeight(container);
+}
+
+export function initCircuitBodies(): void {
+  const template = document.getElementById(
+    "circuit-bodies-template",
+  ) as HTMLTemplateElement | null;
+  if (!template) return;
+
+  document.addEventListener("circuit-expand", function (e) {
+    const detail = e.target as HTMLElement;
+    const container = detail.querySelector<HTMLElement>(".circuit-bodies");
+    if (container) void loadBodies(container, template);
+  });
+}
+```
+
+- [ ] **Step 3: Lint and typecheck**
+
+Run: `npm run lint`
+Expected: no errors. (The new module is imported by nothing yet — that's fine; Task 3 wires it.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/CircuitBodiesTemplate.astro src/lib/circuit-bodies-client.ts
+git commit -m "feat(browse): add circuit-bodies template and lazy-load client module
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Wire up — CircuitRow placeholder, event dispatch, code page
+
+**Files:**
+- Modify: `src/components/CircuitRow.astro`
+- Modify: `src/pages/codes/[code].astro`
+- Modify: `src/lib/queries/circuits.ts` (remove `getCircuitsWithBodies`)
+- Modify: `src/lib/queries/index.ts` (drop its export)
+- Modify: `src/components/FormatSwitcher.astro`, `src/components/CodeBlock.astro` (sync comments only)
+
+- [ ] **Step 1: CircuitRow — drop bodies, render placeholder, dispatch event**
+
+In `src/components/CircuitRow.astro`:
+
+1. Imports/Props: remove `CircuitBody` from the type import and remove the `FormatSwitcher` import; delete `bodies: CircuitBody[];` from `Props`; remove `bodies` from the destructuring.
+
+```ts
+import type { Circuit, Tool } from "../types";
+```
+```ts
+interface Props {
+  circuit: Circuit & { tags: string[] };
+  tool?: Tool;
+  codeSlug: string;
+  currentUrl: URL;
+}
+
+const { circuit, tool, codeSlug, currentUrl } = Astro.props;
+```
+
+2. Replace the `<FormatSwitcher ... />` line at the bottom of the detail panel with the placeholder (filled by circuit-bodies-client.ts on first expand):
+
+```astro
+<div
+  class="circuit-bodies"
+  data-qec-id={anchorId}
+  data-stim-filename={stimFilename}
+  data-source={circuit.source}
+>
+  <p class="circuit-bodies-status text-sm text-gray-400">Loading circuit&hellip;</p>
+</div>
+```
+
+3. In the `<script>`, in the expand branch of the toggle click handler, add the event dispatch directly after `history.replaceState(null, "", "#" + qecId);`:
+
+```ts
+          // Signal circuit-bodies-client (code pages) to lazy-load bodies.
+          detail.dispatchEvent(new CustomEvent("circuit-expand", { bubbles: true }));
+```
+
+- [ ] **Step 2: Code page — drop bodiesMap, render template, init client**
+
+In `src/pages/codes/[code].astro`:
+
+1. Imports: replace `getCircuitsWithBodies` with `getCircuitsForCode` and `filterCircuitsForCode` in the queries import; add the template component import:
+
+```ts
+import CircuitBodiesTemplate from "../../components/CircuitBodiesTemplate.astro";
+```
+
+2. Replace the fetch line:
+
+```ts
+const { circuits, bodiesMap } = getCircuitsWithBodies(code.id, filters, sort);
+```
+
+with:
+
+```ts
+const circuits = hasFilters
+  ? filterCircuitsForCode(code.id, filters, sort)
+  : getCircuitsForCode(code.id, sort);
+```
+
+3. Update the row render (remove the `bodies` prop):
+
+```astro
+<CircuitRow circuit={circuit} tool={toolsMap.get(circuit.id)} codeSlug={codeSlug!} currentUrl={Astro.url} />
+```
+
+4. Render the template once, directly before `</Layout>`:
+
+```astro
+  <CircuitBodiesTemplate />
+</Layout>
+```
+
+5. In the page `<script>`, add:
+
+```ts
+import { initCircuitBodies } from "../../lib/circuit-bodies-client";
+```
+
+and call `initCircuitBodies();` after `initBackKey("/");`.
+
+- [ ] **Step 3: Remove getCircuitsWithBodies**
+
+Verify it has no other callers: `grep -rn "getCircuitsWithBodies" src/` → only `queries/circuits.ts` and `queries/index.ts` remain. Delete the whole `getCircuitsWithBodies` function from `src/lib/queries/circuits.ts` and remove `getCircuitsWithBodies,` from `src/lib/queries/index.ts`.
+
+- [ ] **Step 4: Sync comments in the server-rendered twins**
+
+Top of `src/components/FormatSwitcher.astro` frontmatter, after the imports:
+
+```ts
+// KEEP THE TAB MARKUP IN SYNC with CircuitBodiesTemplate.astro, which is
+// cloned client-side on code pages (this component renders only on circuit
+// detail pages).
+```
+
+Top of `src/components/CodeBlock.astro` frontmatter, after the Props interface:
+
+```ts
+// KEEP THE CODE-BLOCK MARKUP IN SYNC with CircuitBodiesTemplate.astro, which
+// is cloned client-side on code pages (this component renders only on
+// circuit detail pages and the favorites page's export block, if any).
+```
+
+- [ ] **Step 5: Lint, format, smoke**
+
+Run: `npm run lint && npm run format && ./scripts/smoke.sh`
+Expected: lint clean, prettier may rewrite the new files (fine), smoke all `OK`.
+
+Quick behavioral spot-check (dev server auto-reloads):
+
+```bash
+curl -s http://localhost:4321/codes/steane-code | grep -c "circuit-bodies-status"   # expect: number of circuits (213)
+curl -s http://localhost:4321/codes/steane-code | grep -c "format-switcher"          # expect: 1 (the template only)
+curl -s -o /dev/null -w "%{size_download}\n" http://localhost:4321/codes/flag-gadgets # expect: ~1-2 MB, was 15.2 MB
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/CircuitRow.astro "src/pages/codes/[code].astro" src/lib/queries/circuits.ts src/lib/queries/index.ts src/components/FormatSwitcher.astro src/components/CodeBlock.astro
+git commit -m "feat(browse): lazy-load circuit bodies on code pages
+
+Code pages no longer embed circuit bodies (all formats) in the initial
+HTML; bodies are fetched from /api/circuits/[qec_id]/bodies on first row
+expand. /codes/flag-gadgets drops from 15.2 MB to ~1 MB HTML.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Browser verification + production build
+
+**Files:** none (verification only; fix-forward if a check fails)
+
+- [ ] **Step 1: Production build**
+
+Run: `npm run build`
+Expected: build succeeds (this also rebuilds the DB first per the build script).
+
+- [ ] **Step 2: Browser checklist on the dev server**
+
+Use the preview browser (or a manual browser) on `http://localhost:4321`:
+
+1. `/codes/steane-code`: click a circuit row → "Loading circuit…" flashes, then STIM body with line numbers appears; tab bar shows STIM/QASM/CIRQ where the circuit has those formats.
+2. Format tabs: click QASM → body switches; press `1`/`2`/`3` → tabs switch (keyboard path).
+3. Press `c` → "Copied!" label + cite toast appears; paste buffer holds the raw body (no line numbers).
+4. Press `d` → file downloads with the `<code>_<circuit>_G..._2Q..._D..._Q....<format>` name; cite toast appears.
+5. Collapse and re-expand the same row → instant (no second fetch; check the network panel or server log shows one `/bodies` request).
+6. Hash permalink: open `/codes/steane-code#<some qec_id>` directly → row auto-expands and its body loads.
+7. Single-format circuit: find one via `sqlite3 data/qecirc.db "SELECT c.qec_id, co.slug FROM circuits c JOIN codes co ON co.id=c.code_id JOIN circuit_bodies cb ON cb.circuit_id=c.id GROUP BY c.id HAVING COUNT(cb.id)=1 LIMIT 1;"` → expand it → code block renders with NO tab bar.
+8. Failure path: expand a row with dev-tools offline mode (or temporarily rename the endpoint) → placeholder shows "Failed to load — collapse and expand to retry."; going back online, collapse + expand → loads.
+9. `/circuits/<qec_id>` (detail page): unchanged — bodies server-rendered, copy/download work.
+10. Favorites filter (Shift+F), download-all (Shift+D), sorting and tag filters on the code page: still work.
+
+- [ ] **Step 3: Re-measure and record**
+
+```bash
+curl -s -o /dev/null -w "flag-gadgets: %{size_download} bytes\n" http://localhost:4321/codes/flag-gadgets
+```
+
+In the browser console on `/codes/flag-gadgets`:
+
+```js
+({ nodes: document.getElementsByTagName("*").length,
+   interactive: Math.round(performance.getEntriesByType("navigation")[0].domInteractive) })
+```
+
+Expected: ~1–2 MB (was 15.2 MB), roughly 9k nodes (was 39,248). Record actual numbers for the PR description.
+
+---
+
+### Task 5: Housekeeping — changelog, version bump, docs
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `package.json`, `pyproject.toml`, `uv.lock`, `package-lock.json`
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Changelog entry**
+
+In `CHANGELOG.md` under `## Unreleased` → `### Changed`, add:
+
+```markdown
+- Code pages no longer embed circuit bodies in the initial HTML; bodies load
+  on first row expand via the new `/api/circuits/[qec_id]/bodies` endpoint.
+  Largest page (`/codes/flag-gadgets`) drops from ~15 MB to ~1 MB HTML.
+```
+
+- [ ] **Step 2: Version bump (patch: 0.4.6 → 0.4.7)**
+
+- `package.json`: `"version": "0.4.7"`
+- `pyproject.toml`: `version = "0.4.7"`
+- Run: `UV_NO_CONFIG=1 uv lock` (never without `UV_NO_CONFIG=1` — keeps private-registry refs out)
+- Run: `npm install` (syncs `package-lock.json`)
+
+- [ ] **Step 3: Update CLAUDE.md client-side JS inventory**
+
+In the "Rendering strategy" bullet listing client-side JS, extend with the new behavior, e.g. append `, lazy-loaded circuit bodies on code pages (fetch on first expand)` to the existing list.
+
+- [ ] **Step 4: Final checks + commit**
+
+Run: `npm run lint && npm run format:check && ./scripts/smoke.sh`
+Expected: all clean/OK.
+
+```bash
+git add CHANGELOG.md package.json pyproject.toml uv.lock package-lock.json CLAUDE.md
+git commit -m "chore(release): bump version to 0.4.7
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: PR
+
+- [ ] **Step 1: Push and open PR**
+
+```bash
+git push -u origin feat/lazy-circuit-bodies
+gh pr create --title "feat(browse): lazy-load circuit bodies on code pages" --body "$(cat <<'EOF'
+## Summary
+- Code pages no longer embed every circuit body (STIM/QASM/Cirq, each twice) in the initial HTML
+- New `/api/circuits/[qec_id]/bodies` endpoint (mirrors `originals.ts`); bodies fetch on first row expand, following the CodeMatrices lazy-load pattern
+- `/codes/flag-gadgets`: 15.2 MB → <measured> MB HTML, 39,248 → <measured> DOM nodes
+
+## Not changed
+- Circuit detail pages keep fully server-rendered bodies (SEO / SoftwareSourceCode JSON-LD)
+- Download-all, favorites, sorting, filtering, keyboard shortcuts, hash permalinks
+
+## Test plan
+- `scripts/smoke.sh` extended with the new endpoint check
+- Manual browser checklist: expand/format-switch/copy/download/cite-toast, keyboard `1/2/3/c/d`, hash auto-expand, single-format circuits, failure + retry path
+- Design doc: `docs/superpowers/specs/2026-07-08-lazy-circuit-bodies-design.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Fill in the `<measured>` numbers from Task 4 Step 3 before submitting.

--- a/docs/superpowers/specs/2026-07-08-lazy-circuit-bodies-design.md
+++ b/docs/superpowers/specs/2026-07-08-lazy-circuit-bodies-design.md
@@ -14,10 +14,10 @@ attribute. On top of that, each row carries ~13 kB of repeated static chrome
 
 Measured on `/codes/flag-gadgets` (354 circuits, 1000 bodies):
 
-| Metric | Value |
-| --- | --- |
-| HTML size | 15.2 MB (640 kB compressed in production) |
-| DOM nodes | 39,248 (~25× Lighthouse's "excessive DOM" threshold) |
+| Metric           | Value                                                     |
+| ---------------- | --------------------------------------------------------- |
+| HTML size        | 15.2 MB (640 kB compressed in production)                 |
+| DOM nodes        | 39,248 (~25× Lighthouse's "excessive DOM" threshold)      |
 | `domInteractive` | ~334 ms on fast desktop; est. 1.5–3 s on mid-range mobile |
 
 ## Goal
@@ -64,7 +64,7 @@ UX change beyond a brief "Loading circuit…" state on first expand.
   tool, Crumble/Quirk links, notes) and gains a placeholder:
 
   ```html
-  <div class="circuit-bodies" data-qec-id={...} data-stim-filename={...} data-source={...}>
+  <div class="circuit-bodies" data-qec-id="{...}" data-stim-filename="{...}" data-source="{...}">
     <p class="circuit-bodies-status text-sm text-gray-400">Loading circuit…</p>
   </div>
   ```
@@ -79,7 +79,7 @@ UX change beyond a brief "Loading circuit…" state on first expand.
 
 - New component `CircuitBodiesTemplate.astro`, rendered **once** per code
   page (from `codes/[code].astro`), containing a `<template
-  id="circuit-bodies-template">` with the FormatSwitcher + CodeBlock
+id="circuit-bodies-template">` with the FormatSwitcher + CodeBlock
   markup skeleton: tab bar (with kbd hints), and one format-body block
   (header with label, download button, copy button; empty `<pre><code>`).
   The client clones the format-body block per format and the tab button
@@ -121,7 +121,7 @@ Modeled on the `CodeMatrices` lazy-load script:
   - Calls `initFormatSwitchers(clonedRoot)` (it already accepts a root)
     to wire tab switching.
   - Re-syncs the collapse animation: `detail.style.maxHeight =
-    detail.scrollHeight + "px"` after insertion (and the existing
+detail.scrollHeight + "px"` after insertion (and the existing
     format-switcher client already re-syncs on tab clicks).
 
 ### 5. Keyboard shortcuts and existing behaviors
@@ -138,17 +138,17 @@ Modeled on the `CodeMatrices` lazy-load script:
 
 ## Files touched
 
-| File | Change |
-| --- | --- |
-| `src/pages/api/circuits/[qec_id]/bodies.ts` | new endpoint |
-| `src/lib/queries/circuits.ts` | add `getBodiesForCircuitByQecId`; remove `getCircuitsWithBodies` (its only caller was `codes/[code].astro`) |
-| `src/components/CircuitRow.astro` | remove FormatSwitcher/bodies, add placeholder |
-| `src/components/CircuitBodiesTemplate.astro` | new template component |
-| `src/lib/circuit-bodies-client.ts` | new client module |
-| `src/pages/codes/[code].astro` | drop bodiesMap, render template, init client module |
-| `src/components/FormatSwitcher.astro`, `CodeBlock.astro` | sync comments only |
-| `scripts/smoke.sh` | add bodies-endpoint check |
-| `package.json`, `pyproject.toml`, `uv.lock` | version bump 0.4.6 → 0.4.7 |
+| File                                                     | Change                                                                                          |
+| -------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `src/pages/api/circuits/[qec_id]/bodies.ts`              | new endpoint                                                                                    |
+| `src/lib/queries/circuits.ts`                            | add `getBodiesForCircuitByQecId`; `getCircuitsWithBodies` stays (still used by `/api/download`) |
+| `src/components/CircuitRow.astro`                        | remove FormatSwitcher/bodies, add placeholder                                                   |
+| `src/components/CircuitBodiesTemplate.astro`             | new template component                                                                          |
+| `src/lib/circuit-bodies-client.ts`                       | new client module                                                                               |
+| `src/pages/codes/[code].astro`                           | drop bodiesMap, render template, init client module                                             |
+| `src/components/FormatSwitcher.astro`, `CodeBlock.astro` | sync comments only                                                                              |
+| `scripts/smoke.sh`                                       | add bodies-endpoint check                                                                       |
+| `package.json`, `pyproject.toml`, `uv.lock`              | version bump 0.4.6 → 0.4.7                                                                      |
 
 ## Testing & verification
 

--- a/docs/superpowers/specs/2026-07-08-lazy-circuit-bodies-design.md
+++ b/docs/superpowers/specs/2026-07-08-lazy-circuit-bodies-design.md
@@ -1,0 +1,172 @@
+# Lazy-load circuit bodies on code pages — design
+
+**Date:** 2026-07-08
+**Status:** Approved
+
+## Problem
+
+Code pages (`/codes/[code]`) render every circuit's body in every format
+(STIM, QASM, Cirq) into the initial HTML, inside collapsed rows that most
+visitors never expand. Each body ships **twice**: once in the `<pre>` (with a
+line-number gutter) and once HTML-escaped in the copy button's `data-code`
+attribute. On top of that, each row carries ~13 kB of repeated static chrome
+(format tabs, copy/download buttons, SVG icons, kbd hints) × 3 CodeBlocks.
+
+Measured on `/codes/flag-gadgets` (354 circuits, 1000 bodies):
+
+| Metric | Value |
+| --- | --- |
+| HTML size | 15.2 MB (640 kB compressed in production) |
+| DOM nodes | 39,248 (~25× Lighthouse's "excessive DOM" threshold) |
+| `domInteractive` | ~334 ms on fast desktop; est. 1.5–3 s on mid-range mobile |
+
+## Goal
+
+Ship code pages without inline circuit bodies or per-row CodeBlock chrome.
+Target: ~1–2 MB HTML and ~9k DOM nodes on `flag-gadgets`, with no visible
+UX change beyond a brief "Loading circuit…" state on first expand.
+
+## Non-goals
+
+- Circuit detail pages (`/circuits/[qec_id]`) keep fully server-rendered
+  bodies — they are small (~93 kB) and carry the `SoftwareSourceCode`
+  JSON-LD for SEO. `CodeBlock.astro` is unchanged, including its `data-code`
+  attribute (harmless at ≤4 blocks per page).
+- No pagination/virtualization of circuit rows (re-evaluate if needed after
+  this lands).
+- No changes to `/api/download` (download-all zip is built server-side).
+
+## Design
+
+### 1. New API endpoint: `GET /api/circuits/[qec_id]/bodies`
+
+- File: `src/pages/api/circuits/[qec_id]/bodies.ts`, `prerender = false`.
+- Validates `qec_id` (positive integer), looks up the circuit, returns:
+
+  ```json
+  { "bodies": [{ "format": "stim", "body": "..." }, ...] }
+  ```
+
+- Bodies sorted in the existing preferred order (stim, qasm, cirq) by
+  reusing `getBodiesForCircuits` / `FORMAT_ORDER` from
+  `src/lib/queries/circuits.ts` (export a small
+  `getBodiesForCircuitByQecId(qecId)` helper there).
+- 404 when the circuit doesn't exist or has no bodies.
+- `Cache-Control: public, max-age=3600` — same as the sibling
+  `originals.ts` and `matrices.ts` endpoints. Safe because `qec_id` is
+  permanent and never reused; body edits between deploys tolerate ≤1 h of
+  browser-cache staleness.
+
+### 2. `CircuitRow.astro` — stop rendering bodies
+
+- Remove the `bodies` prop and the `<FormatSwitcher>` usage.
+- The detail panel keeps the server-rendered metadata block (ID, source,
+  tool, Crumble/Quirk links, notes) and gains a placeholder:
+
+  ```html
+  <div class="circuit-bodies" data-qec-id={...} data-stim-filename={...} data-source={...}>
+    <p class="circuit-bodies-status text-sm text-gray-400">Loading circuit…</p>
+  </div>
+  ```
+
+- `stimFilename` (already computed server-side per row) and `source` move
+  onto the placeholder as data attributes so the client can build download
+  names and cite notices without re-deriving them.
+- `codes/[code].astro` stops calling `getCircuitsWithBodies` and calls the
+  filter/sort query directly (no `bodiesMap`).
+
+### 3. Shared `<template>` for the switcher/CodeBlock skeleton
+
+- New component `CircuitBodiesTemplate.astro`, rendered **once** per code
+  page (from `codes/[code].astro`), containing a `<template
+  id="circuit-bodies-template">` with the FormatSwitcher + CodeBlock
+  markup skeleton: tab bar (with kbd hints), and one format-body block
+  (header with label, download button, copy button; empty `<pre><code>`).
+  The client clones the format-body block per format and the tab button
+  per format.
+- Markup is copied from `FormatSwitcher.astro` / `CodeBlock.astro`; both
+  files get a "keep in sync with CircuitBodiesTemplate.astro" comment (and
+  vice versa). This is the accepted trade-off of approach A.
+
+### 4. New client module: `src/lib/circuit-bodies-client.ts`
+
+Modeled on the `CodeMatrices` lazy-load script:
+
+- `initCircuitBodies({ containerSelector, templateId })` called from the
+  code page script.
+- Hooks the row-expand path via a custom event: `CircuitRow`'s existing
+  toggle handler dispatches `circuit-expand` on the `.circuit-detail`
+  element whenever it expands a row (same pattern as
+  `CollapsibleSection`'s `collapsible-open`). All expand entry points —
+  click, keyboard nav (which synthesizes a click), and `expandFromHash` —
+  flow through that handler, so one event covers them all.
+  `circuit-bodies-client` listens for it and calls
+  `loadBodies(placeholder)`.
+- `loadBodies`:
+  - WeakSet guard so each row fetches once; on fetch failure the guard is
+    released and the status text becomes
+    "Failed to load — collapse and expand to retry."
+  - Fetches `/api/circuits/${qecId}/bodies`, clones the template, fills:
+    - tab buttons per format (labels + `1`/`2`/`3` kbd hints, first active),
+      hidden entirely when only one format exists (matching current
+      `hasMultipleFormats` behavior);
+    - per-format `<pre><code>` with line-numbered text (same
+      gutter-padding logic as `CodeBlock.astro`: line numbers padded to
+      the width of the last line number, two-space separator);
+    - download names derived from `data-stim-filename` with the format
+      extension swapped (same rule as `FormatSwitcher.downloadNameFor`).
+  - Copy/download handlers read the **raw body from a JS map** (no
+    `data-code` attribute) and fire the existing cite-toast, mirroring
+    `CodeBlock`'s script behavior.
+  - Calls `initFormatSwitchers(clonedRoot)` (it already accepts a root)
+    to wire tab switching.
+  - Re-syncs the collapse animation: `detail.style.maxHeight =
+    detail.scrollHeight + "px"` after insertion (and the existing
+    format-switcher client already re-syncs on tab clicks).
+
+### 5. Keyboard shortcuts and existing behaviors
+
+- `circuit-actions-client` (keys `1/2/3`, `c`, `y`, `d`) targets elements
+  by class inside the expanded `.circuit-detail`; the cloned template uses
+  the same class names (`format-tab`, `copy-btn`, `download-btn`), so the
+  shortcuts work once bodies are loaded. Before the fetch resolves, the
+  keys are no-ops for that row (querySelector finds nothing) — acceptable
+  for a <100 ms window.
+- Hash permalinks (`/codes/foo#42`): `expandFromHash` clicks the toggle,
+  which triggers the same expand path and therefore the fetch.
+- Favorites filter, sorting, tag filtering, download-all: untouched.
+
+## Files touched
+
+| File | Change |
+| --- | --- |
+| `src/pages/api/circuits/[qec_id]/bodies.ts` | new endpoint |
+| `src/lib/queries/circuits.ts` | add `getBodiesForCircuitByQecId`; remove `getCircuitsWithBodies` (its only caller was `codes/[code].astro`) |
+| `src/components/CircuitRow.astro` | remove FormatSwitcher/bodies, add placeholder |
+| `src/components/CircuitBodiesTemplate.astro` | new template component |
+| `src/lib/circuit-bodies-client.ts` | new client module |
+| `src/pages/codes/[code].astro` | drop bodiesMap, render template, init client module |
+| `src/components/FormatSwitcher.astro`, `CodeBlock.astro` | sync comments only |
+| `scripts/smoke.sh` | add bodies-endpoint check |
+| `package.json`, `pyproject.toml`, `uv.lock` | version bump 0.4.6 → 0.4.7 |
+
+## Testing & verification
+
+1. `npm run lint`, `npm run format:check`, `npm run build`.
+2. `scripts/smoke.sh` against the dev server, including the new endpoint
+   check (fetch a real `qec_id` from `/api/circuits?ids=…`, assert JSON
+   shape).
+3. Browser verification on `/codes/flag-gadgets` and a small code page:
+   expand a row (bodies appear, tabs switch, copy + download work, cite
+   toast fires), keyboard shortcuts `1/2/3/c/d`, hash permalink
+   auto-expand, favorites filter, single-format circuits (no tab bar).
+4. Re-measure: HTML size and DOM nodes on `/codes/flag-gadgets` before vs
+   after (expect ~15 MB → ~1–2 MB, ~39k → ~9k nodes).
+
+## Rollout
+
+- Branch + PR per repo convention (no direct commits to `main`).
+- Commit: `feat(browse): lazy-load circuit bodies on code pages`.
+- Patch version bump (non-breaking, no schema change).
+- Follow-up (separate, config-only): Cloudflare Cache Rule to activate the
+  existing `s-maxage` headers — instructions to be provided at that point.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qecirc-website",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qecirc-website",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "license": "MIT",
       "dependencies": {
         "@astrojs/node": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qecirc-website",
   "type": "module",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "license": "MIT",
   "scripts": {
     "dev": "astro dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qecirc-website"
-version = "0.4.6"
+version = "0.4.7"
 description = "QECirc — quantum error correction circuit library"
 license = "MIT"
 requires-python = ">=3.13"

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -43,6 +43,7 @@ if [ -z "$qec_id" ]; then
 else
   check "/circuits/$qec_id"        "<title"
   check "/api/circuits?ids=$qec_id" "qec_id"
+  check "/api/circuits/$qec_id/bodies" '"format":"stim"'
 fi
 
 # Search query path

--- a/src/components/CircuitBodiesTemplate.astro
+++ b/src/components/CircuitBodiesTemplate.astro
@@ -1,0 +1,63 @@
+---
+// Markup skeleton cloned client-side by circuit-bodies-client.ts when a
+// circuit row is first expanded on a code page. Rendered once per code page.
+// KEEP THE TAB / CODE-BLOCK MARKUP IN SYNC with FormatSwitcher.astro and
+// CodeBlock.astro (server-rendered on circuit detail pages).
+import { TAB_INACTIVE_CLASS } from "../lib/constants";
+
+const TAB_BASE_CLASS =
+  "format-tab px-3 py-1.5 text-xs font-semibold rounded-md cursor-pointer transition-colors";
+---
+
+<template id="circuit-bodies-template">
+  <div class="format-switcher">
+    <div class="format-tabs flex gap-0.5 mb-2">
+      <button class={`${TAB_BASE_CLASS} ${TAB_INACTIVE_CLASS}`} data-format="">
+        <span class="tab-label"></span>
+        <kbd
+          class="ml-1.5 inline-block min-w-[1rem] text-center px-1 rounded border border-gray-300 dark:border-gray-700 bg-white/60 dark:bg-gray-900/60 text-[10px] text-gray-400 dark:text-gray-500 font-mono"
+        ></kbd>
+      </button>
+    </div>
+    <div class="format-body" data-format="">
+      <div
+        class="rounded border border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-900 overflow-hidden"
+        data-code-block
+      >
+        <div
+          class="border-b border-gray-200 dark:border-gray-800 px-4 py-2 text-xs text-gray-500 dark:text-gray-400 flex items-center justify-between"
+        >
+          <span class="block-label"></span>
+          <div class="flex items-center gap-3.5">
+            <button
+              class="download-btn flex items-center gap-1 text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 cursor-pointer"
+              aria-label="Download file"
+            >
+              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4M7 10l5 5 5-5M12 15V3" />
+              </svg>
+              <span>Download</span>
+              <kbd class="ml-0.5 inline-block min-w-[1rem] text-center px-1 rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-[10px] text-gray-400 dark:text-gray-500 font-mono">
+                d
+              </kbd>
+            </button>
+            <button
+              class="copy-btn flex items-center gap-1 text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 cursor-pointer"
+              aria-label="Copy to clipboard"
+              title="Copy to clipboard (c)"
+            >
+              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+              </svg>
+              <span class="copy-label">Copy</span>
+              <kbd class="ml-0.5 inline-block min-w-[1rem] text-center px-1 rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-[10px] text-gray-400 dark:text-gray-500 font-mono">
+                c
+              </kbd>
+            </button>
+          </div>
+        </div>
+        <pre class="overflow-x-auto p-4 text-sm leading-relaxed"><code></code></pre>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/CircuitRow.astro
+++ b/src/components/CircuitRow.astro
@@ -1,21 +1,19 @@
 ---
-import type { Circuit, CircuitBody, Tool } from "../types";
+import type { Circuit, Tool } from "../types";
 import { tagToggleUrl } from "../lib/url";
 import { formatCircuitId } from "../lib/queries";
 import { buildStimFilename } from "../lib/filename";
-import FormatSwitcher from "./FormatSwitcher.astro";
 import HeartIcon from "./HeartIcon.astro";
 import MetricBadge from "./MetricBadge.astro";
 
 interface Props {
   circuit: Circuit & { tags: string[] };
-  bodies: CircuitBody[];
   tool?: Tool;
   codeSlug: string;
   currentUrl: URL;
 }
 
-const { circuit, bodies, tool, codeSlug, currentUrl } = Astro.props;
+const { circuit, tool, codeSlug, currentUrl } = Astro.props;
 
 const existingTags = currentUrl.searchParams.getAll("tag");
 const basePath = `/codes/${codeSlug}`;
@@ -181,7 +179,14 @@ const stimFilename = buildStimFilename({
         </div>
       )}
 
-      <FormatSwitcher bodies={bodies} stimFilename={stimFilename} source={circuit.source} />
+      <div
+        class="circuit-bodies"
+        data-qec-id={anchorId}
+        data-stim-filename={stimFilename}
+        data-source={circuit.source}
+      >
+        <p class="circuit-bodies-status text-sm text-gray-400">Loading circuit&hellip;</p>
+      </div>
     </div>
   </div>
 </div>
@@ -229,6 +234,8 @@ const stimFilename = buildStimFilename({
           chevron.classList.add("rotate-90");
           btn.setAttribute("aria-expanded", "true");
           history.replaceState(null, "", "#" + qecId);
+          // Signal circuit-bodies-client (code pages) to lazy-load bodies.
+          detail.dispatchEvent(new CustomEvent("circuit-expand", { bubbles: true }));
 
           // Notes toggle: check overflow after first expand
           const notesText = detail.querySelector(".notes-text") as HTMLElement;

--- a/src/components/CodeBlock.astro
+++ b/src/components/CodeBlock.astro
@@ -6,6 +6,9 @@ interface Props {
   source?: string;
 }
 
+// KEEP THE CODE-BLOCK MARKUP IN SYNC with CircuitBodiesTemplate.astro, which
+// is cloned client-side on code pages (this component renders only on
+// circuit detail pages).
 const { code, label, downloadName, source } = Astro.props;
 const lines = code.trimEnd().split("\n");
 const lineCount = lines.length;

--- a/src/components/FormatSwitcher.astro
+++ b/src/components/FormatSwitcher.astro
@@ -3,6 +3,10 @@ import type { CircuitBody } from "../types";
 import { TAB_ACTIVE_CLASS, TAB_INACTIVE_CLASS } from "../lib/constants";
 import CodeBlock from "./CodeBlock.astro";
 
+// KEEP THE TAB MARKUP IN SYNC with CircuitBodiesTemplate.astro, which is
+// cloned client-side on code pages (this component renders only on circuit
+// detail pages).
+
 interface Props {
   bodies: CircuitBody[];
   stimFilename?: string;

--- a/src/lib/circuit-bodies-client.ts
+++ b/src/lib/circuit-bodies-client.ts
@@ -1,0 +1,176 @@
+// Lazy-loads circuit bodies on code pages. Circuit rows render without any
+// circuit text; on the first expand of a row (signalled by the
+// `circuit-expand` CustomEvent dispatched in CircuitRow.astro) this module
+// fetches /api/circuits/<qec_id>/bodies, clones #circuit-bodies-template and
+// fills in tabs + line-numbered bodies. Mirrors the CodeMatrices lazy-load
+// pattern: fetch-once guard, error text, retry on next expand.
+
+import { copyToClipboard } from "./dom-helpers";
+import { initFormatSwitchers } from "./format-switcher-client";
+import { TAB_ACTIVE_CLASS, TAB_INACTIVE_CLASS } from "./constants";
+
+interface BodyEntry {
+  format: string;
+  body: string;
+}
+
+// Keep in sync with FormatSwitcher.astro / format-switcher-client.ts.
+const TAB_BASE_CLASS =
+  "format-tab px-3 py-1.5 text-xs font-semibold rounded-md cursor-pointer transition-colors";
+
+const loaded = new WeakSet<HTMLElement>();
+
+/** Same line-number gutter format as CodeBlock.astro. */
+function lineNumbered(code: string): string {
+  const lines = code.trimEnd().split("\n");
+  const gutterWidth = String(lines.length).length;
+  return lines
+    .map((line, i) => `${String(i + 1).padStart(gutterWidth, " ")}  ${line}`)
+    .join("\n");
+}
+
+/** Same cite-toast behavior as CodeBlock.astro's copy/download handlers. */
+function citeNotice(source: string): void {
+  if (typeof window.showCiteToast !== "function") return;
+  if (source && source.startsWith("http")) {
+    window.showCiteToast("Please cite the source when using this circuit:", source);
+  } else if (source) {
+    window.showCiteToast("Please cite the source when using this circuit: " + source);
+  } else {
+    window.showCiteToast(
+      "Please check and cite the corresponding source when using this circuit.",
+    );
+  }
+}
+
+function buildSwitcher(
+  container: HTMLElement,
+  template: HTMLTemplateElement,
+  bodies: BodyEntry[],
+): void {
+  const fragment = template.content.cloneNode(true) as DocumentFragment;
+  const switcher = fragment.querySelector<HTMLElement>(".format-switcher");
+  const tabBar = switcher?.querySelector<HTMLElement>(".format-tabs");
+  const tabProto = tabBar?.querySelector<HTMLElement>(".format-tab");
+  const bodyProto = switcher?.querySelector<HTMLElement>(".format-body");
+  if (!switcher || !tabBar || !tabProto || !bodyProto) return;
+  tabProto.remove();
+  bodyProto.remove();
+
+  const stimFilename = container.dataset.stimFilename ?? "";
+  const source = container.dataset.source ?? "";
+
+  bodies.forEach(function (entry, i) {
+    const raw = entry.body.trimEnd();
+
+    const tab = tabProto.cloneNode(true) as HTMLElement;
+    tab.className = `${TAB_BASE_CLASS} ${i === 0 ? TAB_ACTIVE_CLASS : TAB_INACTIVE_CLASS}`;
+    tab.dataset.format = entry.format;
+    tab.title = `Switch to ${entry.format.toUpperCase()} (${i + 1})`;
+    const tabLabel = tab.querySelector<HTMLElement>(".tab-label");
+    if (tabLabel) tabLabel.textContent = entry.format.toUpperCase();
+    const kbd = tab.querySelector<HTMLElement>("kbd");
+    if (kbd) {
+      if (i < 3) kbd.textContent = String(i + 1);
+      else kbd.remove();
+    }
+    tabBar.appendChild(tab);
+
+    const bodyEl = bodyProto.cloneNode(true) as HTMLElement;
+    bodyEl.dataset.format = entry.format;
+    if (i !== 0) bodyEl.style.display = "none";
+    const blockLabel = bodyEl.querySelector<HTMLElement>(".block-label");
+    if (blockLabel) blockLabel.textContent = `${entry.format.toUpperCase()} Circuit`;
+    const codeEl = bodyEl.querySelector<HTMLElement>("pre code");
+    if (codeEl) codeEl.textContent = lineNumbered(entry.body);
+
+    const downloadBtn = bodyEl.querySelector<HTMLElement>(".download-btn");
+    if (downloadBtn) {
+      const downloadName = stimFilename
+        ? stimFilename.replace(/\.stim$/, `.${entry.format}`)
+        : "";
+      if (downloadName) {
+        downloadBtn.title = `Download ${downloadName} (d)`;
+        downloadBtn.addEventListener("click", function () {
+          const blob = new Blob([raw], { type: "text/plain" });
+          const url = URL.createObjectURL(blob);
+          const a = document.createElement("a");
+          a.href = url;
+          a.download = downloadName;
+          a.click();
+          URL.revokeObjectURL(url);
+          citeNotice(source);
+        });
+      } else {
+        downloadBtn.remove();
+      }
+    }
+
+    const copyBtn = bodyEl.querySelector<HTMLElement>(".copy-btn");
+    if (copyBtn) {
+      copyBtn.addEventListener("click", async function () {
+        const ok = await copyToClipboard(raw);
+        if (!ok) return;
+        const label = copyBtn.querySelector<HTMLElement>(".copy-label");
+        if (label) {
+          const original = label.textContent;
+          label.textContent = "Copied!";
+          setTimeout(function () {
+            label.textContent = original;
+          }, 1500);
+        }
+        citeNotice(source);
+      });
+    }
+
+    switcher.appendChild(bodyEl);
+  });
+
+  // Match FormatSwitcher.astro: no tab bar for single-format circuits.
+  if (bodies.length < 2) tabBar.remove();
+
+  container.replaceChildren(fragment);
+  initFormatSwitchers(container);
+}
+
+/** Re-sync the expand animation height after content changes. */
+function syncDetailHeight(container: HTMLElement): void {
+  const detail = container.closest<HTMLElement>(".circuit-detail");
+  if (detail && detail.style.maxHeight !== "0px") {
+    detail.style.maxHeight = detail.scrollHeight + "px";
+  }
+}
+
+async function loadBodies(
+  container: HTMLElement,
+  template: HTMLTemplateElement,
+): Promise<void> {
+  if (loaded.has(container)) return;
+  loaded.add(container);
+  const qecId = container.dataset.qecId;
+  if (!qecId) return;
+  try {
+    const res = await fetch(`/api/circuits/${qecId}/bodies`);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = (await res.json()) as { bodies: BodyEntry[] };
+    buildSwitcher(container, template, data.bodies);
+  } catch {
+    loaded.delete(container); // allow a fresh expand to retry
+    const status = container.querySelector<HTMLElement>(".circuit-bodies-status");
+    if (status) status.textContent = "Failed to load — collapse and expand to retry.";
+  }
+  syncDetailHeight(container);
+}
+
+export function initCircuitBodies(): void {
+  const template = document.getElementById(
+    "circuit-bodies-template",
+  ) as HTMLTemplateElement | null;
+  if (!template) return;
+
+  document.addEventListener("circuit-expand", function (e) {
+    const detail = e.target as HTMLElement;
+    const container = detail.querySelector<HTMLElement>(".circuit-bodies");
+    if (container) void loadBodies(container, template);
+  });
+}

--- a/src/lib/circuit-bodies-client.ts
+++ b/src/lib/circuit-bodies-client.ts
@@ -24,9 +24,7 @@ const loaded = new WeakSet<HTMLElement>();
 function lineNumbered(code: string): string {
   const lines = code.trimEnd().split("\n");
   const gutterWidth = String(lines.length).length;
-  return lines
-    .map((line, i) => `${String(i + 1).padStart(gutterWidth, " ")}  ${line}`)
-    .join("\n");
+  return lines.map((line, i) => `${String(i + 1).padStart(gutterWidth, " ")}  ${line}`).join("\n");
 }
 
 /** Same cite-toast behavior as CodeBlock.astro's copy/download handlers. */
@@ -37,9 +35,7 @@ function citeNotice(source: string): void {
   } else if (source) {
     window.showCiteToast("Please cite the source when using this circuit: " + source);
   } else {
-    window.showCiteToast(
-      "Please check and cite the corresponding source when using this circuit.",
-    );
+    window.showCiteToast("Please check and cite the corresponding source when using this circuit.");
   }
 }
 
@@ -86,9 +82,7 @@ function buildSwitcher(
 
     const downloadBtn = bodyEl.querySelector<HTMLElement>(".download-btn");
     if (downloadBtn) {
-      const downloadName = stimFilename
-        ? stimFilename.replace(/\.stim$/, `.${entry.format}`)
-        : "";
+      const downloadName = stimFilename ? stimFilename.replace(/\.stim$/, `.${entry.format}`) : "";
       if (downloadName) {
         downloadBtn.title = `Download ${downloadName} (d)`;
         downloadBtn.addEventListener("click", function () {
@@ -141,10 +135,7 @@ function syncDetailHeight(container: HTMLElement): void {
   }
 }
 
-async function loadBodies(
-  container: HTMLElement,
-  template: HTMLTemplateElement,
-): Promise<void> {
+async function loadBodies(container: HTMLElement, template: HTMLTemplateElement): Promise<void> {
   if (loaded.has(container)) return;
   loaded.add(container);
   const qecId = container.dataset.qecId;
@@ -163,9 +154,7 @@ async function loadBodies(
 }
 
 export function initCircuitBodies(): void {
-  const template = document.getElementById(
-    "circuit-bodies-template",
-  ) as HTMLTemplateElement | null;
+  const template = document.getElementById("circuit-bodies-template") as HTMLTemplateElement | null;
   if (!template) return;
 
   document.addEventListener("circuit-expand", function (e) {

--- a/src/lib/queries/circuits.ts
+++ b/src/lib/queries/circuits.ts
@@ -142,6 +142,17 @@ export function getBodiesForCircuits(circuitIds: number[]): Map<number, CircuitB
   return result;
 }
 
+/** Bodies for a single circuit looked up by its public qec_id, in preferred
+ * format order. Returns [] when the circuit doesn't exist. */
+export function getBodiesForCircuitByQecId(qecId: number): CircuitBody[] {
+  const db = getDb();
+  const row = db.prepare("SELECT id FROM circuits WHERE qec_id = ?").get(qecId) as
+    | { id: number }
+    | undefined;
+  if (!row) return [];
+  return getBodiesForCircuits([row.id]).get(row.id) ?? [];
+}
+
 export function getCircuitByQecId(
   qecId: number,
 ): (Circuit & { tags: string[]; code_slug: string; code_name: string }) | null {

--- a/src/lib/queries/circuits.ts
+++ b/src/lib/queries/circuits.ts
@@ -147,8 +147,7 @@ export function getBodiesForCircuits(circuitIds: number[]): Map<number, CircuitB
 export function getBodiesForCircuitByQecId(qecId: number): CircuitBody[] {
   const db = getDb();
   const row = db.prepare("SELECT id FROM circuits WHERE qec_id = ?").get(qecId) as
-    | { id: number }
-    | undefined;
+    { id: number } | undefined;
   if (!row) return [];
   return getBodiesForCircuits([row.id]).get(row.id) ?? [];
 }

--- a/src/lib/queries/index.ts
+++ b/src/lib/queries/index.ts
@@ -10,6 +10,7 @@ export {
   filterCircuitsForCode,
   getCircuitsWithBodies,
   getBodiesForCircuits,
+  getBodiesForCircuitByQecId,
   getCircuitByQecId,
   getCircuitsByQecIds,
   getAllCircuitQecIds,

--- a/src/pages/api/circuits/[qec_id]/bodies.ts
+++ b/src/pages/api/circuits/[qec_id]/bodies.ts
@@ -1,0 +1,25 @@
+export const prerender = false;
+
+import type { APIRoute } from "astro";
+import { getBodiesForCircuitByQecId } from "../../../../lib/queries";
+
+export const GET: APIRoute = ({ params }) => {
+  const qecId = Number(params.qec_id);
+  if (!Number.isInteger(qecId) || qecId < 1) {
+    return new Response("Invalid qec_id", { status: 400 });
+  }
+
+  const bodies = getBodiesForCircuitByQecId(qecId);
+  if (bodies.length === 0) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  return new Response(JSON.stringify({ bodies }), {
+    headers: {
+      "Content-Type": "application/json",
+      // qec_ids are permanent and never reused; body edits between deploys
+      // tolerate <=1h of browser-cache staleness (matches originals.ts).
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
+};

--- a/src/pages/codes/[code].astro
+++ b/src/pages/codes/[code].astro
@@ -5,6 +5,7 @@ import Layout from "../../components/Layout.astro";
 import TagList from "../../components/TagList.astro";
 import CircuitFilter from "../../components/CircuitFilter.astro";
 import CircuitRow from "../../components/CircuitRow.astro";
+import CircuitBodiesTemplate from "../../components/CircuitBodiesTemplate.astro";
 import CodeMatrices from "../../components/CodeMatrices.astro";
 import CollapsibleSection from "../../components/CollapsibleSection.astro";
 import HeartIcon from "../../components/HeartIcon.astro";
@@ -16,7 +17,8 @@ import {
   countCircuitsForCode,
   codeHasWeightedCircuits,
   getCircuitTagsForCode,
-  getCircuitsWithBodies,
+  getCircuitsForCode,
+  filterCircuitsForCode,
   getToolsForCircuits,
 } from "../../lib/queries";
 import { parseCircuitParams, circuitSortToggleUrl } from "../../lib/url";
@@ -41,7 +43,9 @@ const { raw, errors, tags: selectedTags, focus, filters, sort } = parseCircuitPa
 const hasFilters = hasActiveFilters(filters);
 const totalCount = countCircuitsForCode(code.id);
 const showWeight = codeHasWeightedCircuits(code.id);
-const { circuits, bodiesMap } = getCircuitsWithBodies(code.id, filters, sort);
+const circuits = hasFilters
+  ? filterCircuitsForCode(code.id, filters, sort)
+  : getCircuitsForCode(code.id, sort);
 const allCircuitTags = getCircuitTagsForCode(code.id);
 const toolsMap = getToolsForCircuits(circuits.map((c) => c.id));
 
@@ -227,11 +231,13 @@ const jsonLd = [
       </div>
       <div class="space-y-2">
         {circuits.map((circuit) => (
-          <CircuitRow circuit={circuit} bodies={bodiesMap.get(circuit.id) ?? []} tool={toolsMap.get(circuit.id)} codeSlug={codeSlug!} currentUrl={Astro.url} />
+          <CircuitRow circuit={circuit} tool={toolsMap.get(circuit.id)} codeSlug={codeSlug!} currentUrl={Astro.url} />
         ))}
       </div>
     </div>
   )}
+
+  <CircuitBodiesTemplate />
 </Layout>
 
 <script>
@@ -239,8 +245,10 @@ const jsonLd = [
   import { initListKeynav } from "../../lib/list-keynav-client";
   import { initCircuitActions } from "../../lib/circuit-actions-client";
   import { initBackKey } from "../../lib/back-key-client";
+  import { initCircuitBodies } from "../../lib/circuit-bodies-client";
 
   initBackKey("/");
+  initCircuitBodies();
 
   initListKeynav({
     rowSelector: "[data-list-row]",

--- a/uv.lock
+++ b/uv.lock
@@ -829,7 +829,7 @@ wheels = [
 
 [[package]]
 name = "qecirc-website"
-version = "0.4.6"
+version = "0.4.7"
 source = { virtual = "." }
 dependencies = [
     { name = "mqt-qecc" },


### PR DESCRIPTION
## Summary
- Code pages no longer embed every circuit body (STIM/QASM/Cirq — each shipped twice: `<pre>` + copy-button `data-code` attribute) in the initial HTML
- New `/api/circuits/[qec_id]/bodies` endpoint (mirrors `originals.ts`, `Cache-Control: max-age=3600`); bodies fetch on first row expand via a `circuit-expand` CustomEvent, following the CodeMatrices lazy-load pattern (fetch-once guard, error text, retry on re-expand)
- Measured on `/codes/flag-gadgets` (354 circuits): **15.2 MB → 3.1 MB** HTML, **39,248 → 20,247** DOM nodes, domInteractive 334 ms → 150 ms

## Not changed
- Circuit detail pages keep fully server-rendered bodies (SEO / `SoftwareSourceCode` JSON-LD)
- `getCircuitsWithBodies` stays (still used by `/api/download`)
- Download-all, favorites, sorting, filtering, keyboard shortcuts (`1/2/3/c/y/d`, Shift+D/F), hash permalinks — all verified working

## Test plan
- `scripts/smoke.sh` extended with the new endpoint check (+ 400/404 edge cases verified)
- Browser-verified: expand → lazy load, format tabs (click + keyboard), copy (raw body, no line numbers) + cite toast, download filename, no refetch on re-expand, hash auto-expand (`#<qec_id>`), single-format rendering (no tab bar), failure → retry path, circuit detail page unchanged
- `npm run lint`, `format:check`, `build`, `pytest` (167 passed), `ruff` all green
- Design doc: `docs/superpowers/specs/2026-07-08-lazy-circuit-bodies-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)