### PR TITLE
fix(browse): mobile layout and text contrast

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qecirc-website",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qecirc-website",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "MIT",
       "dependencies": {
         "@astrojs/node": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qecirc-website",
   "type": "module",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "license": "MIT",
   "scripts": {
     "dev": "astro dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qecirc-website"
-version = "0.5.2"
+version = "0.5.3"
 description = "QECirc — quantum error correction circuit library"
 license = "MIT"
 requires-python = ">=3.13"

--- a/src/components/CircuitBodiesTemplate.astro
+++ b/src/components/CircuitBodiesTemplate.astro
@@ -17,7 +17,7 @@ const TAB_BASE_CLASS =
       <button class={`${TAB_BASE_CLASS} ${TAB_INACTIVE_CLASS}`} data-format="">
         <span class="tab-label"></span>
         <kbd
-          class="ml-1.5 inline-block min-w-[1rem] text-center px-1 rounded border border-gray-300 dark:border-gray-700 bg-white/60 dark:bg-gray-900/60 text-[10px] text-gray-400 dark:text-gray-500 font-mono"
+          class="ml-1.5 inline-block min-w-[1rem] text-center px-1 rounded border border-gray-300 dark:border-gray-700 bg-white/60 dark:bg-gray-900/60 text-[10px] text-gray-500 dark:text-gray-400 font-mono"
         ></kbd>
       </button>
       <div class="coords-slot ml-auto flex items-center gap-0.5" data-body-switches>
@@ -43,7 +43,7 @@ const TAB_BASE_CLASS =
                 <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4M7 10l5 5 5-5M12 15V3" />
               </svg>
               <span>Download</span>
-              <kbd class="ml-0.5 inline-block min-w-[1rem] text-center px-1 rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-[10px] text-gray-400 dark:text-gray-500 font-mono">
+              <kbd class="ml-0.5 inline-block min-w-[1rem] text-center px-1 rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-[10px] text-gray-500 dark:text-gray-400 font-mono">
                 d
               </kbd>
             </button>
@@ -56,7 +56,7 @@ const TAB_BASE_CLASS =
                 <path d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
               </svg>
               <span class="copy-label">Copy</span>
-              <kbd class="ml-0.5 inline-block min-w-[1rem] text-center px-1 rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-[10px] text-gray-400 dark:text-gray-500 font-mono">
+              <kbd class="ml-0.5 inline-block min-w-[1rem] text-center px-1 rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-[10px] text-gray-500 dark:text-gray-400 font-mono">
                 c
               </kbd>
             </button>

--- a/src/components/CircuitFilter.astro
+++ b/src/components/CircuitFilter.astro
@@ -20,7 +20,9 @@ const basePath = `/codes/${codeSlug}`;
 // Matches the server's default ordering (parseCircuitParams).
 const DEFAULT_SORT_FIELD: CircuitSortField = "two_qubit_gate_count";
 
-const INPUT_CLASS = "w-24 px-2 py-1 text-sm focus:outline-none bg-transparent";
+// w-full below sm so the box fills its grid column; the fixed w-24 above it
+// keeps the flex-wrap row as it was.
+const INPUT_CLASS = "w-full min-w-0 sm:w-24 px-2 py-1 text-sm focus:outline-none bg-transparent";
 
 function labelInfo(field: CircuitSortField) {
   const isActive = field === DEFAULT_SORT_FIELD;
@@ -53,19 +55,25 @@ const tagGroups = TAG_CATEGORIES.map((c) => ({
 ---
 
 <form id="circuit-filter" method="GET" action={basePath} class="mb-6 space-y-2 sm:sticky sm:top-0 sm:z-20 bg-white dark:bg-gray-950 sm:border-b sm:border-gray-200 sm:dark:border-gray-800 sm:pb-4 sm:-mb-2">
-  <div class="flex flex-wrap items-center gap-3">
+  {/* An even 2-up grid below sm. Left to flex-wrap, the boxes measure 160-188px
+      against a 343px line -- close enough to differ, too wide to pair -- so they
+      landed one, one, two down the page. Above sm they all fit and flex-wrap is
+      the simpler thing. */}
+  <div class="grid grid-cols-2 gap-2 sm:flex sm:flex-wrap sm:items-center sm:gap-3">
     {FIELDS.map(({ field, label, aria }) => {
       const info = labelInfo(field);
       return (
-        <div class="flex items-center gap-1.5 rounded border border-gray-300 dark:border-gray-700 px-1.5 py-0.5">
-          <a href={sortHref(field)} data-sort-field={field} class={`px-1 py-0.5 text-xs transition-colors ${info.cls}`} title={`Sort by ${label}`}>
+        <div class="flex items-center gap-1.5 rounded border border-gray-300 dark:border-gray-700 px-1.5 py-0.5 min-w-0">
+          {/* nowrap: "2Q Gates" is two words and broke over two lines in the
+              narrow grid column, making that box taller than its neighbours. */}
+          <a href={sortHref(field)} data-sort-field={field} class={`px-1 py-0.5 text-xs whitespace-nowrap transition-colors ${info.cls}`} title={`Sort by ${label}`}>
             {label}<span data-sort-arrow class="ml-0.5 text-[10px] text-gray-500 dark:text-gray-500">{info.arrow}</span>
           </a>
           <input type="text" name={field} class={INPUT_CLASS} aria-label={aria} data-filter />
         </div>
       );
     })}
-    <FilterStatus basePath={basePath} />
+    <FilterStatus basePath={basePath} class="col-span-2 sm:col-auto" />
   </div>
 
   <TagFilterDropdowns

--- a/src/components/CircuitRow.astro
+++ b/src/components/CircuitRow.astro
@@ -101,20 +101,29 @@ const stimFilename = buildStimFilename({
       <HeartIcon filled class="fav-filled w-3.5 h-3.5 hidden" />
     </button>
 
-    <span class="text-center">
-      <MetricBadge value={circuit.gate_count} title="Gate count" />
-    </span>
-    <span class="text-center">
-      <MetricBadge value={circuit.two_qubit_gate_count} title="Two-qubit gate count" />
-    </span>
-    <span class="text-center">
-      <MetricBadge value={circuit.depth} title="Circuit depth" />
-    </span>
-    <span class="text-center">
-      <MetricBadge value={circuit.qubit_count} title="Qubit count" />
-    </span>
+    {/* `md:contents` dissolves this wrapper above md, so the four spans go back
+        to being grid items in their own columns and the desktop row is
+        unchanged. Below md the wrapper is one item on a line of its own
+        (order-1) carrying the labels the desktop column headers supply.
+        col-start-4 is the name's column, so the metrics line up under the name
+        without hard-coding the width of the three columns before it.
+        See --circuit-grid in global.css. */}
+    <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1 col-start-4 order-1 mt-1.5 md:contents">
+      <span class="text-center">
+        <MetricBadge value={circuit.gate_count} label="G:" labelClass="md:hidden" title="Gate count" />
+      </span>
+      <span class="text-center">
+        <MetricBadge value={circuit.two_qubit_gate_count} label="2Q:" labelClass="md:hidden" title="Two-qubit gate count" />
+      </span>
+      <span class="text-center">
+        <MetricBadge value={circuit.depth} label="D:" labelClass="md:hidden" title="Circuit depth" />
+      </span>
+      <span class="text-center">
+        <MetricBadge value={circuit.qubit_count} label="Q:" labelClass="md:hidden" title="Qubit count" />
+      </span>
+    </div>
 
-    <span></span>
+    <span class="hidden md:block"></span>
     <div class="flex items-baseline gap-2 min-w-0">
       <a href={`/circuits/${circuit.qec_id}`} class="circuit-detail-link font-medium text-sm hover:underline inline-flex items-baseline gap-1 w-fit max-w-full min-w-0" data-list-detail-link>
         <span class="truncate">{circuit.name}</span>
@@ -130,7 +139,7 @@ const stimFilename = buildStimFilename({
     </div>
 
     {circuit.tags.length > 0 && (
-      <div class="flex flex-wrap gap-1 justify-end col-span-full mt-1.5 md:col-auto md:mt-0 md:justify-self-end">
+      <div class="flex flex-wrap gap-1 justify-end col-span-full order-2 mt-1.5 md:col-auto md:order-none md:mt-0 md:justify-self-end">
         {circuit.tags.map((tag) => (
           <a
             href={tagHref(tag)}

--- a/src/components/CircuitRow.astro
+++ b/src/components/CircuitRow.astro
@@ -78,7 +78,7 @@ const stimFilename = buildStimFilename({
     </svg>
 
     <button
-      class="circuit-permalink text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 font-mono text-xs shrink-0 cursor-pointer"
+      class="circuit-permalink text-gray-500 dark:text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 font-mono text-xs shrink-0 cursor-pointer"
       aria-label="Copy link to circuit"
       title="Copy link"
       data-qec-id={anchorId}
@@ -221,7 +221,7 @@ const stimFilename = buildStimFilename({
               nowhere to break -- it runs straight out of the column. */}
           <p class="notes-text text-sm text-gray-600 dark:text-gray-400 whitespace-pre-line break-words line-clamp-1">{circuit.notes}</p>
           <button
-            class="notes-toggle text-xs text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 cursor-pointer mt-0.5 hidden"
+            class="notes-toggle text-xs text-gray-500 dark:text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 cursor-pointer mt-0.5 hidden"
             type="button"
           >
             Show more
@@ -235,7 +235,7 @@ const stimFilename = buildStimFilename({
         data-stim-filename={stimFilename}
         data-source={circuit.source}
       >
-        <p class="circuit-bodies-status text-sm text-gray-400">Loading circuit&hellip;</p>
+        <p class="circuit-bodies-status text-sm text-gray-500 dark:text-gray-400">Loading circuit&hellip;</p>
       </div>
     </div>
   </div>

--- a/src/components/CircuitRow.astro
+++ b/src/components/CircuitRow.astro
@@ -207,7 +207,10 @@ const stimFilename = buildStimFilename({
 
       {circuit.notes && (
         <div class="notes-wrapper">
-          <p class="notes-text text-sm text-gray-600 dark:text-gray-400 whitespace-pre-line line-clamp-1">{circuit.notes}</p>
+          {/* break-words: 311 of the 756 circuits with notes cite a source path
+              of 100+ characters and no spaces, which `normal` overflow-wrap has
+              nowhere to break -- it runs straight out of the column. */}
+          <p class="notes-text text-sm text-gray-600 dark:text-gray-400 whitespace-pre-line break-words line-clamp-1">{circuit.notes}</p>
           <button
             class="notes-toggle text-xs text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 cursor-pointer mt-0.5 hidden"
             type="button"

--- a/src/components/CiteToast.astro
+++ b/src/components/CiteToast.astro
@@ -10,7 +10,7 @@
   <span id="cite-toast-msg" class="flex-1"></span>
   <button
     id="cite-toast-close"
-    class="shrink-0 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 cursor-pointer"
+    class="shrink-0 text-gray-500 dark:text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 cursor-pointer"
     aria-label="Dismiss"
   >
     <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">

--- a/src/components/CodeBlock.astro
+++ b/src/components/CodeBlock.astro
@@ -60,7 +60,7 @@ const needsRaw = hasCoords || hasDetectors(raw);
               <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4M7 10l5 5 5-5M12 15V3" />
             </svg>
             <span>Download</span>
-            <kbd class="ml-0.5 inline-block min-w-[1rem] text-center px-1 rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-[10px] text-gray-400 dark:text-gray-500 font-mono">
+            <kbd class="ml-0.5 inline-block min-w-[1rem] text-center px-1 rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-[10px] text-gray-500 dark:text-gray-400 font-mono">
               d
             </kbd>
           </button>
@@ -75,7 +75,7 @@ const needsRaw = hasCoords || hasDetectors(raw);
             <path d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
           </svg>
           <span class="copy-label">Copy</span>
-          <kbd class="ml-0.5 inline-block min-w-[1rem] text-center px-1 rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-[10px] text-gray-400 dark:text-gray-500 font-mono">
+          <kbd class="ml-0.5 inline-block min-w-[1rem] text-center px-1 rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-[10px] text-gray-500 dark:text-gray-400 font-mono">
             c
           </kbd>
         </button>

--- a/src/components/CodeCard.astro
+++ b/src/components/CodeCard.astro
@@ -36,7 +36,7 @@ const rowTags = JSON.stringify(tags);
     <a href={`/codes/${slug}`} class="flex items-baseline gap-2" data-list-link>
       <h3 class="font-medium">{name}</h3>
       {showParams && <span class="text-sm text-gray-500 dark:text-gray-400">{params}</span>}
-      <span class="text-xs text-gray-400 dark:text-gray-500">{circuit_count} {circuit_count === 1 ? "circuit" : "circuits"}</span>
+      <span class="text-xs text-gray-500 dark:text-gray-400">{circuit_count} {circuit_count === 1 ? "circuit" : "circuits"}</span>
     </a>
     <div class="ml-auto">
       <TagList tags={tags} basePath={basePath} baseUrl={baseUrl} selectedTags={selectedTags} />

--- a/src/components/CodeFilter.astro
+++ b/src/components/CodeFilter.astro
@@ -19,7 +19,9 @@ const { allTags, basePath } = Astro.props;
 // Matches the server's default ordering (buildCodeOrderBy: n, k, d, name).
 const DEFAULT_SORT_FIELD: CodeSortField = "n";
 
-const INPUT_CLASS = "w-24 px-2 py-1 text-sm focus:outline-none bg-transparent";
+// w-full below sm so the box fills its grid column; the fixed w-24 above it
+// keeps the flex-wrap row as it was.
+const INPUT_CLASS = "w-full min-w-0 sm:w-24 px-2 py-1 text-sm focus:outline-none bg-transparent";
 
 function labelInfo(field: CodeSortField) {
   const isActive = field === DEFAULT_SORT_FIELD;
@@ -44,11 +46,13 @@ const tagGroups = CODE_TAG_CATEGORIES.map((c) => ({
 ---
 
 <form id="code-filter" method="GET" action={basePath} class="mb-6 space-y-2">
-  <div class="flex flex-wrap items-center gap-3">
+  {/* An even 3-up grid below sm (n, k and d are one character each, so three
+      fit); flex-wrap above it, where they all sit on one line anyway. */}
+  <div class="grid grid-cols-3 gap-2 sm:flex sm:flex-wrap sm:items-center sm:gap-3">
     {FIELDS.map((field) => {
       const info = labelInfo(field);
       return (
-        <div class="flex items-center gap-1.5 rounded border border-gray-300 dark:border-gray-700 px-1.5 py-0.5">
+        <div class="flex items-center gap-1.5 rounded border border-gray-300 dark:border-gray-700 px-1.5 py-0.5 min-w-0">
           <a href={sortHref(field)} data-sort-field={field} class={`px-1 py-0.5 text-xs transition-colors ${info.cls}`} title={`Click to sort by ${field}`}>
             {field}<span data-sort-arrow class="ml-0.5 text-[10px] text-gray-500 dark:text-gray-500">{info.arrow}</span>
           </a>
@@ -56,7 +60,7 @@ const tagGroups = CODE_TAG_CATEGORIES.map((c) => ({
         </div>
       );
     })}
-    <FilterStatus basePath={basePath} />
+    <FilterStatus basePath={basePath} class="col-span-3 sm:col-auto" />
   </div>
 
   <TagFilterDropdowns

--- a/src/components/FilterStatus.astro
+++ b/src/components/FilterStatus.astro
@@ -14,9 +14,11 @@
 interface Props {
   /** Where "Clear filters" points; must equal the page's own path. */
   basePath: string;
+  /** Extra classes for the slot itself, for the caller's own layout. */
+  class?: string;
 }
 
-const { basePath } = Astro.props;
+const { basePath, class: className } = Astro.props;
 
 // Mirrors parseFilterString's grammar (queries/shared.ts and
 // list-filter-client.ts): a bare number, an operator and a number, or several
@@ -35,7 +37,7 @@ const HINT_TITLE =
     an element carrying one of those simply never hides. That is why the clear
     link below lays its icon out with `inline-block` on the *svg* instead of
     `inline-flex` on itself. */}
-<div class="text-xs" data-filter-status>
+<div class:list={["text-xs", className]} data-filter-status>
   <span data-filter-error class="hidden text-red-500">Invalid filter</span>
 
   <span data-filter-hint class="text-gray-400 dark:text-gray-500" title={HINT_TITLE}>

--- a/src/components/FilterStatus.astro
+++ b/src/components/FilterStatus.astro
@@ -40,7 +40,7 @@ const HINT_TITLE =
 <div class:list={["text-xs", className]} data-filter-status>
   <span data-filter-error class="hidden text-red-500">Invalid filter</span>
 
-  <span data-filter-hint class="text-gray-400 dark:text-gray-500" title={HINT_TITLE}>
+  <span data-filter-hint class="text-gray-500 dark:text-gray-400" title={HINT_TITLE}>
     e.g.{" "}
     {EXAMPLES.map((example, i) => (
       <Fragment>

--- a/src/components/FormatSwitcher.astro
+++ b/src/components/FormatSwitcher.astro
@@ -61,7 +61,7 @@ const TAB_BASE_CLASS =
         >
           {b.format.toUpperCase()}
           {i < 3 && (
-            <kbd class="ml-1.5 inline-block min-w-[1rem] text-center px-1 rounded border border-gray-300 dark:border-gray-700 bg-white/60 dark:bg-gray-900/60 text-[10px] text-gray-400 dark:text-gray-500 font-mono">
+            <kbd class="ml-1.5 inline-block min-w-[1rem] text-center px-1 rounded border border-gray-300 dark:border-gray-700 bg-white/60 dark:bg-gray-900/60 text-[10px] text-gray-500 dark:text-gray-400 font-mono">
               {i + 1}
             </kbd>
           )}
@@ -96,7 +96,7 @@ const TAB_BASE_CLASS =
     source={source}
   />
 ) : (
-  <p class="text-sm text-gray-400">No circuit body available.</p>
+  <p class="text-sm text-gray-500 dark:text-gray-400">No circuit body available.</p>
 )}
 
 <script>

--- a/src/components/HowToStep.astro
+++ b/src/components/HowToStep.astro
@@ -38,7 +38,7 @@ const flip = n % 2 === 0;
 >
   <div class:list={["p-4 bg-gray-50 dark:bg-gray-900", flip && "sm:order-2"]}>
     <h3 class="font-medium mb-1 flex items-baseline gap-2">
-      <span class="font-mono text-xs text-gray-400 dark:text-gray-500">{n}</span>
+      <span class="font-mono text-xs text-gray-500 dark:text-gray-400">{n}</span>
       {title}
     </h3>
     <p class="text-sm text-gray-500 dark:text-gray-400 mb-2">
@@ -48,7 +48,7 @@ const flip = n % 2 === 0;
   </div>
   <div class:list={["p-4 min-w-0", flip && "sm:order-1"]}>
     <p
-      class="text-[11px] font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-1.5"
+      class="text-[11px] font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-1.5"
     >
       {previewLabel}
     </p>

--- a/src/components/KeyboardHelp.astro
+++ b/src/components/KeyboardHelp.astro
@@ -54,7 +54,7 @@ const SHORTCUTS: { keys: string[]; action: string }[] = [
                 <td class="py-1.5 pr-4">
                   {keys.map((k, i) => (
                     <>
-                      {i > 0 && <span class="mx-1 text-gray-400">/</span>}
+                      {i > 0 && <span class="mx-1 text-gray-500 dark:text-gray-400">/</span>}
                       <kbd class="inline-block min-w-[1.5rem] text-center px-1.5 py-0.5 font-mono text-xs border border-gray-300 dark:border-gray-700 rounded bg-gray-50 dark:bg-gray-800">
                         {k}
                       </kbd>

--- a/src/components/Layout.astro
+++ b/src/components/Layout.astro
@@ -208,11 +208,11 @@ const sunIconSvg = `<svg class="w-4 h-4 hidden dark:block" viewBox="0 0 24 24" f
         <div class="flex items-center justify-between">
           <span>QECirc — A community-driven library for quantum error correction circuits.</span>
           <div class="flex gap-4">
-            <a href="/privacy" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">Privacy Policy</a>
-            <a href="/legal" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">Legal Notice</a>
+            <a href="/privacy" class="text-gray-500 dark:text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">Privacy Policy</a>
+            <a href="/legal" class="text-gray-500 dark:text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">Legal Notice</a>
           </div>
         </div>
-        <div class="mt-2 flex justify-end font-mono text-[11px] text-gray-400 dark:text-gray-500">
+        <div class="mt-2 flex justify-end font-mono text-[11px] text-gray-500 dark:text-gray-400">
           v{version} · {totalCircuitsLabel} circuits
         </div>
       </div>

--- a/src/components/MetricBadge.astro
+++ b/src/components/MetricBadge.astro
@@ -2,10 +2,14 @@
 interface Props {
   value: number | null;
   label?: string;
+  /** Classes for the label alone. Circuit rows pass `md:hidden`: above md the
+   *  column header names the metric, below md there is no header and the label
+   *  has to travel with the number. */
+  labelClass?: string;
   title: string;
 }
 
-const { value, label, title } = Astro.props;
+const { value, label, labelClass, title } = Astro.props;
 ---
 
 {
@@ -14,7 +18,8 @@ const { value, label, title } = Astro.props;
       class="font-mono text-[13px] font-medium text-gray-900 dark:text-gray-100 tabular-nums"
       title={title}
     >
-      {label ? `${label} ${value}` : value}
+      {label && <span class={labelClass}>{label} </span>}
+      {value}
     </span>
   )
 }

--- a/src/components/SearchBar.astro
+++ b/src/components/SearchBar.astro
@@ -9,7 +9,7 @@
     aria-label="Search codes, circuits, and tools"
     autocomplete="off"
   />
-  <kbd aria-hidden="true" class="search-hint pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-1.5 py-0.5 text-[10px] text-gray-400 dark:text-gray-500 font-sans">/</kbd>
+  <kbd aria-hidden="true" class="search-hint pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-1.5 py-0.5 text-[10px] text-gray-500 dark:text-gray-400 font-sans">/</kbd>
   <ul
     class="search-results absolute right-0 top-full mt-1 w-96 rounded border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-lg hidden z-50 max-h-80 overflow-y-auto"
     role="listbox"
@@ -80,7 +80,7 @@
     cachedItems = [];
 
     if (results.length === 0) {
-      resultsList.innerHTML = '<li class="px-3 py-2 text-sm text-gray-400">No results</li>';
+      resultsList.innerHTML = '<li class="px-3 py-2 text-sm text-gray-500 dark:text-gray-400">No results</li>';
       appendAdvanced(query);
       cachedItems = resultsList.querySelectorAll<HTMLLIElement>("li[data-href]");
       show();
@@ -106,7 +106,7 @@
 
       if (item.params) {
         const paramsSpan = document.createElement("span");
-        paramsSpan.className = "text-gray-400";
+        paramsSpan.className = "text-gray-500 dark:text-gray-400";
         paramsSpan.textContent = item.params;
         topRow.appendChild(paramsSpan);
       }
@@ -118,7 +118,7 @@
       if (item.qec_id) meta.push(item.qec_id);
       if (item.subtitle) meta.push(item.subtitle);
       const metaDiv = document.createElement("div");
-      metaDiv.className = "text-xs text-gray-400 dark:text-gray-500";
+      metaDiv.className = "text-xs text-gray-500 dark:text-gray-400";
       metaDiv.textContent = meta.join(" · ");
       li.appendChild(metaDiv);
 

--- a/src/components/TagFilterDropdowns.astro
+++ b/src/components/TagFilterDropdowns.astro
@@ -92,7 +92,7 @@ const selectedInGroup = (g: { tags: TagWithCount[] }) =>
                   ]}
                 >
                   {t.name}
-                  <span class:list={[selected.has(t.name) ? "opacity-70" : "text-gray-400 dark:text-gray-500"]}>{t.count}</span>
+                  <span class:list={[selected.has(t.name) ? "opacity-70" : "text-gray-500 dark:text-gray-400"]}>{t.count}</span>
                 </a>
               ))}
             </div>
@@ -117,13 +117,13 @@ const selectedInGroup = (g: { tags: TagWithCount[] }) =>
           </a>
         ))}
       </span>
-      <button type="button" data-tag-view-toggle class="text-xs text-gray-400 dark:text-gray-500 underline hover:text-gray-600 dark:hover:text-gray-300 cursor-pointer">
+      <button type="button" data-tag-view-toggle class="text-xs text-gray-500 dark:text-gray-400 underline hover:text-gray-600 dark:hover:text-gray-300 cursor-pointer">
         all tags
       </button>
     </div>
     <div data-tag-cloud class:list={["min-w-0", defaultView !== "all" && "hidden"]}>
       <TagList tags={allTags} showCount basePath={basePath} baseUrl={baseUrl} selectedTags={selectedTags}>
-        <button type="button" data-tag-view-toggle class="text-xs text-gray-400 dark:text-gray-500 underline hover:text-gray-600 dark:hover:text-gray-300 cursor-pointer">
+        <button type="button" data-tag-view-toggle class="text-xs text-gray-500 dark:text-gray-400 underline hover:text-gray-600 dark:hover:text-gray-300 cursor-pointer">
           by category
         </button>
       </TagList>

--- a/src/components/ToolCard.astro
+++ b/src/components/ToolCard.astro
@@ -13,7 +13,7 @@ const { tool, baseUrl } = Astro.props;
 <div id={tool.slug} class="scroll-mt-4 rounded border border-gray-200 dark:border-gray-800 p-4">
   <div class="flex flex-wrap items-baseline gap-x-2 gap-y-1 mb-1">
     <h3 class="font-medium">{tool.name}</h3>
-    <span class="text-xs text-gray-400 dark:text-gray-500">
+    <span class="text-xs text-gray-500 dark:text-gray-400">
       {tool.circuit_count === 0
         ? "no circuits yet"
         : `${tool.circuit_count} circuit${tool.circuit_count !== 1 ? "s" : ""}`}

--- a/src/pages/circuits/[qec_id].astro
+++ b/src/pages/circuits/[qec_id].astro
@@ -93,14 +93,14 @@ const jsonLd = [
       <path d="M15 19l-7-7 7-7" />
     </svg>
     {circuit.code_name}
-    <kbd class="inline-block min-w-[1rem] text-center px-1 rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-[10px] text-gray-400 dark:text-gray-500 font-mono">
+    <kbd class="inline-block min-w-[1rem] text-center px-1 rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-[10px] text-gray-500 dark:text-gray-400 font-mono">
       ⌫
     </kbd>
   </a>
 
   <div class="flex flex-wrap items-baseline gap-3 mb-4">
     <h1 class="text-2xl font-bold">{circuit.name}</h1>
-    <span class="font-mono text-gray-400 dark:text-gray-500 text-lg">{displayId}</span>
+    <span class="font-mono text-gray-500 dark:text-gray-400 text-lg">{displayId}</span>
     <button
       id="detail-fav"
       class="circuit-fav-detail inline-flex items-center gap-1.5 text-gray-300 dark:text-gray-600 hover:text-red-400 dark:hover:text-red-400 cursor-pointer self-center"
@@ -110,7 +110,7 @@ const jsonLd = [
     >
       <HeartIcon class="fav-outline w-5 h-5" />
       <HeartIcon filled class="fav-filled w-5 h-5 hidden" />
-      <kbd class="inline-block min-w-[1rem] text-center px-1 rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-[10px] text-gray-400 dark:text-gray-500 font-mono">
+      <kbd class="inline-block min-w-[1rem] text-center px-1 rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-[10px] text-gray-500 dark:text-gray-400 font-mono">
         f
       </kbd>
     </button>

--- a/src/pages/circuits/[qec_id].astro
+++ b/src/pages/circuits/[qec_id].astro
@@ -167,8 +167,10 @@ const jsonLd = [
     )}
   </div>
 
+  {/* break-words: many notes cite a source path of 100+ characters and no
+      spaces, which `normal` overflow-wrap has nowhere to break. */}
   {circuit.notes && (
-    <p class="text-sm text-gray-600 dark:text-gray-400 whitespace-pre-line mb-4">{circuit.notes}</p>
+    <p class="text-sm text-gray-600 dark:text-gray-400 whitespace-pre-line break-words mb-4">{circuit.notes}</p>
   )}
 
   {circuit.tags.length > 0 && (

--- a/src/pages/codes/[code].astro
+++ b/src/pages/codes/[code].astro
@@ -193,8 +193,11 @@ const jsonLd = [
     </div>
   ) : (
     <div>
+      {/* Headers only above md: below it the row has no metric columns to head,
+          and the numbers carry their own labels. Sorting stays reachable there
+          through the filter boxes, whose labels are the same sort links. */}
       <div
-        class="grid items-center gap-x-1.5 px-4 py-1.5 text-[11px] font-bold tracking-wider uppercase text-gray-500 dark:text-gray-400"
+        class="hidden md:grid items-center gap-x-1.5 px-4 py-1.5 text-[11px] font-bold tracking-wider uppercase text-gray-500 dark:text-gray-400"
         style="grid-template-columns: var(--circuit-grid);"
       >
         <span></span>

--- a/src/pages/codes/[code].astro
+++ b/src/pages/codes/[code].astro
@@ -112,7 +112,7 @@ const jsonLd = [
       <path d="M15 19l-7-7 7-7" />
     </svg>
     Codes
-    <kbd class="inline-block min-w-[1rem] text-center px-1 rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-[10px] text-gray-400 dark:text-gray-500 font-mono">
+    <kbd class="inline-block min-w-[1rem] text-center px-1 rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-[10px] text-gray-500 dark:text-gray-400 font-mono">
       ⌫
     </kbd>
   </a>
@@ -161,7 +161,7 @@ const jsonLd = [
             <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4M7 10l5 5 5-5M12 15V3" />
           </svg>
           <span data-list-count>{countLabel}</span>
-          <kbd class="ml-0.5 inline-block min-w-[1rem] text-center px-1 rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-[10px] text-gray-400 dark:text-gray-500 font-mono">
+          <kbd class="ml-0.5 inline-block min-w-[1rem] text-center px-1 rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-[10px] text-gray-500 dark:text-gray-400 font-mono">
             ⇧D
           </kbd>
         </button>
@@ -178,7 +178,7 @@ const jsonLd = [
       >
         <HeartIcon class="w-3.5 h-3.5" />
         <span>Favorites</span>
-        <kbd class="ml-0.5 inline-block min-w-[1rem] text-center px-1 rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-[10px] text-gray-400 dark:text-gray-500 font-mono">
+        <kbd class="ml-0.5 inline-block min-w-[1rem] text-center px-1 rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-[10px] text-gray-500 dark:text-gray-400 font-mono">
           ⇧F
         </kbd>
       </button>

--- a/src/pages/favorites.astro
+++ b/src/pages/favorites.astro
@@ -9,7 +9,7 @@ import Layout from "../components/Layout.astro";
     <h1 class="text-2xl font-bold">Favorites</h1>
     <button
       id="download-all-favs"
-      class="hidden text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 cursor-pointer"
+      class="hidden text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 cursor-pointer"
       title="Download all favorite circuits — Shift+D"
       aria-label="Download all favorite circuits"
     >
@@ -17,7 +17,7 @@ import Layout from "../components/Layout.astro";
         <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
           <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4M7 10l5 5 5-5M12 15V3" />
         </svg>
-        <kbd class="inline-block min-w-[1rem] text-center px-1 rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-[10px] text-gray-400 dark:text-gray-500 font-mono">
+        <kbd class="inline-block min-w-[1rem] text-center px-1 rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-[10px] text-gray-500 dark:text-gray-400 font-mono">
           ⇧D
         </kbd>
       </span>
@@ -30,12 +30,12 @@ import Layout from "../components/Layout.astro";
 
   <div id="fav-empty" class="text-center py-8 hidden">
     <p class="text-gray-500 dark:text-gray-400 mb-2">No favorites yet.</p>
-    <p class="text-sm text-gray-400 dark:text-gray-500">Browse circuits and click the heart icon to save them here.</p>
+    <p class="text-sm text-gray-500 dark:text-gray-400">Browse circuits and click the heart icon to save them here.</p>
   </div>
 
   <div id="fav-error" class="text-center py-8 hidden">
     <p class="text-gray-500 dark:text-gray-400 mb-2">Could not load favorites.</p>
-    <p class="text-sm text-gray-400 dark:text-gray-500">Please reload the page or try again later.</p>
+    <p class="text-sm text-gray-500 dark:text-gray-400">Please reload the page or try again later.</p>
   </div>
 
   <div id="fav-content" class="hidden space-y-6"></div>
@@ -160,7 +160,7 @@ import Layout from "../components/Layout.astro";
 
             // ID
             const idSpan = document.createElement("span");
-            idSpan.className = "font-mono text-xs text-gray-400 dark:text-gray-500 shrink-0";
+            idSpan.className = "font-mono text-xs text-gray-500 dark:text-gray-400 shrink-0";
             idSpan.textContent = `#${circuit.qec_id}`;
             row.appendChild(idSpan);
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -146,7 +146,7 @@ const CONTRIBUTE_STEPS = [
 const cardCls =
   "rounded border border-gray-200 dark:border-gray-800 p-4 hover:border-gray-400 dark:hover:border-gray-600 transition-colors";
 const previewLabelCls =
-  "text-[11px] font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-1.5";
+  "text-[11px] font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-1.5";
 
 // The preview half sits on the page colour (HowToStep fills only the text
 // half), so a border is what frames these -- a fill would compete with the
@@ -366,7 +366,7 @@ const jsonLd = {
           </Fragment>
           <div class={previewCardCls}>
             <div class="flex flex-wrap items-baseline gap-2">
-              <span class="font-mono text-sm text-gray-400 dark:text-gray-500">
+              <span class="font-mono text-sm text-gray-500 dark:text-gray-400">
                 {formatCircuitId(EXAMPLE_CIRCUIT.qec_id)}
               </span>
               <span class="font-medium text-sm">{EXAMPLE_CIRCUIT.name}</span>
@@ -384,7 +384,7 @@ const jsonLd = {
               ))}
             </div>
             {EXAMPLE_HAS_ORIGINAL && (
-              <p class="text-xs text-gray-400 dark:text-gray-500">&#9656; Original submission</p>
+              <p class="text-xs text-gray-500 dark:text-gray-400">&#9656; Original submission</p>
             )}
           </div>
         </HowToStep>
@@ -401,7 +401,7 @@ const jsonLd = {
         <div class={previewCardCls}>
           <div class="flex items-center gap-2 text-sm">
             <span class="text-red-400"><HeartIcon filled class="w-4 h-4" /></span>
-            <span class="font-mono text-xs text-gray-400 dark:text-gray-500">
+            <span class="font-mono text-xs text-gray-500 dark:text-gray-400">
               {EXAMPLE_CIRCUIT ? formatCircuitId(EXAMPLE_CIRCUIT.qec_id) : "#1"}
             </span>
             <span class="text-gray-500 dark:text-gray-400">saved</span>
@@ -443,7 +443,7 @@ const jsonLd = {
         <ol class="text-sm text-gray-500 dark:text-gray-400 space-y-1">
           {CONTRIBUTE_STEPS.map((s, i) => (
             <li class="flex gap-2">
-              <span class="font-mono text-xs text-gray-400 dark:text-gray-500 pt-0.5">{i + 1}</span>
+              <span class="font-mono text-xs text-gray-500 dark:text-gray-400 pt-0.5">{i + 1}</span>
               <span>{s}</span>
             </li>
           ))}
@@ -468,7 +468,7 @@ const jsonLd = {
             href={`/circuits/${circuit.qec_id}`}
             class="rounded border border-gray-200 dark:border-gray-800 px-4 py-2.5 flex items-baseline gap-2 flex-wrap hover:border-gray-400 dark:hover:border-gray-600 transition-colors"
           >
-            <span class="font-mono text-xs text-gray-400 dark:text-gray-500">{formatCircuitId(circuit.qec_id)}</span>
+            <span class="font-mono text-xs text-gray-500 dark:text-gray-400">{formatCircuitId(circuit.qec_id)}</span>
             <span class="font-medium text-sm">{circuit.name}</span>
             <span class="text-sm text-gray-500 dark:text-gray-400">{circuit.code_name}</span>
           </a>

--- a/src/pages/legal.astro
+++ b/src/pages/legal.astro
@@ -4,7 +4,7 @@ import Layout from "../components/Layout.astro";
 
 <Layout title="Legal Notice" description="Legal Notice (Impressum) — Technische Universität München">
   <div lang="de" class="space-y-6">
-    <h1 class="text-2xl font-bold">Legal Notice <span class="text-gray-400 dark:text-gray-500 font-normal">(Impressum)</span></h1>
+    <h1 class="text-2xl font-bold">Legal Notice <span class="text-gray-500 dark:text-gray-400 font-normal">(Impressum)</span></h1>
 
     <section>
       <h2 class="text-lg font-semibold mb-1">Herausgeber</h2>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -130,6 +130,6 @@ import Layout from "../components/Layout.astro";
       </ul>
     </section>
 
-    <p class="text-xs text-gray-400 dark:text-gray-500 mt-4"><a href="https://datenschutz-generator.de/" target="_blank" rel="noopener noreferrer nofollow" class="underline hover:text-gray-600 dark:hover:text-gray-300">Erstellt mit kostenlosem Datenschutz-Generator.de von Dr. Thomas Schwenke</a></p>
+    <p class="text-xs text-gray-500 dark:text-gray-400 mt-4"><a href="https://datenschutz-generator.de/" target="_blank" rel="noopener noreferrer nofollow" class="underline hover:text-gray-600 dark:hover:text-gray-300">Erstellt mit kostenlosem Datenschutz-Generator.de von Dr. Thomas Schwenke</a></p>
   </div>
 </Layout>

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -232,9 +232,10 @@ Astro.response.headers.set("Cache-Control", "public, max-age=0, s-maxage=600");
       ) : (
         <div>
           {/* Same columns as a code page's circuit list. Not sortable here:
-              order is relevance, which is the point of the page. */}
+              order is relevance, which is the point of the page. Above md only,
+              like the code page's: below it the row has no metric columns. */}
           <div
-            class="grid items-center gap-x-1.5 px-4 py-1.5 text-[11px] font-bold tracking-wider uppercase text-gray-500 dark:text-gray-400"
+            class="hidden md:grid items-center gap-x-1.5 px-4 py-1.5 text-[11px] font-bold tracking-wider uppercase text-gray-500 dark:text-gray-400"
             style="grid-template-columns: var(--circuit-grid);"
           >
             <span></span>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -16,6 +16,13 @@
    are worth 96px, which on a 375px screen left the name track 91px -- about ten
    characters of a name that routinely runs past sixty. The numbers are worth
    less than knowing which circuit you are looking at. */
+/* Muted text is `text-gray-500 dark:text-gray-400`, and not the reverse.
+   gray-400 measures 2.6:1 on white -- under the 4.5:1 WCAG AA asks for at the
+   sizes it gets used at -- while gray-500 manages 4.84:1 on white and gray-400
+   manages 7.74:1 on gray-950. The inverted pair is wrong at both ends, so if
+   you find yourself typing `text-gray-400 dark:text-gray-500`, swap it.
+   gray-400 on its own is fine for decorative svg, which carries no text. */
+
 :root {
   --circuit-grid: 1rem 1.5rem 1.25rem 1fr;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -6,8 +6,24 @@
   @apply underline text-gray-900 dark:text-gray-100 hover:text-gray-600 dark:hover:text-gray-300;
 }
 
+/* Circuit row tracks. The row's inline `grid-template-columns: var(--circuit-grid)`
+   reads whichever definition the viewport matches, so the two layouts stay in
+   one place.
+
+   Below md the row is chevron | id | heart | name, and the metrics drop to a
+   line of their own (CircuitRow wraps them in `flex md:contents`, so above md
+   they go back to being grid items in their own columns). The metric columns
+   are worth 96px, which on a 375px screen left the name track 91px -- about ten
+   characters of a name that routinely runs past sixty. The numbers are worth
+   less than knowing which circuit you are looking at. */
 :root {
-  /* Last column (tags) caps at 40% of the row so long tag lists wrap
-     instead of forcing a horizontal scroll. */
-  --circuit-grid: 1rem 1.5rem 1.25rem 1.5rem 1.5rem 1.5rem 1.5rem 0.5rem 1fr fit-content(40%);
+  --circuit-grid: 1rem 1.5rem 1.25rem 1fr;
+}
+
+@media (width >= 48rem) {
+  :root {
+    /* Last column (tags) caps at 40% of the row so long tag lists wrap
+       instead of forcing a horizontal scroll. */
+    --circuit-grid: 1rem 1.5rem 1.25rem 1.5rem 1.5rem 1.5rem 1.5rem 0.5rem 1fr fit-content(40%);
+  }
 }

--- a/uv.lock
+++ b/uv.lock
@@ -829,7 +829,7 @@ wheels = [
 
 [[package]]
 name = "qecirc-website"
-version = "0.5.2"
+version = "0.5.3"
 source = { virtual = "." }
 dependencies = [
     { name = "mqt-qecc" },


### PR DESCRIPTION
The four items from the UI/UX review. Three of them are phone-only — none would show on the machine the site was built on.

## 1. Circuit notes ran out of their column — 41% of circuits

311 of the 756 circuits with notes cite their source as a path, some over 100 characters, none with a space in it. `overflow-wrap: normal` has nowhere to break such a token. On [#1027](https://qecirc.com/circuits/1027) the paragraph is 343px wide and its content measured **851px**.

## 2. The circuit name got ten characters on a phone

The row grid was one definition at every width. At 375px its tracks resolved to:

```
16  24  20  24 24 24 24  8  91  0
             └── metrics: 96px ──┘   └ name: 91px
```

91px is about ten characters of a name that routinely runs past sixty — `Circuit-S…`. The four numbers outranked the one thing that says which circuit the row is.

Below `md` the row is now `chevron | id | heart | name` (**231px**, ~30 characters) and the metrics drop to a line under it. The wrapper is `md:contents`, so above `md` it dissolves and the four spans go back to being grid items in their own columns — **the desktop row is unchanged, tracks and all**.

The metrics carry labels below `md` (`G: 11`), reusing the pattern the circuit detail page already uses. That is also what let the column headers go: `title` tooltips don't exist on a touch screen, so on a phone those headers were the only explanation of G/2Q/D/Q *and* they sat above columns the phone couldn't afford. Sorting stays reachable — the filter box labels are the same sort links.

## 3. Muted text was below the contrast floor

`text-gray-400` on white measures **2.6:1**, under the 4.5:1 WCAG AA asks for at these sizes. It carried real text: footer links, every keyboard hint, circuit ids, tag counts, "Loading circuit…", "No results", "Show more", the favorites empty state.

Most sites had `text-gray-400 dark:text-gray-500` — the site's muted pair *inverted*, so too light on white **and** too dark on gray-950 (2.9:1 for a kbd on gray-800). `text-gray-500 dark:text-gray-400` fixes both ends: 4.84:1 and 7.74:1. `global.css` now records the rule.

Verified by measuring every element that owns text across `/`, `/codes`, `/codes/steane-code`, `/circuits/1027`, `/tools`, `/favorites` and `/search` — against its real resolved background, at its real size and weight. No grey text fails on any of them.

Three uses stay: the row chevron, the row's detail arrow, the favorites arrow. Decorative svg with no text, which the contrast rules exempt.

**Still failing, deliberately:** `text-amber-600` at 3.2:1 — the α badge and the active sort highlight. It's the brand accent; amber-700 (5.03:1) is a colour decision, not a fix. Happy to take it if you want it.

## 4. Filter boxes wrapped raggedly

Left to flex-wrap they measure 160–188px against a 343px line: close enough to look like they should align, too wide for two to fit, so they came down the page one, one, two. Now an even grid below `sm` (2-up circuits, 3-up codes) — uniform 168×34 — and flex-wrap above it. "2Q Gates" also broke over two lines and made its box taller than its neighbours; hence the nowrap.

## Notes

- The filter hint shipped in #118 with the inverted pair. The fix was pushed after that PR had already merged, so it never landed — it's here.
- Two things investigated and **dropped**: `/codes/flag-gadgets` serves 3.5 MB of HTML, but Cloudflare brotli-compresses it to 91 KB, so it's a non-issue; and an apparent horizontal scroll was the preview pane's viewport emulation, not the page.

## Verification

`npm run build`, `npm run lint`, `npm run format:check`, 19/19 smoke. Checked at 375px and 1280px, light and dark. Version 0.5.2 → 0.5.3 across all four files; `uv lock --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)