### PR TITLE
fix(circuits): validate non-CSS circuits instead of skipping them

### DIFF
--- a/.claude/commands/add-circuit.md
+++ b/.claude/commands/add-circuit.md
@@ -107,6 +107,9 @@ result = validate_encoding(circuit_text, Hx, Hz)
 result = validate_state_prep(circuit_text, Hx, Hz)
 ```
 
+For a non-CSS code (no Hx/Hz split) pass the symplectic `h` instead:
+`validate_encoding_h(circuit_text, h, n)` / `validate_state_prep_h(circuit_text, h, n)`.
+
 If validation fails, report details and stop. Do not proceed with invalid circuits unless the user explicitly overrides.
 
 ### 2d. Dry-run preview

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,7 +248,7 @@ npm run lint                        # ESLint
 npm run format:check                # Check Prettier formatting
 npm run format                      # Auto-format with Prettier
 npm run validate:yaml               # Validate data_yaml/ schemas
-npm run validate:circuits           # Validate encoding/state-prep circuits against the code's check matrices (derived from h)
+npm run validate:circuits           # Validate encoding/state-prep circuits against the code's symplectic h (CSS and non-CSS alike)
 uv run ruff check scripts/          # Lint Python code
 uv run ruff format scripts/          # Format Python code
 npm run db:create                   # Build database from data_yaml/ (restart dev server after)

--- a/docs/adding-circuits.md
+++ b/docs/adding-circuits.md
@@ -92,6 +92,21 @@ print(validate_state_prep(circuit, Hx, Hz)) # 'passed' or 'failed: ...'
 
 Validation uses your provided Hx/Hz (same source as the circuit). If the code already exists in the library with a different qubit ordering, `add_circuit()` handles the relabeling separately.
 
+For a **non-CSS** code there is no Hx/Hz split; pass the symplectic `h` (shape
+`(m, 2n)`, X-half then Z-half — the form stored in `codes.h`) instead:
+
+```python
+from scripts.add_circuit import validate_encoding_h, validate_state_prep_h
+
+print(validate_encoding_h(circuit, h, n))    # 'passed' or 'failed: ...'
+print(validate_state_prep_h(circuit, h, n))  # 'passed' or 'failed: ...'
+```
+
+These are the general implementations — the Hx/Hz pair above is a thin wrapper —
+so CSS codes may use either. Both check each stabilizer up to **sign** (`|⟨S⟩| = 1`,
+not `⟨S⟩ = +1`): a sign-free binary `h` names a stabilizer group only up to a Pauli
+frame, so a circuit preparing a codeword in a different frame is still valid.
+
 ### Extract code from circuit (optional)
 
 If you have a circuit but no check matrices, you can derive Hx/Hz directly:
@@ -276,7 +291,7 @@ Hx, Hz = derive_matrices_self_dual(zero_circuit, n)
 Hx, Hz = derive_matrices_two_circuit(zero_circuit, plus_circuit, n)
 ```
 
