### PR TITLE
chore(robots): block Amazon's Amzn-SearchBot crawler

### DIFF
--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -11,6 +11,9 @@ Allow: /
 User-agent: Amazonbot
 Disallow: /
 
+User-agent: Amzn-SearchBot
+Disallow: /
+
 User-agent: Applebot-Extended
 Disallow: /
 


### PR DESCRIPTION
## What

Adds `User-agent: Amzn-SearchBot` → `Disallow: /` to the generated `robots.txt`.

## Why

Amazon's AI-search crawler identifies as the token **`Amzn-SearchBot`**, which is *distinct* from `Amazonbot`. Per the robots spec a bot only obeys a record whose token matches its own, so our existing `Amazonbot` disallow never applied to it — it fell through to `User-agent: *` (`Allow: /`) and was crawling `/tools` at a steady ~6 requests/minute from AWS `us-east-1` (verified bot, ASN 14618).

## Scope

- Only the `Amzn-SearchBot` token is added. Search/answer engines (Googlebot, Bing, Applebot, OAI-SearchBot, PerplexityBot, …) remain allowed via the default `*` record.
- `robots.txt` is cooperative: `Amzn-SearchBot` is a verified, well-behaved bot and honors `robots.txt`, so it should stop within a crawl cycle. If instant/enforced blocking is desired, a Cloudflare WAF rule on the UA/ASN can be added separately.

Verified locally: `GET /robots.txt` renders the new record in the correct position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)