### PR TITLE
fix(browse): correct the filter bar status area

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qecirc-website",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qecirc-website",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "MIT",
       "dependencies": {
         "@astrojs/node": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qecirc-website",
   "type": "module",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "license": "MIT",
   "scripts": {
     "dev": "astro dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qecirc-website"
-version = "0.5.1"
+version = "0.5.2"
 description = "QECirc — quantum error correction circuit library"
 license = "MIT"
 requires-python = ">=3.13"

--- a/src/components/CircuitFilter.astro
+++ b/src/components/CircuitFilter.astro
@@ -2,6 +2,7 @@
 import type { TagWithCount, CircuitSortField } from "../types";
 import { TAG_CATEGORIES, categorizeTag } from "../lib/tag-categories";
 import TagFilterDropdowns from "./TagFilterDropdowns.astro";
+import FilterStatus from "./FilterStatus.astro";
 
 // Filtering/sorting runs client-side (list-filter-client.ts, initialised by
 // the page). Inputs render empty and sort labels render the default state;
@@ -62,20 +63,7 @@ const tagGroups = TAG_CATEGORIES.map((c) => ({
         </div>
       );
     })}
-    <div class="text-xs" data-filter-status>
-      <span data-filter-error class="text-red-500 hidden">Invalid filter</span>
-      <a
-        href={basePath}
-        data-clear-filters
-        class="hidden inline-flex items-center gap-1 font-medium text-amber-600 dark:text-amber-400 hover:text-amber-800 dark:hover:text-amber-200"
-        title="Clear all active filters"
-      >
-        <svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-          <path d="M6 18L18 6M6 6l12 12" />
-        </svg>
-        Clear filters
-      </a>
-    </div>
+    <FilterStatus basePath={basePath} />
   </div>
 
   <TagFilterDropdowns

--- a/src/components/CircuitFilter.astro
+++ b/src/components/CircuitFilter.astro
@@ -34,14 +34,16 @@ function labelInfo(field: CircuitSortField) {
 
 const sortHref = (field: CircuitSortField) => `${basePath}?sort=${field}&sort_dir=asc`;
 
-const FIELDS: { field: CircuitSortField; label: string; placeholder: string; aria: string }[] = [
-  { field: "gate_count", label: "Gates", placeholder: ">10", aria: "Filter by gate count" },
-  { field: "two_qubit_gate_count", label: "2Q Gates", placeholder: ">5", aria: "Filter by two-qubit gate count" },
-  { field: "depth", label: "Depth", placeholder: "<=5", aria: "Filter by depth" },
-  { field: "qubit_count", label: "Qubits", placeholder: "7", aria: "Filter by qubit count" },
+// Inputs render with no placeholder: the examples live in FilterStatus, beside
+// the boxes rather than inside them.
+const FIELDS: { field: CircuitSortField; label: string; aria: string }[] = [
+  { field: "gate_count", label: "Gates", aria: "Filter by gate count" },
+  { field: "two_qubit_gate_count", label: "2Q Gates", aria: "Filter by two-qubit gate count" },
+  { field: "depth", label: "Depth", aria: "Filter by depth" },
+  { field: "qubit_count", label: "Qubits", aria: "Filter by qubit count" },
 ];
 if (showWeight) {
-  FIELDS.push({ field: "weight", label: "Weight", placeholder: "<=8", aria: "Filter by stabiliser weight" });
+  FIELDS.push({ field: "weight", label: "Weight", aria: "Filter by stabiliser weight" });
 }
 
 const tagGroups = TAG_CATEGORIES.map((c) => ({
@@ -52,14 +54,14 @@ const tagGroups = TAG_CATEGORIES.map((c) => ({
 
 <form id="circuit-filter" method="GET" action={basePath} class="mb-6 space-y-2 sm:sticky sm:top-0 sm:z-20 bg-white dark:bg-gray-950 sm:border-b sm:border-gray-200 sm:dark:border-gray-800 sm:pb-4 sm:-mb-2">
   <div class="flex flex-wrap items-center gap-3">
-    {FIELDS.map(({ field, label, placeholder, aria }) => {
+    {FIELDS.map(({ field, label, aria }) => {
       const info = labelInfo(field);
       return (
         <div class="flex items-center gap-1.5 rounded border border-gray-300 dark:border-gray-700 px-1.5 py-0.5">
           <a href={sortHref(field)} data-sort-field={field} class={`px-1 py-0.5 text-xs transition-colors ${info.cls}`} title={`Sort by ${label}`}>
             {label}<span data-sort-arrow class="ml-0.5 text-[10px] text-gray-500 dark:text-gray-500">{info.arrow}</span>
           </a>
-          <input type="text" name={field} class={INPUT_CLASS} placeholder={placeholder} aria-label={aria} data-filter />
+          <input type="text" name={field} class={INPUT_CLASS} aria-label={aria} data-filter />
         </div>
       );
     })}

--- a/src/components/CodeFilter.astro
+++ b/src/components/CodeFilter.astro
@@ -33,11 +33,9 @@ function labelInfo(field: CodeSortField) {
 
 const sortHref = (field: CodeSortField) => `${basePath}?sort=${field}&sort_dir=asc`;
 
-const FIELDS: { field: CodeSortField; placeholder: string }[] = [
-  { field: "n", placeholder: ">3,<10" },
-  { field: "k", placeholder: ">=2" },
-  { field: "d", placeholder: "!=5" },
-];
+// Inputs render with no placeholder: the examples live in FilterStatus, beside
+// the boxes rather than inside them.
+const FIELDS: CodeSortField[] = ["n", "k", "d"];
 
 const tagGroups = CODE_TAG_CATEGORIES.map((c) => ({
   label: c.label,
@@ -47,14 +45,14 @@ const tagGroups = CODE_TAG_CATEGORIES.map((c) => ({
 
 <form id="code-filter" method="GET" action={basePath} class="mb-6 space-y-2">
   <div class="flex flex-wrap items-center gap-3">
-    {FIELDS.map(({ field, placeholder }) => {
+    {FIELDS.map((field) => {
       const info = labelInfo(field);
       return (
         <div class="flex items-center gap-1.5 rounded border border-gray-300 dark:border-gray-700 px-1.5 py-0.5">
           <a href={sortHref(field)} data-sort-field={field} class={`px-1 py-0.5 text-xs transition-colors ${info.cls}`} title={`Click to sort by ${field}`}>
             {field}<span data-sort-arrow class="ml-0.5 text-[10px] text-gray-500 dark:text-gray-500">{info.arrow}</span>
           </a>
-          <input id={`filter-${field}`} type="text" name={field} class={INPUT_CLASS} placeholder={placeholder} aria-label={`Filter by ${field}`} data-filter />
+          <input id={`filter-${field}`} type="text" name={field} class={INPUT_CLASS} aria-label={`Filter by ${field}`} data-filter />
         </div>
       );
     })}

--- a/src/components/CodeFilter.astro
+++ b/src/components/CodeFilter.astro
@@ -2,6 +2,7 @@
 import type { TagWithCount, CodeSortField } from "../types";
 import { CODE_TAG_CATEGORIES, categorizeCodeTag } from "../lib/tag-categories";
 import TagFilterDropdowns from "./TagFilterDropdowns.astro";
+import FilterStatus from "./FilterStatus.astro";
 
 // Filtering/sorting runs client-side (list-filter-client.ts, initialised by
 // the page). Inputs render empty and sort labels render the default state;
@@ -57,20 +58,7 @@ const tagGroups = CODE_TAG_CATEGORIES.map((c) => ({
         </div>
       );
     })}
-    <div class="text-xs" data-filter-status>
-      <span data-filter-error class="text-red-500 hidden">Invalid filter</span>
-      <a
-        href={basePath}
-        data-clear-filters
-        class="hidden inline-flex items-center gap-1 font-medium text-amber-600 dark:text-amber-400 hover:text-amber-800 dark:hover:text-amber-200"
-        title="Clear all active filters"
-      >
-        <svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-          <path d="M6 18L18 6M6 6l12 12" />
-        </svg>
-        Clear filters
-      </a>
-    </div>
+    <FilterStatus basePath={basePath} />
   </div>
 
   <TagFilterDropdowns

--- a/src/components/FilterStatus.astro
+++ b/src/components/FilterStatus.astro
@@ -2,9 +2,14 @@
 /**
  * The status slot of a filter bar, shared by CodeFilter and CircuitFilter.
  *
- * It shows at most one thing at a time -- a parse error, or a "Clear filters"
- * link -- and which one is list-filter-client.ts's call (see renderStatus
- * there). An error outranks the link.
+ * It shows exactly one of three things -- a parse error, a "Clear filters"
+ * link, or the syntax hint -- and which one is list-filter-client.ts's call
+ * (see renderStatus there). The three are mutually exclusive by design: there
+ * is nothing to clear while the hint is up, and an error outranks both.
+ *
+ * The examples live here rather than in the inputs' `placeholder`s. In a box
+ * that is otherwise empty, a greyed-out `>3,<10` reads as a value the filter
+ * already has, so people took the boxes for pre-filled rather than blank.
  */
 interface Props {
   /** Where "Clear filters" points; must equal the page's own path. */
@@ -12,6 +17,14 @@ interface Props {
 }
 
 const { basePath } = Astro.props;
+
+// Mirrors parseFilterString's grammar (queries/shared.ts and
+// list-filter-client.ts): a bare number, an operator and a number, or several
+// of those comma-separated. Ordered simplest-first.
+const EXAMPLES = ["7", ">3", "<=10", ">3,<10"];
+
+const HINT_TITLE =
+  "A number, or an operator (>, >=, <, <=, !=) and a number. Comma-separate to combine.";
 ---
 
 {/* Everything in here is shown and hidden by toggling Tailwind's `hidden`, so
@@ -24,6 +37,16 @@ const { basePath } = Astro.props;
     `inline-flex` on itself. */}
 <div class="text-xs" data-filter-status>
   <span data-filter-error class="hidden text-red-500">Invalid filter</span>
+
+  <span data-filter-hint class="text-gray-400 dark:text-gray-500" title={HINT_TITLE}>
+    e.g.{" "}
+    {EXAMPLES.map((example, i) => (
+      <Fragment>
+        {i > 0 && <span class="mx-1 opacity-60">&#183;</span>}
+        <span class="font-mono">{example}</span>
+      </Fragment>
+    ))}
+  </span>
 
   <a
     href={basePath}

--- a/src/components/FilterStatus.astro
+++ b/src/components/FilterStatus.astro
@@ -1,0 +1,45 @@
+---
+/**
+ * The status slot of a filter bar, shared by CodeFilter and CircuitFilter.
+ *
+ * It shows at most one thing at a time -- a parse error, or a "Clear filters"
+ * link -- and which one is list-filter-client.ts's call (see renderStatus
+ * there). An error outranks the link.
+ */
+interface Props {
+  /** Where "Clear filters" points; must equal the page's own path. */
+  basePath: string;
+}
+
+const { basePath } = Astro.props;
+---
+
+{/* Everything in here is shown and hidden by toggling Tailwind's `hidden`, so
+    none of it may carry a display utility that sorts after `hidden`
+    alphabetically. Tailwind v4 emits them all into the `utilities` layer at
+    equal specificity, so source order decides the winner -- `.hidden` (none)
+    is beaten by `.inline`, `.inline-block`, `.inline-flex` and `.table`, and
+    an element carrying one of those simply never hides. That is why the clear
+    link below lays its icon out with `inline-block` on the *svg* instead of
+    `inline-flex` on itself. */}
+<div class="text-xs" data-filter-status>
+  <span data-filter-error class="hidden text-red-500">Invalid filter</span>
+
+  <a
+    href={basePath}
+    data-clear-filters
+    class="hidden font-medium text-amber-600 dark:text-amber-400 hover:text-amber-800 dark:hover:text-amber-200"
+    title="Clear all active filters"
+  >
+    <svg
+      class="inline-block w-3 h-3 mr-0.5 align-[-2px]"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <path d="M6 18L18 6M6 6l12 12" />
+    </svg>Clear filters
+  </a>
+</div>

--- a/src/lib/list-filter-client.ts
+++ b/src/lib/list-filter-client.ts
@@ -157,8 +157,11 @@ export function initListFilter(config: ListFilterConfig): void {
     ? Array.from(form.querySelectorAll<HTMLInputElement>("input[data-filter]"))
     : [];
   const inputByField = new Map(inputs.map((i) => [i.name, i]));
+  // All three live in the form's FilterStatus slot. Scoped to the form, not the
+  // document: the empty state carries its own [data-clear-filters] link (a
+  // plain href, so it works without JS) that must never be toggled from here.
   const errorSpan = form?.querySelector<HTMLElement>("[data-filter-error]") ?? null;
-  const clearLink = document.querySelector<HTMLElement>("[data-clear-filters]");
+  const clearLink = form?.querySelector<HTMLElement>("[data-clear-filters]") ?? null;
   const countEl = config.countSelector
     ? document.querySelector<HTMLElement>(config.countSelector)
     : null;
@@ -169,6 +172,7 @@ export function initListFilter(config: ListFilterConfig): void {
 
   let state = stateFromLocation();
   let appliedSortKey = `${config.defaultSort.field}:${config.defaultSort.dir}`;
+  let inputError = false;
 
   function stateFromLocation(): ListState {
     const params = new URLSearchParams(location.search);
@@ -218,6 +222,17 @@ export function initListFilter(config: ListFilterConfig): void {
     return (
       state.tags.length > 0 || config.fields.some((f) => (state.conditions[f]?.length ?? 0) > 0)
     );
+  }
+
+  /** The one writer of the FilterStatus slot (FilterStatus.astro).
+   *
+   *  It holds at most one thing: a parse error, or the clear link once filters
+   *  are active. An error outranks the link — so deciding both in one place is
+   *  what keeps them from contradicting each other.
+   */
+  function renderStatus(): void {
+    errorSpan?.classList.toggle("hidden", !inputError);
+    clearLink?.classList.toggle("hidden", inputError || !hasActiveFilters());
   }
 
   function rowMatches(data: RowData): boolean {
@@ -270,7 +285,7 @@ export function initListFilter(config: ListFilterConfig): void {
       countEl.textContent = config.formatCount(visible, rows.length, active);
     }
     if (emptyEl) emptyEl.classList.toggle("hidden", visible > 0);
-    if (clearLink) clearLink.classList.toggle("hidden", !active);
+    renderStatus();
   }
 
   // -------------------------------------------------------------------------
@@ -352,9 +367,8 @@ export function initListFilter(config: ListFilterConfig): void {
       input.classList.toggle("ring-1", invalid);
       input.classList.toggle("ring-red-300", invalid);
     }
-    if (errorSpan) errorSpan.classList.toggle("hidden", !hasError);
-    // The clear link shares the status area: an error message displaces it.
-    if (clearLink) clearLink.classList.toggle("hidden", hasError || !hasActiveFilters());
+    inputError = hasError;
+    renderStatus();
     return !hasError;
   }
 

--- a/src/lib/list-filter-client.ts
+++ b/src/lib/list-filter-client.ts
@@ -161,6 +161,7 @@ export function initListFilter(config: ListFilterConfig): void {
   // document: the empty state carries its own [data-clear-filters] link (a
   // plain href, so it works without JS) that must never be toggled from here.
   const errorSpan = form?.querySelector<HTMLElement>("[data-filter-error]") ?? null;
+  const hintEl = form?.querySelector<HTMLElement>("[data-filter-hint]") ?? null;
   const clearLink = form?.querySelector<HTMLElement>("[data-clear-filters]") ?? null;
   const countEl = config.countSelector
     ? document.querySelector<HTMLElement>(config.countSelector)
@@ -226,13 +227,16 @@ export function initListFilter(config: ListFilterConfig): void {
 
   /** The one writer of the FilterStatus slot (FilterStatus.astro).
    *
-   *  It holds at most one thing: a parse error, or the clear link once filters
-   *  are active. An error outranks the link — so deciding both in one place is
-   *  what keeps them from contradicting each other.
+   *  It holds exactly one of three things, in priority order: a parse error, the
+   *  clear link, or the syntax hint. There is nothing to clear while the hint is
+   *  up, and an error outranks both — so deciding all three in one place is what
+   *  keeps them from contradicting each other.
    */
   function renderStatus(): void {
+    const active = hasActiveFilters();
     errorSpan?.classList.toggle("hidden", !inputError);
-    clearLink?.classList.toggle("hidden", inputError || !hasActiveFilters());
+    clearLink?.classList.toggle("hidden", inputError || !active);
+    hintEl?.classList.toggle("hidden", inputError || active);
   }
 
   function rowMatches(data: RowData): boolean {

--- a/uv.lock
+++ b/uv.lock
@@ -829,7 +829,7 @@ wheels = [
 
 [[package]]
 name = "qecirc-website"
-version = "0.5.1"
+version = "0.5.2"
 source = { virtual = "." }
 dependencies = [
     { name = "mqt-qecc" },


### PR DESCRIPTION
Two filter-bar issues reported from use.

## 1. "Clear filters" showed when nothing was filtered

The link is rendered `hidden inline-flex` and un-hidden by `list-filter-client` once filters are active. It was never hidden in the first place: **Tailwind v4 emits display utilities into the `utilities` layer in alphabetical order**, so `.inline-flex` lands after `.hidden` at equal specificity and wins on source order.

```
100 .block    103 .grid     106 .inline-block
101 .contents 104 .hidden   107 .inline-flex   <- beats .hidden
102 .flex     105 .inline   108 .table
```

`hidden` still beats `block`/`contents`/`flex`/`grid`, which is why this stayed invisible — the pairing only breaks against `inline*` and `table`. A sweep found the two clear links were the only such pairs in the codebase.

The icon is now laid out with `inline-block` on the **svg**, so nothing on the toggled element competes with `hidden`.

## 2. Examples inside the boxes read as pre-filled values

`>3,<10` / `>=2` / `!=5` sat in the inputs as placeholders. In an otherwise empty box, greyed-out text reads as a value the filter already holds. Being per-field, they also implied the syntax differs between fields when it never did.

The inputs now render blank and the grammar is stated once beside them — `e.g. 7 · >3 · <=10 · >3,<10`, simplest first. It shares the status slot with the clear link, as suggested: the hint has nothing to say once filters are active, and the link has nothing to offer before then.

## Also

- The status markup was duplicated byte-for-byte across both filter bars → extracted to `FilterStatus.astro`, which carries a comment on why `inline-flex` must not come back.
- `apply()` and `validateInputs()` each toggled the clear link from their own view of state, so an error and the link could show at once. `renderStatus()` is now the single writer.
- The status lookup is scoped to the form: the empty state has its own clear link (a plain href that works without JS) that must not be toggled.

## Verification

Driven in the browser on `/codes` and `/codes/steane-code`, both filter bars, light and dark:

| state | shows |
| --- | --- |
| no filters | hint |
| `n=>3,<10` (5 of 38) | Clear filters |
| `n=abc` | Invalid filter |
| cleared | hint |

Exactly one of the three is visible in every state. Deep links (`?tag=CSS` → "Showing 35 of 38") render Clear on load, and clicking it returns to `/codes` + hint.

`npm run build`, `npm run lint`, `npm run format:check`, and 19/19 smoke all pass.

Version 0.5.1 → 0.5.2 (patch) across `package.json`, `package-lock.json`, `pyproject.toml`, `uv.lock`; `uv lock --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)