-`n` is the number of **data** qubits; flag/ancilla qubits live at indices `≥ n` and are handled automatically (`strip_flags(circuit, n)` exposes the data-only sub-circuit if you need it). `logical_state_of(circuit, n, d, Hx=Hx, Hz=Hz)` reports which basis state the circuit prepares (`'zero'` / `'one'` / `'plus'` / `'minus'`), and `symplectic_validate(circuit, H, n)` checks the prepared state is a `+1` eigenstate of every stabilizer (the non-CSS counterpart of `validate_state_prep`).
+`n` is the number of **data** qubits; flag/ancilla qubits live at indices `≥ n` and are handled automatically (`strip_flags(circuit, n)` exposes the data-only sub-circuit if you need it). `logical_state_of(circuit, n, d, Hx=Hx, Hz=Hz)` reports which basis state the circuit prepares (`'zero'` / `'one'` / `'plus'` / `'minus'`), and `symplectic_validate(circuit, H, n)` checks the prepared state is a strict `+1` eigenstate of every stabilizer — use it when `H` is in a **known** sign frame (e.g. an importer's own matrices). Against a stored `codes.h`, whose frame is arbitrary, use the sign-tolerant `validate_state_prep_h` instead.
 
 ### Import
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qecirc-website",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qecirc-website",
-      "version": "0.4.14",
+      "version": "0.4.15",
       "license": "MIT",
       "dependencies": {
         "@astrojs/node": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qecirc-website",
   "type": "module",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "license": "MIT",
   "scripts": {
     "dev": "astro dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qecirc-website"
-version = "0.4.14"
+version = "0.4.15"
 description = "QECirc — quantum error correction circuit library"
 license = "MIT"
 requires-python = ">=3.13"

--- a/scripts/add_circuit/__init__.py
+++ b/scripts/add_circuit/__init__.py
@@ -29,7 +29,9 @@ import stim
 from .circuit_validate import (  # noqa: F401
     extract_code,
     validate_encoding,
+    validate_encoding_h,
     validate_state_prep,
+    validate_state_prep_h,
     validate_syndrome_extraction,
 )
 from .code_identify import gf2_row_basis
@@ -461,7 +463,9 @@ __all__ = [  # noqa: F822  (names defined above / re-exported)
     "preview_circuit",
     "summarize_circuit",
     "validate_encoding",
+    "validate_encoding_h",
     "validate_state_prep",
+    "validate_state_prep_h",
     "validate_syndrome_extraction",
     "extract_code",
     "ExtractedCode",

--- a/scripts/add_circuit/circuit_validate.py
+++ b/scripts/add_circuit/circuit_validate.py
@@ -16,6 +16,9 @@ from .models import CircuitProperties, ExtractedCode
 # Gate data for classification (computed once at module level)
 _ALL_GATES = stim.gate_data()
 
+# (x, z) bit pair from a symplectic row -> stim Pauli code (0=I, 1=X, 2=Y, 3=Z)
+_XZ_TO_PAULI = {(0, 0): 0, (1, 0): 1, (1, 1): 2, (0, 1): 3}
+
 
 def _is_entangling(name: str) -> bool:
     """True for genuinely-entangling two-qubit gates.
@@ -182,89 +185,176 @@ def _to_stim_circuit(circuit: Union[stim.Circuit, str]) -> stim.Circuit:
     return stim.Circuit(circuit)
 
 
-def _check_codespace_on_zero_input(circ: stim.Circuit, Hx: np.ndarray, Hz: np.ndarray) -> str:
-    """Simulate ``circ`` on ``|0...0>`` and check every code stabilizer is +1.
+def _widen(circ: stim.Circuit, n: int) -> stim.Circuit:
+    """Ensure ``circ`` declares at least ``n`` qubits.
+
+    ``num_qubits`` is the highest index stim *sees*, so a code whose last data
+    qubits are never touched yields a narrower circuit than the code it encodes.
+    Padding with an identity keeps those qubits addressable instead of making a
+    legitimate circuit look like a width mismatch.
+    """
+    if circ.num_qubits >= n:
+        return circ
+    return circ + stim.Circuit(f"I {n - 1}")
+
+
+def _row_to_pauli_string(row: np.ndarray, n: int, width: int) -> stim.PauliString:
+    """A symplectic row (X-half ``0..n-1`` | Z-half ``n..2n-1``) as a Pauli string.
+
+    ``width`` may exceed ``n``: flag / routing ancillas live at indices ``>= n``
+    and carry identity in a code stabilizer.
+    """
+    ps = stim.PauliString(width)
+    for i in range(n):
+        pauli = _XZ_TO_PAULI[(int(row[i]), int(row[i + n]))]
+        if pauli:
+            ps[i] = pauli
+    return ps
+
+
+def _css_to_h(Hx: np.ndarray, Hz: np.ndarray) -> tuple[np.ndarray, int]:
+    """Assemble CSS halves into a symplectic ``h``, returning ``(h, n)``.
+
+    Lets the CSS entry points share the general symplectic implementation rather
+    than keeping a parallel X/Z-specific one.
+    """
+    Hx = np.atleast_2d(np.asarray(Hx, dtype=int))
+    Hz = np.atleast_2d(np.asarray(Hz, dtype=int))
+    n = Hx.shape[1] if Hx.size else Hz.shape[1]
+    zx = np.zeros_like(Hx)
+    zz = np.zeros_like(Hz)
+    rows = []
+    if Hx.size:
+        rows.append(np.hstack([Hx, zx]))
+    if Hz.size:
+        rows.append(np.hstack([zz, Hz]))
+    if not rows:
+        return np.zeros((0, 2 * n), dtype=int), n
+    return np.vstack(rows), n
+
+
+def _check_codespace_on_zero_input(circ: stim.Circuit, h: np.ndarray, n: int) -> str:
+    """Simulate ``circ`` on ``|0...0>`` and check every stabilizer row of ``h``
+    fixes the output state, up to sign.
 
     Reset-tolerant: uses a ``TableauSimulator`` (which supports ``R``/``RX``)
     rather than ``to_tableau``, so it works for ancilla-initialising circuits.
-    Shared by :func:`validate_state_prep` and by :func:`validate_encoding`'s
+    Shared by :func:`validate_state_prep_h` and by :func:`validate_encoding_h`'s
     non-unitary fallback.
+
+    **Sign.** The test is ``|<S>| == 1``, not ``<S> == +1``. ``codes.h`` is a
+    sign-free binary matrix, so it names a stabilizer *group* only up to a choice
+    of signs: a circuit that prepares a codeword in a different Pauli frame
+    (``-YZIZY`` where the frame ``h`` was written in has ``+YZIZY``) encodes the
+    same code and must pass. Since the generators commute, ``|<S>| == 1`` on each
+    row means the state is a simultaneous eigenstate of all of them — i.e. it
+    lies in the codespace of *some* signing of ``h``, which is exactly as much as
+    a sign-free ``h`` can assert. Demanding ``+1`` would reject valid circuits.
+    ``logical_state_of`` is what pins down the frame when that actually matters.
 
     Returns 'passed' or 'failed: <reason>'.
     """
+    circ = _widen(circ, n)
     sim = stim.TableauSimulator()
     sim.do_circuit(circ)
-    n = Hx.shape[1]
+    width = max(circ.num_qubits, n)
 
-    for row in Hz:
-        ps = stim.PauliString(n)
-        for i, v in enumerate(row):
-            if v:
-                ps[i] = 3  # Z
-        if sim.peek_observable_expectation(ps) != 1:
-            return "failed: Z-stabilizer not satisfied"
-
-    for row in Hx:
-        ps = stim.PauliString(n)
-        for i, v in enumerate(row):
-            if v:
-                ps[i] = 1  # X
-        if sim.peek_observable_expectation(ps) != 1:
-            return "failed: X-stabilizer not satisfied"
+    for row in h:
+        ps = _row_to_pauli_string(row, n, width)
+        # 0 = not an eigenstate at all; ±1 = eigenstate in some Pauli frame.
+        if abs(sim.peek_observable_expectation(ps)) != 1:
+            return f"failed: stabilizer {ps} does not fix the prepared state"
 
     return "passed"
 
 
-def validate_encoding(circuit: Union[stim.Circuit, str], Hx: np.ndarray, Hz: np.ndarray) -> str:
-    """Verify encoding circuit maps |0...0> to the code space.
+def validate_encoding_h(circuit: Union[stim.Circuit, str], h: np.ndarray, n: int) -> str:
+    """Verify an encoding circuit maps |0...0> into the code space of ``h``.
+
+    ``h`` is the symplectic stabilizer matrix (shape ``(m, 2n)``, X-half then
+    Z-half) — the form stored in ``codes.h``. Works for CSS and non-CSS codes
+    alike; :func:`validate_encoding` is the CSS-shaped wrapper.
 
     An encoding circuit U should satisfy: for every stabilizer S of the code,
-    U^dag S U stabilizes |0...0> (only Z and I components, no X or Y).
+    U^dag S U stabilizes |0...0> (only Z and I components, no X or Y). That test
+    ignores sign by construction, matching the sign-free ``h`` — see
+    :func:`_check_codespace_on_zero_input`.
 
     Ancilla-initialising encoders contain reset instructions (``R``/``RX`` on
     the ancilla qubits) and so have no unitary tableau. For those we fall back
     to simulating on |0...0>: the encoder then prepares |0_L>, so every code
-    stabilizer must be a +1 eigenstate of the output — the same
-    ``|0...0> -> codespace`` property the unitary path checks, just evaluated by
-    simulation instead of by pulling the stabilizers back through U.
+    stabilizer must fix the output — the same ``|0...0> -> codespace`` property
+    the unitary path checks, just evaluated by simulation instead of by pulling
+    the stabilizers back through U.
 
     Returns 'passed' or 'failed: <reason>'.
     """
-    circ = _to_stim_circuit(circuit)
+    h = np.atleast_2d(np.asarray(h, dtype=int)) % 2
+    if h.size and h.shape[1] != 2 * n:
+        raise ValueError(f"Expected h with 2n={2 * n} columns, got {h.shape[1]}")
+
+    circ = _widen(_to_stim_circuit(circuit), n)
     try:
         tableau = circ.to_tableau()
     except ValueError:
         # Non-unitary (contains resets/measurements) — use the reset-tolerant
         # simulation check.
-        return _check_codespace_on_zero_input(circ, Hx, Hz)
+        return _check_codespace_on_zero_input(circ, h, n)
 
-    num_qubits = len(tableau)
+    width = len(tableau)
     inv = tableau.inverse()
 
-    for label, H, pauli_val in [("Z", Hz, 3), ("X", Hx, 1)]:
-        for row in H:
-            ps = stim.PauliString(num_qubits)
-            for i, v in enumerate(row):
-                if v:
-                    # stim Pauli encoding: 0=I, 1=X, 2=Y, 3=Z
-                    ps[i] = pauli_val
-            propagated = inv(ps)
-            for i in range(num_qubits):
-                if propagated[i] in (1, 2):  # X or Y -> doesn't stabilize |0>
-                    return f"failed: {label}-stabilizer does not stabilize input"
+    for row in h:
+        ps = _row_to_pauli_string(row, n, width)
+        propagated = inv(ps)
+        for i in range(width):
+            if propagated[i] in (1, 2):  # X or Y -> doesn't stabilize |0>
+                return f"failed: stabilizer {ps} does not stabilize input"
 
     return "passed"
 
 
-def validate_state_prep(circuit: Union[stim.Circuit, str], Hx: np.ndarray, Hz: np.ndarray) -> str:
-    """Verify state-prep circuit creates correct stabilizer state.
+def validate_state_prep_h(circuit: Union[stim.Circuit, str], h: np.ndarray, n: int) -> str:
+    """Verify a state-prep circuit creates a state in the code space of ``h``.
 
-    Simulates the circuit on |0...0> and checks that all stabilizer
-    generators have expectation value +1.
+    ``h`` is the symplectic stabilizer matrix (shape ``(m, 2n)``) — see
+    :func:`validate_encoding_h`. Works for CSS and non-CSS codes alike;
+    :func:`validate_state_prep` is the CSS-shaped wrapper.
+
+    Simulates the circuit on |0...0> and checks every stabilizer generator fixes
+    the result (eigenvalue ±1 — see :func:`_check_codespace_on_zero_input` on why
+    the sign is free). This says the output is *a* codeword; it does not say
+    which one — use ``logical_state_of`` for that.
 
     Returns 'passed' or 'failed: <reason>'.
     """
-    return _check_codespace_on_zero_input(_to_stim_circuit(circuit), Hx, Hz)
+    h = np.atleast_2d(np.asarray(h, dtype=int)) % 2
+    if h.size and h.shape[1] != 2 * n:
+        raise ValueError(f"Expected h with 2n={2 * n} columns, got {h.shape[1]}")
+    return _check_codespace_on_zero_input(_to_stim_circuit(circuit), h, n)
+
+
+def validate_encoding(circuit: Union[stim.Circuit, str], Hx: np.ndarray, Hz: np.ndarray) -> str:
+    """Verify encoding circuit maps |0...0> to the code space (CSS codes).
+
+    Thin wrapper over :func:`validate_encoding_h` for callers holding CSS halves.
+
+    Returns 'passed' or 'failed: <reason>'.
+    """
+    h, n = _css_to_h(Hx, Hz)
+    return validate_encoding_h(circuit, h, n)
+
+
+def validate_state_prep(circuit: Union[stim.Circuit, str], Hx: np.ndarray, Hz: np.ndarray) -> str:
+    """Verify state-prep circuit creates correct stabilizer state (CSS codes).
+
+    Thin wrapper over :func:`validate_state_prep_h` for callers holding CSS
+    halves.
+
+    Returns 'passed' or 'failed: <reason>'.
+    """
+    h, n = _css_to_h(Hx, Hz)
+    return validate_state_prep_h(circuit, h, n)
 
 
 def validate_syndrome_extraction(

--- a/scripts/add_circuit/state_prep.py
+++ b/scripts/add_circuit/state_prep.py
@@ -47,7 +47,7 @@ from typing import TYPE_CHECKING, Optional, Union
 import numpy as np
 import stim
 
-from .circuit_validate import _classify_generators, _propagate_z
+from .circuit_validate import _XZ_TO_PAULI, _classify_generators, _propagate_z
 from .code_identify import is_css
 
 if TYPE_CHECKING:
@@ -138,9 +138,6 @@ def derive_matrices_self_dual(
 # ---------------------------------------------------------------------------
 
 
-_XZ_TO_PAULI = {(0, 0): 0, (1, 0): 1, (1, 1): 2, (0, 1): 3}  # (x,z) -> stim pauli
-
-
 def _row_support(row: np.ndarray, n: int) -> list[tuple[int, int]]:
     """A symplectic row -> ``[(data-qubit role j, stim pauli)]`` over the ``n``
     data qubits, dropping identity positions."""
@@ -178,8 +175,15 @@ def _simulate(circuit: Union[str, stim.Circuit], n: int):
 
 def symplectic_validate(circuit: Union[str, stim.Circuit], H: np.ndarray, n: int) -> str:
     """Check every stabilizer row of a symplectic ``H`` (shape ``(m, 2n)``) is a
-    ``+1`` eigenvalue of the state the circuit prepares. Works for non-CSS codes
-    (the CSS-only counterpart is :func:`scripts.add_circuit.validate_state_prep`).
+    ``+1`` eigenvalue of the state the circuit prepares.
+
+    **Strict on sign**, which is the difference from
+    :func:`scripts.add_circuit.validate_state_prep_h`. Use this one only when
+    ``H`` comes with a known sign frame — an importer's own matrices, where a
+    ``-1`` really is a discrepancy worth failing on. A stored ``codes.h`` is
+    *not* such a matrix: canonicalization row-reduces it over GF(2), which
+    cannot preserve signs, so its frame is arbitrary and this check would reject
+    valid circuits. Validate against a stored ``h`` with ``validate_state_prep_h``.
 
     Row layout: columns ``0..n-1`` are the X-half, ``n..2n-1`` the Z-half. The
     circuit may act on more than ``n`` qubits (flag / routing ancillas at indices

--- a/scripts/tests/test_circuit_validate.py
+++ b/scripts/tests/test_circuit_validate.py
@@ -9,7 +9,9 @@ from scripts.add_circuit.circuit_validate import (
     circuit_properties,
     extract_code,
     validate_encoding,
+    validate_encoding_h,
     validate_state_prep,
+    validate_state_prep_h,
 )
 
 # ---------------------------------------------------------------------------
@@ -206,6 +208,111 @@ class TestValidateStatePrep:
         result = validate_state_prep("", Hx, Hz)
         # Empty circuit has no instructions, so TableauSimulator stays at |0>
         assert result == "passed"
+
+
+# ---------------------------------------------------------------------------
+# Symplectic (non-CSS-capable) validators
+# ---------------------------------------------------------------------------
+
+# The five-qubit perfect code: non-CSS, so it has no Hx/Hz split at all.
+FIVE_QUBIT_H = np.array(
+    [
+        [1, 0, 0, 0, 1, 1, 1, 0, 1, 1],
+        [0, 1, 0, 0, 1, 0, 0, 1, 1, 0],
+        [0, 0, 1, 0, 1, 1, 1, 0, 0, 0],
+        [0, 0, 0, 1, 1, 1, 0, 1, 1, 1],
+    ]
+)
+
+FIVE_QUBIT_ENCODER = """\
+S 4
+X 0
+S_DAG 1
+H 2
+Z 3
+H 4 0 1
+SWAP 4 0 1 3
+S_DAG 0
+SWAP 4 2
+H 3 1
+S_DAG 2 4
+S 3
+S_DAG 1
+H 3
+CZ 1 0
+H 0
+S_DAG 1
+CZ 3 4
+S 0
+S_DAG 4
+Y 3
+H 0
+S_DAG 3
+H 3
+CZ 2 0 3 1
+H 0
+S_DAG 2
+H 1 3
+CZ 2 4
+S_DAG 3
+CZ 3 0
+"""
+
+
+class TestSymplecticValidators:
+    def test_non_css_encoder_passes(self):
+        assert validate_encoding_h(FIVE_QUBIT_ENCODER, FIVE_QUBIT_H, 5) == "passed"
+
+    def test_non_css_bad_encoder_fails(self):
+        assert validate_encoding_h("I 0 1 2 3 4", FIVE_QUBIT_H, 5).startswith("failed:")
+
+    def test_non_css_state_prep_fails_on_product_state(self):
+        assert validate_state_prep_h("I 0 1 2 3 4", FIVE_QUBIT_H, 5).startswith("failed:")
+
+    def test_css_wrapper_agrees_with_symplectic(self):
+        # Steane via the CSS wrapper and via an explicitly assembled h.
+        zeros = np.zeros_like(STEANE_H)
+        h = np.vstack([np.hstack([STEANE_H, zeros]), np.hstack([zeros, STEANE_H])])
+        assert validate_encoding_h(STEANE_STIM, h, 7) == "passed"
+        assert validate_encoding(STEANE_STIM, STEANE_H, STEANE_H) == "passed"
+
+    def test_wrong_h_width_raises(self):
+        with pytest.raises(ValueError, match="columns"):
+            validate_encoding_h(FIVE_QUBIT_ENCODER, FIVE_QUBIT_H, 4)
+
+    def test_circuit_narrower_than_code_is_padded(self):
+        # stim sizes a circuit by its highest touched qubit, so an encoder that
+        # never touches the last data qubits is narrower than n. That must not
+        # be mistaken for a width mismatch.
+        h = np.array([[0, 0, 0, 1, 0, 0], [0, 0, 0, 0, 1, 0], [0, 0, 0, 0, 0, 1]])
+        assert validate_state_prep_h("I 0", h, 3) == "passed"
+
+
+class TestSignTolerance:
+    """``codes.h`` is sign-free, so a codeword prepared in a different Pauli
+    frame is still a valid preparation of the same code and must pass."""
+
+    def test_state_prep_accepts_negative_frame(self):
+        # |1> is stabilized by -Z; h names the sign-free row "Z".
+        h = np.array([[0, 1]])
+        assert validate_state_prep_h("X 0", h, 1) == "passed"
+
+    def test_state_prep_rejects_non_eigenstate(self):
+        # |+> is not a Z eigenstate at all: expectation 0, not ±1.
+        assert validate_state_prep_h("H 0", np.array([[0, 1]]), 1).startswith("failed:")
+
+    def test_encoding_accepts_negative_frame(self):
+        # Same for the reset-fallback path (X 0 after a reset -> -Z frame).
+        h = np.array([[0, 1]])
+        assert validate_encoding_h("R 0\nX 0", h, 1) == "passed"
+
+    def test_negative_frame_steane_state_prep(self):
+        # Flipping a data qubit of a Steane |0_L> prep lands in the codespace
+        # with some stabilizer signs flipped — still a codeword of the same code.
+        flipped = STEANE_STATE_PREP + "Z 0\n"
+        zeros = np.zeros_like(STEANE_H)
+        h = np.vstack([np.hstack([STEANE_H, zeros]), np.hstack([zeros, STEANE_H])])
+        assert validate_state_prep_h(flipped, h, 7) == "passed"
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_validate_circuits.py
+++ b/scripts/tests/test_validate_circuits.py
@@ -1,47 +1,150 @@
 """Tests for validate_circuits.py."""
 
+from pathlib import Path
+
 import yaml
 
 from scripts.validate_circuits import validate_all
 
+# The five-qubit perfect code: non-CSS (every stabilizer mixes X and Z, e.g.
+# YZIZY), so it has no Hx/Hz split and used to be skipped entirely.
+FIVE_QUBIT_CODE = {
+    "name": "Five-Qubit Perfect Code",
+    "n": 5,
+    "k": 1,
+    "d": 3,
+    "h": [
+        [1, 0, 0, 0, 1, 1, 1, 0, 1, 1],
+        [0, 1, 0, 0, 1, 0, 0, 1, 1, 0],
+        [0, 0, 1, 0, 1, 1, 1, 0, 0, 0],
+        [0, 0, 0, 1, 1, 1, 0, 1, 1, 1],
+    ],
+    "logical": [[1, 0, 1, 1, 0, 0, 0, 1, 1, 0], [0, 0, 1, 1, 0, 1, 0, 0, 0, 0]],
+    "canonical_hash": "sym:5:1:abc",
+}
 
-def test_skips_non_css_with_explanatory_message(tmp_path):
-    # Set up a minimal non-CSS code + tagged encoding circuit.
-    (tmp_path / "tools").mkdir()
-    (tmp_path / "codes").mkdir()
-    (tmp_path / "circuits").mkdir()
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_FIVE_QUBIT_ENCODER = (
+    _REPO_ROOT / "data_yaml/circuits/five-qubit-code--circuit-synth-encoding-depth-optimized.stim"
+).read_text()
 
-    code_yaml = {
-        "name": "Test Code",
-        "n": 5,
-        "k": 1,
-        "h": [[1, 0, 0, 0, 1, 1, 1, 0, 1, 1]],
-        "logical": [[1, 1, 1, 1, 1, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 1, 1, 1, 1, 1]],
-        "canonical_hash": "sym:5:1:abc",
-    }
-    (tmp_path / "codes" / "test-code.yaml").write_text(yaml.dump(code_yaml))
 
-    circ_yaml = {
-        "qec_id": 9999,
-        "name": "Stub",
-        "source": "test",
-        "tags": ["encoding"],
-    }
+def _build(tmp_path, stim_body, code=None, tags=("encoding",)):
+    """Lay out a minimal data_yaml tree with one code and one circuit."""
+    for sub in ("tools", "codes", "circuits"):
+        (tmp_path / sub).mkdir()
+    (tmp_path / "codes" / "test-code.yaml").write_text(yaml.dump(code or FIVE_QUBIT_CODE))
+    circ_yaml = {"qec_id": 9999, "name": "Stub", "source": "test", "tags": list(tags)}
     (tmp_path / "circuits" / "test-code--stub.yaml").write_text(yaml.dump(circ_yaml))
-    (tmp_path / "circuits" / "test-code--stub.stim").write_text("I 0 1 2 3 4")
+    (tmp_path / "circuits" / "test-code--stub.stim").write_text(stim_body)
+    return validate_all(data_dir=str(tmp_path))
 
-    results = validate_all(data_dir=str(tmp_path))
-    statuses = [c.status for r in results for c in r.checks]
-    assert "skipped" in statuses
+
+def _checks(results):
+    return {c.name: c for r in results for c in r.checks}
+
+
+def test_non_css_encoder_is_validated_and_passes(tmp_path):
+    """A correct non-CSS encoder must be checked, not skipped."""
+    results = _build(tmp_path, _FIVE_QUBIT_ENCODER)
+    checks = _checks(results)
+    assert checks["validate_encoding"].status == "passed"
+    assert checks["logical_input_count"].status == "passed"
+    assert results[0].passed is True
+    assert results[0].is_skipped is False
+
+
+def test_non_css_bad_encoder_fails(tmp_path):
+    """The gap this closes: an identity circuit does not encode the five-qubit
+    code, and must now be reported as failed rather than skipped."""
+    results = _build(tmp_path, "I 0 1 2 3 4")
+    checks = _checks(results)
+    assert checks["validate_encoding"].status == "failed"
+    assert results[0].is_skipped is False
+    assert results[0].passed is False
+
+
+def test_logical_input_count_catches_wrong_k(tmp_path):
+    """The #134 failure mode: a circuit whose implied logical-input count
+    disagrees with the code's k. Here the encoder is genuinely the five-qubit
+    code's, but the code claims k=2, so exactly one input goes unaccounted for."""
+    code = {**FIVE_QUBIT_CODE, "k": 2}
+    results = _build(tmp_path, _FIVE_QUBIT_ENCODER, code=code)
+    check = _checks(results)["logical_input_count"]
+    assert check.status == "failed"
+    assert "implies 1 logical inputs" in check.detail
+    assert "k=2" in check.detail
+
+
+def test_non_css_state_prep_is_validated(tmp_path):
+    """State-prep on a non-CSS code takes the same symplectic path."""
+    results = _build(tmp_path, "I 0 1 2 3 4", tags=("state-preparation",))
+    checks = _checks(results)
+    # |00000> is not a five-qubit codeword, so this must be a real verdict.
+    assert checks["validate_state_prep"].status == "failed"
+    assert "logical_input_count" not in checks  # encoder-only invariant
+
+
+# A [[3,2,1]] toy: qubit 2 is held at |0> by the lone stabilizer Z2, and qubits
+# 0-1 carry the two logical inputs. An encoder need never touch qubit 2, so stim
+# sizes it at 2 qubits — narrower than n = 3.
+NARROW_CODE = {
+    "name": "Narrow",
+    "n": 3,
+    "k": 2,
+    "d": 1,
+    "h": [[0, 0, 0, 0, 0, 1]],
+    "logical": [
+        [1, 0, 0, 0, 0, 0],
+        [0, 0, 0, 1, 0, 0],
+        [0, 1, 0, 0, 0, 0],
+        [0, 0, 0, 0, 1, 0],
+    ],
+    "canonical_hash": "x",
+}
+
+# The 3-qubit repetition code: k=1, stabilizers Z0Z1 and Z1Z2.
+REPETITION_CODE = {
+    "name": "Rep",
+    "n": 3,
+    "k": 1,
+    "d": 1,
+    "h": [[0, 0, 0, 1, 1, 0], [0, 0, 0, 0, 1, 1]],
+    "logical": [[0, 0, 0, 0, 0, 1], [1, 1, 1, 0, 0, 0]],
+    "canonical_hash": "x",
+}
+
+
+def test_encoder_narrower_than_code_still_checks_inputs(tmp_path):
+    """stim sizes a circuit by its highest touched qubit, so a valid encoder can
+    be narrower than n. That must not make logical_input_count silently skip —
+    silent skipping is the exact failure this check exists to prevent."""
+    results = _build(tmp_path, "CX 0 1", code=NARROW_CODE)  # num_qubits = 2 < n = 3
+    check = _checks(results)["logical_input_count"]
+    assert check.status != "skipped", check.detail
+    assert check.status == "passed"
+
+
+def test_logical_input_count_catches_what_codespace_check_cannot(tmp_path):
+    """An all-Z stabilizer group stabilizes |0...0> no matter what the circuit
+    does, so the codespace check passes any CNOT circuit on the repetition code.
+    Only the input-count invariant notices the encoder is incomplete."""
+    # A correct encoder is CX 0 1 + CX 0 2; this one leaves qubit 2 unentangled.
+    results = _build(tmp_path, "CX 0 1", code=REPETITION_CODE)
+    checks = _checks(results)
+    assert checks["validate_encoding"].status == "passed"  # blind to this
+    assert checks["logical_input_count"].status == "failed"
+    assert "implies 2 logical inputs" in checks["logical_input_count"].detail
+    assert results[0].passed is False
 
 
 def test_all_skipped_checks_count_as_skipped_not_failed():
-    """A circuit whose only check is 'skipped' (e.g. a non-CSS code) must report
-    is_skipped=True and passed=False, so the summary counts it as skipped."""
+    """A circuit whose only check is 'skipped' must report is_skipped=True and
+    passed=False, so the summary counts it as skipped rather than a failure."""
     from scripts.validate_circuits import CheckResult, CircuitResult
 
     r = CircuitResult(stem="x--y", circuit_type="state-preparation")
-    r.checks.append(CheckResult("load_code", "skipped", "non-CSS validation not yet supported"))
+    r.checks.append(CheckResult("load_code", "skipped", "not derivable"))
     assert r.is_skipped is True
     assert r.passed is False
 

--- a/scripts/validate_circuits.py
+++ b/scripts/validate_circuits.py
@@ -2,10 +2,12 @@
 Validate encoding and state-prep circuits against stored code check matrices.
 
 Iterates over all circuit YAML files in data_yaml/circuits/, identifies encoding
-and state-preparation circuits (via tags), and verifies correctness:
+and state-preparation circuits (via tags), and verifies correctness against the
+code's symplectic ``h`` — CSS and non-CSS codes alike:
 
-  - Encoding: validate_encoding (circuit maps |0...0⟩ to the code space)
-  - State-prep: validate_state_prep (all stabilizers satisfied)
+  - Encoding: validate_encoding_h (circuit maps |0...0⟩ to the code space)
+            + logical_input_count (the encoder has exactly k free inputs)
+  - State-prep: validate_state_prep_h (all stabilizers satisfied)
 
 Usage:
     uv run python scripts/validate_circuits.py
@@ -23,13 +25,15 @@ if _PROJECT_ROOT not in sys.path:
     sys.path.insert(0, _PROJECT_ROOT)
 
 import numpy as np  # noqa: E402
+import stim  # noqa: E402
 import yaml  # noqa: E402
 
+from scripts.add_circuit.annotate import logical_input_qubits  # noqa: E402
 from scripts.add_circuit.circuit_validate import (  # noqa: E402
-    validate_encoding,
-    validate_state_prep,
+    _widen,
+    validate_encoding_h,
+    validate_state_prep_h,
 )
-from scripts.add_circuit.code_identify import split_h_to_css  # noqa: E402
 
 
 @dataclass
@@ -56,9 +60,10 @@ class CircuitResult:
 
     @property
     def is_skipped(self) -> bool:
-        # Skipped = no runnable validation for this circuit: either it lacks a
-        # functionality tag, or every check was skipped (e.g. non-CSS codes,
-        # which have no CSS validator yet). These must not count as failures.
+        # Skipped = no runnable validation for this circuit: it lacks a
+        # functionality tag, or every check was skipped. These must not count as
+        # failures. Note the validators themselves no longer skip on non-CSS
+        # codes — they check the symplectic h directly.
         return self.circuit_type == "skipped" or (
             bool(self.checks) and all(c.status == "skipped" for c in self.checks)
         )
@@ -99,8 +104,8 @@ def validate_all(data_dir: str = "data_yaml") -> list[CircuitResult]:
 
         code_data = yaml.safe_load(code_yaml_path.read_text())
 
-        # CSS path is required for the existing validators. Recover Hx/Hz from
-        # the symplectic h when it is row-CSS decomposable; otherwise skip.
+        # The validators check the symplectic h directly, so no CSS split is
+        # needed — non-CSS codes take the same path as CSS ones.
         if code_data.get("h") is None:
             result.checks.append(CheckResult("load_code", "error", "Code YAML missing h"))
             results.append(result)
@@ -112,20 +117,7 @@ def validate_all(data_dir: str = "data_yaml") -> list[CircuitResult]:
             results.append(result)
             continue
 
-        css_split = split_h_to_css(np.array(code_data["h"], dtype=int), n)
-        if css_split is None:
-            result.checks.append(
-                CheckResult(
-                    "load_code",
-                    "skipped",
-                    "non-CSS validation not yet supported "
-                    "(only encoding/state-prep validators for CSS)",
-                )
-            )
-            results.append(result)
-            continue
-
-        Hx, Hz = css_split
+        h = np.array(code_data["h"], dtype=int)
 
         # Load STIM body
         stim_path = circ_yaml_path.with_suffix(".stim")
@@ -140,23 +132,19 @@ def validate_all(data_dir: str = "data_yaml") -> list[CircuitResult]:
 
         # Run checks
         if circuit_type == "encoding":
-            _check_encoding(result, circuit_text, Hx, Hz)
+            _check_encoding(result, circuit_text, h, n)
+            _check_logical_input_count(result, circuit_text, h, n, code_data.get("k"))
         elif circuit_type == "state-preparation":
-            _check_state_prep(result, circuit_text, Hx, Hz)
+            _check_state_prep(result, circuit_text, h, n)
 
         results.append(result)
 
     return results
 
 
-def _check_encoding(
-    result: CircuitResult,
-    circuit_text: str,
-    Hx: np.ndarray,
-    Hz: np.ndarray,
-) -> None:
+def _check_encoding(result: CircuitResult, circuit_text: str, h: np.ndarray, n: int) -> None:
     try:
-        outcome = validate_encoding(circuit_text, Hx, Hz)
+        outcome = validate_encoding_h(circuit_text, h, n)
         if outcome == "passed":
             result.checks.append(CheckResult("validate_encoding", "passed"))
         else:
@@ -165,20 +153,63 @@ def _check_encoding(
         result.checks.append(CheckResult("validate_encoding", "error", str(e)))
 
 
-def _check_state_prep(
-    result: CircuitResult,
-    circuit_text: str,
-    Hx: np.ndarray,
-    Hz: np.ndarray,
-) -> None:
+def _check_state_prep(result: CircuitResult, circuit_text: str, h: np.ndarray, n: int) -> None:
     try:
-        outcome = validate_state_prep(circuit_text, Hx, Hz)
+        outcome = validate_state_prep_h(circuit_text, h, n)
         if outcome == "passed":
             result.checks.append(CheckResult("validate_state_prep", "passed"))
         else:
             result.checks.append(CheckResult("validate_state_prep", "failed", outcome))
     except Exception as e:
         result.checks.append(CheckResult("validate_state_prep", "error", str(e)))
+
+
+def _check_logical_input_count(
+    result: CircuitResult,
+    circuit_text: str,
+    h: np.ndarray,
+    n: int,
+    k: int | None,
+) -> None:
+    """An encoder must expose exactly k free logical inputs.
+
+    Basis-independent, and complementary to the codespace check: it looks at the
+    encoder's *inputs* rather than its output on |0...0>, so it catches circuits
+    that land in a valid codespace but of the wrong code. That is exactly how the
+    Gottesman [[8,3,3]] gate-optimized encoder (#134) was caught — it implied 7
+    logical inputs where k=3.
+    """
+    if k is None:
+        result.checks.append(CheckResult("logical_input_count", "error", "Code YAML missing k"))
+        return
+    try:
+        # Widen to n first, as the codespace check does: an encoder that never
+        # touches its last data qubits is narrower than the code, and
+        # logical_input_qubits reports a width mismatch as "not derivable" —
+        # i.e. it would silently skip rather than check.
+        circ = _widen(stim.Circuit(circuit_text), n)
+        inputs = logical_input_qubits(circ, h, n)
+        if inputs is None:
+            result.checks.append(
+                CheckResult(
+                    "logical_input_count",
+                    "skipped",
+                    "inputs not derivable (no tableau and no resets)",
+                )
+            )
+        elif len(inputs) != k:
+            result.checks.append(
+                CheckResult(
+                    "logical_input_count",
+                    "failed",
+                    f"failed: circuit implies {len(inputs)} logical inputs {inputs}, "
+                    f"but the code has k={k}",
+                )
+            )
+        else:
+            result.checks.append(CheckResult("logical_input_count", "passed"))
+    except Exception as e:
+        result.checks.append(CheckResult("logical_input_count", "error", str(e)))
 
 
 def print_results(results: list[CircuitResult]) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -829,7 +829,7 @@ wheels = [
 
 [[package]]
 name = "qecirc-website"
-version = "0.4.14"
+version = "0.4.15"
 source = { virtual = "." }
 dependencies = [
     { name = "mqt-qecc" },


### PR DESCRIPTION
## Problem

`npm run validate:circuits` silently skipped every circuit on a non-CSS code.

`validate_circuits.py` obtained `Hx`/`Hz` from `split_h_to_css(h, n)`, which returns `None` for a non-CSS code — so the circuit was reported `SKIPPED` rather than checked. **61 circuits were never validated at all**: the five-qubit code (54) and the Gottesman [[8,3,3]] code (7).

This wasn't hypothetical. It hid a genuinely broken circuit: the Gottesman [[8,3,3]] gate-optimized encoder (#134) did not encode the code it was filed under — 2 of its 5 stored stabilizers came out random on the `|0...0>` run. It was only caught because the #108 detector work derives encoder inputs in a basis-independent way. That circuit is gone; the gap that let it sit there was not.

## Fix

The check never needed the CSS split. `validate_encoding_h` / `validate_state_prep_h` take the symplectic `h` directly and handle CSS and non-CSS alike. The existing `validate_encoding(circuit, Hx, Hz)` entry points remain as thin wrappers, so docs and `/add-circuit` are unaffected.

**Stabilizers are checked up to sign** (`|<S>| == 1`, not `<S> == +1`). `codes.h` is canonicalized by GF(2) row reduction, which cannot preserve signs — its Pauli frame is arbitrary by construction, so a sign-sensitive test against it is meaningless. This is load-bearing, not theoretical: all 7 Gottesman circuits sit in a **negative** frame, and a strict `+1` check false-fails its 4 state-preps. I confirmed those 4 are genuine codewords (each prepares a rank-8 = n stabilizer state whose group contains `h`'s row space). The unitary encoding path already ignored sign, so this also removes a real inconsistency between the two paths.

**New encoder invariant.** Propagating `Z_q` through the tableau must leave exactly `k` of the `n` single-qubit `Z` operators outside the stabilizer row space (`logical_input_qubits`). It's basis-independent and catches what the codespace check structurally cannot: an all-Z stabilizer group stabilizes `|0...0>` no matter how the circuit is wired, so the codespace check passes *any* CNOT circuit on a repetition code. Both are regression-tested.

## Verification

Restoring #134 from history, both new checks catch it:

```
validate_encoding:    failed: stabilizer +_ZXY_ZXY does not stabilize input
logical_input_count:  failed: circuit implies 7 logical inputs [1..7], but the code has k=3
```

Library-wide `validate:circuits`, before → after:

| | before | after |
|---|---|---|
| checked | 418 | **479** (+61) |
| passed | 418 | **479** |
| failed | 0 | **0** |
| skipped | 415 | 354 |

All 68 encoders also pass the new `logical_input_count` check, with zero skips. No new failures fell out of the rest of the library. 242 Python tests pass; `validate:yaml`, ESLint, ruff, and Prettier are clean.

## Notes for review

- **The sign relaxation is the one judgment call worth a second opinion.** It means an appended Pauli error on a state-prep no longer trips `validate_state_prep`. It costs nothing today (every existing circuit was already in the `+1` frame — no verdict changed), and stabilizers can't distinguish `|0_L>` from `|1_L>` regardless. If we want that detection power back, the place for it is a `logical_state_of` check on state-preps, mirroring `logical_input_count` for encoders. Happy to add it here or separately.
- `symplectic_validate` in `state_prep.py` stays **strict** on sign: its caller (`data-imports/mqt-ftsp`) validates against the importer's own matrices, where a `-1` is a real discrepancy. Its docstring now says when to use which.
- Version bumped 0.4.14 → 0.4.15 (patch: additive API, wrappers preserved, no YAML schema or DB migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)