### PR TITLE
feat(cache): 7-day edge TTL + Cloudflare purge on deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ the source-of-truth `package.json` version.
 
 ### Added
 
+- Edge caching: `s-maxage` raised from 10 minutes to 7 days (pages and API),
+  paired with an automatic Cloudflare purge-everything on each deploy
+  (`src/lib/cache-purge.ts`, activated by the `CLOUDFLARE_ZONE_ID` /
+  `CLOUDFLARE_API_TOKEN` env vars; logged no-op without them).
+
 - Social-share card: static `og:image` / `twitter:image` (1200×630, generated
   by `scripts/icons/generate.mjs`) on all pages; Twitter card upgraded to
   `summary_large_image`.

--- a/docs/superpowers/specs/2026-07-08-long-edge-cache-purge-on-deploy-design.md
+++ b/docs/superpowers/specs/2026-07-08-long-edge-cache-purge-on-deploy-design.md
@@ -1,0 +1,94 @@
+# Long edge-cache TTL + Cloudflare purge on deploy — design
+
+**Date:** 2026-07-08
+**Status:** Approved (option C of the caching discussion)
+
+## Rationale
+
+The SQLite DB is built from YAML at build time; the running server never
+mutates it, so rendered output is immutable **between deploys**. Cloudflare
+caches per data center and traffic is sparse, so the current 10-minute
+`s-maxage` yields mostly cache misses. A long TTL plus an automatic
+purge-everything on each deploy gives warm edge caches worldwide with ~zero
+staleness.
+
+## Design
+
+### 1. Middleware TTL (`src/middleware.ts`)
+
+Both branches (pages and `/api/`) become the same header, so they collapse
+into one:
+
+```
+Cache-Control: public, max-age=0, s-maxage=604800, stale-while-revalidate=86400
+```
+
+- `s-maxage=604800` (7 days) — edge lifetime; correctness is guaranteed by
+  the purge-on-deploy, not by expiry.
+- `max-age=0` — browsers always revalidate (a purge can't reach browsers).
+- Existing skips unchanged: `/_` paths and responses that set their own
+  `Cache-Control`.
+
+### 2. Per-endpoint headers (`bodies.ts`, `originals.ts`, `matrices.ts`)
+
+`public, max-age=3600` → `public, max-age=3600, s-maxage=604800`.
+Browser behavior unchanged (1 h); edge lifetime extended to match the pages.
+
+### 3. Purge module (`src/lib/cache-purge.ts`), scheduled from middleware
+
+- `schedulePurgeOnBoot()` called at module top-level of `src/middleware.ts`,
+  i.e. once per server process start (each deploy starts a fresh process).
+- No-op unless both `CLOUDFLARE_ZONE_ID` and `CLOUDFLARE_API_TOKEN` env vars
+  are set (absent in local dev and CI).
+- Waits `CLOUDFLARE_PURGE_DELAY_SECONDS` (default 60) before purging, so the
+  purge lands **after** Railway has switched traffic to the new container —
+  otherwise a request racing the cutover could re-cache a page from the old
+  container for 7 days.
+- `POST {CLOUDFLARE_API_BASE|https://api.cloudflare.com}/client/v4/zones/{zone}/purge_cache`
+  with `{"purge_everything": true}`. `CLOUDFLARE_API_BASE` is overridable
+  for testing against a local mock.
+- Logs success/failure; never throws — a failed purge must not affect
+  serving. Multiple replicas/restarts each purge; harmless.
+
+### 4. Token management (operator setup, documented in module comment)
+
+- Cloudflare dashboard → My Profile → API Tokens → Create custom token with
+  the single permission **Zone → Cache Purge → Purge**, scoped to the
+  qecirc.com zone only. Worst case if leaked: someone can empty the cache
+  (nuisance, no data access).
+- Zone ID from the zone's Overview page sidebar.
+- Both values set as Railway service variables; never committed.
+
+## Non-goals
+
+- No purge CLI / npm script (the Cloudflare dashboard purge button covers
+  manual needs).
+- No per-URL selective purge (purge-everything is fine at this scale;
+  hashed static assets repopulate on first request).
+
+## Testing & verification
+
+- Dev server without env vars → single "purge skipped" log line, no request.
+- Dev server with env vars + `CLOUDFLARE_API_BASE` pointing at a local mock
+  and delay=1 → mock receives the POST with the right path/body/auth header.
+- Failure path: mock returns 500 → logged, server unaffected.
+- `lint`, `format:check`, `build`, `scripts/smoke.sh`.
+- Post-deploy (after operator sets the token): Railway logs show the purge
+  line; `cf-cache-status` flips to `MISS` right after a deploy, `HIT` on
+  repeat requests.
+
+## Rollout
+
+- Branch `feat/cloudflare-purge-on-deploy` off `main`; PR; patch bump
+  0.4.8 → 0.4.9.
+- The feature activates only when the operator adds the two Railway env
+  vars — merging without them changes edge TTL only after the operator has
+  the purge in place? **No** — see risk below.
+
+## Risk & ordering
+
+The TTL bump and the purge ship in the same PR, but the purge only works
+once the env vars exist. If the PR deploys before the vars are set, pages
+could be cached for up to 7 days with no purge to clear them. Mitigation:
+the operator sets the Railway variables **before** merging this PR (they
+are inert until the code arrives), making activation atomic.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qecirc-website",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qecirc-website",
-      "version": "0.4.8",
+      "version": "0.4.9",
       "license": "MIT",
       "dependencies": {
         "@astrojs/node": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qecirc-website",
   "type": "module",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "license": "MIT",
   "scripts": {
     "dev": "astro dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qecirc-website"
-version = "0.4.8"
+version = "0.4.9"
 description = "QECirc — quantum error correction circuit library"
 license = "MIT"
 requires-python = ">=3.13"

--- a/src/lib/cache-purge.ts
+++ b/src/lib/cache-purge.ts
@@ -1,0 +1,61 @@
+// Purges the Cloudflare edge cache once per server boot (= once per deploy,
+// since every deploy starts a fresh process). This is what makes the 7-day
+// `s-maxage` in src/middleware.ts safe: rendered output only changes at
+// deploy time (the SQLite DB is built from YAML during `npm run build`), so
+// long edge TTL + purge-on-deploy gives warm caches with ~zero staleness.
+//
+// Operator setup (values live as Railway service variables, never in the repo):
+//   CLOUDFLARE_ZONE_ID    — zone Overview page, right sidebar
+//   CLOUDFLARE_API_TOKEN  — custom API token with the single permission
+//                           "Zone → Cache Purge → Purge", scoped to this zone
+// Optional:
+//   CLOUDFLARE_PURGE_DELAY_SECONDS — default 60; the delay lets the purge land
+//     after the host has switched traffic to the new container, so a request
+//     racing the cutover can't re-cache a page from the old one.
+//   CLOUDFLARE_API_BASE — default https://api.cloudflare.com; override to
+//     point at a mock when testing.
+//
+// Without the two required vars (local dev, CI, forks) this is a logged no-op.
+
+const DEFAULT_DELAY_SECONDS = 60;
+
+async function purgeEverything(zoneId: string, token: string, apiBase: string): Promise<void> {
+  const url = `${apiBase}/client/v4/zones/${zoneId}/purge_cache`;
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ purge_everything: true }),
+    });
+    if (res.ok) {
+      console.log("[cache-purge] Cloudflare cache purged.");
+    } else {
+      const body = await res.text().catch(() => "");
+      console.error(`[cache-purge] purge failed: HTTP ${res.status} ${body.slice(0, 300)}`);
+    }
+  } catch (err) {
+    console.error("[cache-purge] purge failed:", err);
+  }
+}
+
+/** Schedule a one-shot purge-everything shortly after boot. Never throws. */
+export function schedulePurgeOnBoot(): void {
+  const zoneId = process.env.CLOUDFLARE_ZONE_ID;
+  const token = process.env.CLOUDFLARE_API_TOKEN;
+  if (!zoneId || !token) {
+    console.log("[cache-purge] CLOUDFLARE_ZONE_ID/CLOUDFLARE_API_TOKEN not set — purge skipped.");
+    return;
+  }
+  const apiBase = process.env.CLOUDFLARE_API_BASE || "https://api.cloudflare.com";
+  const delaySeconds =
+    Number(process.env.CLOUDFLARE_PURGE_DELAY_SECONDS) >= 0
+      ? Number(process.env.CLOUDFLARE_PURGE_DELAY_SECONDS)
+      : DEFAULT_DELAY_SECONDS;
+  console.log(`[cache-purge] purge scheduled in ${delaySeconds}s.`);
+  const timer = setTimeout(() => void purgeEverything(zoneId, token, apiBase), delaySeconds * 1000);
+  // Don't keep the process alive just for the purge (e.g. fast shutdowns).
+  timer.unref?.();
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,9 @@
 import { defineMiddleware } from "astro:middleware";
+import { schedulePurgeOnBoot } from "./lib/cache-purge";
+
+// Once per server process (= once per deploy): schedule the Cloudflare
+// purge that makes the long s-maxage below safe. See src/lib/cache-purge.ts.
+schedulePurgeOnBoot();
 
 export const onRequest = defineMiddleware(async (context, next) => {
   const response = await next();
@@ -7,17 +12,14 @@ export const onRequest = defineMiddleware(async (context, next) => {
   if (pathname.startsWith("/_")) return response;
   if (response.headers.has("Cache-Control")) return response;
 
-  if (pathname.startsWith("/api/")) {
-    response.headers.set(
-      "Cache-Control",
-      "public, max-age=0, s-maxage=3600, stale-while-revalidate=86400",
-    );
-  } else {
-    response.headers.set(
-      "Cache-Control",
-      "public, max-age=0, s-maxage=600, stale-while-revalidate=3600",
-    );
-  }
+  // Rendered output is immutable between deploys (the DB is baked at build
+  // time), so the edge may hold pages for a week; every deploy purges the
+  // Cloudflare cache on boot. Browsers always revalidate (max-age=0) since
+  // a purge can't reach them.
+  response.headers.set(
+    "Cache-Control",
+    "public, max-age=0, s-maxage=604800, stale-while-revalidate=86400",
+  );
 
   return response;
 });

--- a/src/pages/api/circuits/[qec_id]/bodies.ts
+++ b/src/pages/api/circuits/[qec_id]/bodies.ts
@@ -19,7 +19,8 @@ export const GET: APIRoute = ({ params }) => {
       "Content-Type": "application/json",
       // qec_ids are permanent and never reused; body edits between deploys
       // tolerate <=1h of browser-cache staleness (matches originals.ts).
-      "Cache-Control": "public, max-age=3600",
+      // Edge holds for a week — every deploy purges (src/lib/cache-purge.ts).
+      "Cache-Control": "public, max-age=3600, s-maxage=604800",
     },
   });
 };

