### PR TITLE
docs: link Luis Colmenarez's GitHub account in the contributor lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The project is funded by the [Unitary Foundation](https://unitary.foundation) an
      the unlinked names. Mirror any change here in src/lib/contributors.ts, which
      the About page renders and the landing page counts. -->
 
-[Ludwig Schmid](https://github.com/lsschmid), [Tom Peham](https://github.com/pehamTom), [Remmy Zen](https://github.com/remmyzen), [Maxie Helen Bichmann](https://github.com/MaxieHelenBichmann), [Diego Forlivesi](https://github.com/DiegoForlivesi), [David Amaro](https://github.com/davamaro), Luis Colmenarez
+[Ludwig Schmid](https://github.com/lsschmid), [Tom Peham](https://github.com/pehamTom), [Remmy Zen](https://github.com/remmyzen), [Maxie Helen Bichmann](https://github.com/MaxieHelenBichmann), [Diego Forlivesi](https://github.com/DiegoForlivesi), [David Amaro](https://github.com/davamaro), [Luis Colmenarez](https://github.com/luis2colmena)
 
 ## Quick Start
 

--- a/src/lib/contributors.ts
+++ b/src/lib/contributors.ts
@@ -22,5 +22,5 @@ export const CONTRIBUTORS: readonly Contributor[] = [
   { name: "Maxie Helen Bichmann", github: "MaxieHelenBichmann" },
   { name: "Diego Forlivesi", github: "DiegoForlivesi" },
   { name: "David Amaro", github: "davamaro" },
-  { name: "Luis Colmenarez" },
+  { name: "Luis Colmenarez", github: "luis2colmena" },
 ];


### PR DESCRIPTION
Luis was listed unlinked in the contributor lists because he had no GitHub account when the surface code unitary Pauli-state encodings landed (#106, #110). He has since shared one: [@luis2colmena](https://github.com/luis2colmena).

## What changed

- `src/lib/contributors.ts` — his entry gains `github: "luis2colmena"`, so the About page and landing-page count render him linked like everyone else.
- `README.md` — the mirrored list links his name.

## Getting him into the contributors graph

The profile links above are only display. What actually credits Luis in GitHub's contributors graph is the `Co-authored-by` trailer on this PR's commit, since he has no commits of his own:

    Co-authored-by: Luis Colmenarez <68283580+luis2colmena@users.noreply.github.com>

The address is his account's GitHub-provided noreply address (user id `68283580`), which is what GitHub matches on.

> [!IMPORTANT]
> **Please keep the `Co-authored-by` trailer in the squash-merge message.** GitHub carries it over by default, but if it gets edited out of the squash body, the attribution is lost and Luis will not appear in the contributors graph.

Attributing him on the original circuit commits (#106, #110) was not an option — those are already on `main`, and rewriting them would mean a force-push of public history. A fresh commit gets him into the graph just as well.

## Note on the retained comment

The "people who helped without committing and so have no GitHub link (listed unlinked)" note stays in both files. No one in the list is unlinked now, but that note is the maintenance policy for the list, not a statement about Luis — removing it would re-open the regenerate-from-the-API footgun that #110 deliberately closed.

## Verification

`astro build` from a clean worktree off `main`; the built `about/index.html` renders all seven contributors as links, with Luis pointing at `https://github.com/luis2colmena`. Prettier and ESLint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)