### PR TITLE
fix(search): link circuit results to the circuit detail page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ the source-of-truth `package.json` version.
 
 ### Changed
 
+- Circuit results in the search dropdown now link to the circuit's own page
+  (`/circuits/<id>`) instead of the anchored code list.
 - Filtering and sorting on the codes index and code pages now run client-side
   over the rendered rows: filter changes apply instantly (no page reload) and
   every visit shares one canonical cached document. The URL contract is

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qecirc-website",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qecirc-website",
-      "version": "0.4.10",
+      "version": "0.4.11",
       "license": "MIT",
       "dependencies": {
         "@astrojs/node": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qecirc-website",
   "type": "module",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "license": "MIT",
   "scripts": {
     "dev": "astro dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qecirc-website"
-version = "0.4.10"
+version = "0.4.11"
 description = "QECirc — quantum error correction circuit library"
 license = "MIT"
 requires-python = ">=3.13"

--- a/src/pages/api/search.ts
+++ b/src/pages/api/search.ts
@@ -42,7 +42,7 @@ export const GET: APIRoute = ({ url }) => {
       .filter(Boolean)
       .join(", "),
     tags: ci.tags,
-    href: `/codes/${ci.code_slug}#${ci.qec_id}`,
+    href: `/circuits/${ci.qec_id}`,
     subtitle: ci.code_name,
   }));
 

--- a/uv.lock
+++ b/uv.lock
@@ -829,7 +829,7 @@ wheels = [
 
 [[package]]
 name = "qecirc-website"
-version = "0.4.10"
+version = "0.4.11"
 source = { virtual = "." }
 dependencies = [
     { name = "mqt-qecc" },


### PR DESCRIPTION
## Summary
- Circuit results in the search dropdown now navigate to the circuit's own page (`/circuits/<id>`, full bodies + matrices + source + JSON-LD) instead of `/codes/<slug>#<id>` (the anchored, expanded row in the code list)
- The detail page's existing breadcrumb links back to the code list, so the previous destination remains one click away
- Code and tool results unchanged

## Notes
- Search API responses are edge-cached; cached responses with old hrefs are flushed by the purge-on-deploy when this lands
- Version bump 0.4.11

## Test plan
- Verified in browser: search → click circuit result → lands on `/circuits/163`
- `/api/search?q=steane` returns `"href": "/circuits/91"` for circuit entries
- `lint`, `format:check`, `smoke.sh` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)