--- a/src/pages/api/circuits/[qec_id]/originals.ts
+++ b/src/pages/api/circuits/[qec_id]/originals.ts
@@ -42,7 +42,8 @@ export const GET: APIRoute = ({ params }) => {
     {
       headers: {
         "Content-Type": "application/json",
-        "Cache-Control": "public, max-age=3600",
+        // Edge holds for a week — every deploy purges (src/lib/cache-purge.ts).
+        "Cache-Control": "public, max-age=3600, s-maxage=604800",
       },
     },
   );

--- a/src/pages/api/codes/[slug]/matrices.ts
+++ b/src/pages/api/codes/[slug]/matrices.ts
@@ -34,7 +34,8 @@ export const GET: APIRoute = ({ params }) => {
         "Content-Type": "application/json",
         // The page passes ?v=<canonical_hash> as a cache key; when matrices
         // change between deploys the hash changes and the browser refetches.
-        "Cache-Control": "public, max-age=3600",
+        // Edge holds for a week — every deploy purges (src/lib/cache-purge.ts).
+        "Cache-Control": "public, max-age=3600, s-maxage=604800",
       },
     },
   );

--- a/uv.lock
+++ b/uv.lock
@@ -829,7 +829,7 @@ wheels = [
 
 [[package]]
 name = "qecirc-website"
-version = "0.4.8"
+version = "0.4.9"
 source = { virtual = "." }
 dependencies = [
     { name = "mqt-qecc" },


### PR DESCRIPTION
## Summary
- Raises `s-maxage` from 10 min to 7 days on pages and API responses — safe because rendered output is immutable between deploys (the SQLite DB is baked from YAML at build time)
- New `src/lib/cache-purge.ts`, scheduled once per server boot from the middleware: purges the whole Cloudflare cache ~60 s after each deploy starts (delay lets the purge land after traffic cutover, so a racing request can't re-cache an old page)
- Activated by `CLOUDFLARE_ZONE_ID` + `CLOUDFLARE_API_TOKEN` env vars on Railway; **logged no-op without them** (local dev, CI, forks). Optional knobs: `CLOUDFLARE_PURGE_DELAY_SECONDS`, `CLOUDFLARE_API_BASE` (test override)
- Bodies/originals/matrices endpoints gain `s-maxage=604800` alongside their existing browser `max-age=3600`

## ⚠️ Merge order
Set the two Railway variables **before** merging — they are inert until this code deploys, but merging first would cache pages for up to 7 days with no purge in place. Token setup: Cloudflare custom API token with the single permission "Zone → Cache Purge → Purge", scoped to the qecirc.com zone.

## Test plan (all verified locally)
- Success path: mock Cloudflare API received `POST /client/v4/zones/<zone>/purge_cache` with Bearer auth and `{"purge_everything":true}`
- Failure path: unreachable API → error logged, server keeps serving 200
- No-op path: without env vars, single "purge skipped" log line, no request
- Headers verified: pages `public, max-age=0, s-maxage=604800, stale-while-revalidate=86400`; bodies `public, max-age=3600, s-maxage=604800`
- `lint`, `format:check`, `build`, `scripts/smoke.sh` all green
- Design doc: `docs/superpowers/specs/2026-07-08-long-edge-cache-purge-on-deploy-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)