### PR TITLE
feat(circuits): check state-preps prepare the basis their tag claims

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,3 +68,5 @@ jobs:
       - run: uv run ruff check scripts/
       - run: uv run ruff format --check scripts/
       - run: uv run pytest --cov=scripts/add_circuit --cov-fail-under=60
+      # Same as `npm run validate:circuits`, invoked directly (no node in this job).
+      - run: uv run python scripts/validate_circuits.py

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qecirc-website",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qecirc-website",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "license": "MIT",
       "dependencies": {
         "@astrojs/node": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qecirc-website",
   "type": "module",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "license": "MIT",
   "scripts": {
     "dev": "astro dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qecirc-website"
-version = "0.5.3"
+version = "0.5.4"
 description = "QECirc — quantum error correction circuit library"
 license = "MIT"
 requires-python = ">=3.13"

--- a/scripts/add_circuit/state_prep.py
+++ b/scripts/add_circuit/state_prep.py
@@ -198,6 +198,49 @@ def symplectic_validate(circuit: Union[str, stim.Circuit], H: np.ndarray, n: int
     return "passed"
 
 
+def _logical_expectations(
+    circuit: Union[str, stim.Circuit],
+    n: int,
+    d: int,
+    *,
+    Hx: Optional[np.ndarray] = None,
+    Hz: Optional[np.ndarray] = None,
+    H: Optional[np.ndarray] = None,
+) -> Optional[tuple[list[int], list[int]]]:
+    """``(x_exps, z_exps)``: the expectation of each X-bar and each Z-bar on the
+    state ``circuit`` prepares. Each entry is ``+1``, ``-1`` or ``0``.
+
+    The logical operators are computed from the code matrices in the **circuit's
+    own labeling** (so no permutation is needed). Returns ``None`` when they
+    cannot be pinned down: a non-CSS code with ``k != 1`` (the X-bar/Z-bar
+    ordering is not canonical), or ``k == 0`` (no logical state to speak of).
+    """
+    from .code_identify import build_symplectic_logical
+    from .compute import _compute_logicals_css, _compute_symplectic_logicals
+
+    if Hx is not None and Hz is not None:
+        Lx, Lz = _compute_logicals_css(np.asarray(Hx), np.asarray(Hz), d)
+        logical = build_symplectic_logical(Lx, Lz, n=n, k=Lx.shape[0])
+    elif H is not None:
+        k = n - np.asarray(H).shape[0]
+        if k != 1:
+            return None
+        # Only the expectation (a ±1/0) is read off below, so skip the cosmetic
+        # minimum-weight reduction — any valid logical representative agrees.
+        logical = _compute_symplectic_logicals(np.asarray(H), n, k, minimize=False)
+    else:
+        raise ValueError("Provide (Hx, Hz) or H.")
+
+    k = logical.shape[0] // 2  # rows 0..k-1 are X-bars, k..2k-1 Z-bars
+    if k == 0:
+        return None
+
+    peek = _simulate(circuit, n)  # simulate in full; ancillas may route the data
+    x_exps = [peek(_row_support(logical[i], n)) for i in range(k)]
+    z_exps = [peek(_row_support(logical[k + i], n)) for i in range(k)]
+    return x_exps, z_exps
+
+
 def logical_state_of(
     circuit: Union[str, stim.Circuit],
     n: int,
@@ -211,8 +254,7 @@ def logical_state_of(
 
     Stabilizers alone cannot tell |0_L> from |1_L> (both are +1 eigenstates of
     every stabilizer), so we evaluate the *logical* operator expectations on the
-    prepared state. The logical operators are computed from the code matrices in
-    the **circuit's own labeling** (so no permutation is needed).
+    prepared state.
 
     For CSS codes any ``k`` is supported: ``'zero'`` means the all-zeros state
     |0...0_L> (every Z-bar at +1), ``'plus'`` the all-plus state, and so on.
@@ -223,30 +265,16 @@ def logical_state_of(
     Caveat on sign: the logical operators are recomputed from binary (sign-free)
     matrices, so the *basis* (Z vs X) is robust but the absolute 0/1 (resp. +/-)
     label is only defined relative to the recomputed Z-bar (resp. X-bar) sign.
-    Two labelings of the same code can disagree on which eigenstate is |0>. Use
-    :func:`logical_basis_of` when only the basis matters (the reliable part).
+    Two labelings of the same code can disagree on which eigenstate is |0>. That
+    also makes the unanimity below fragile: a genuine |0...0_L> on a multi-k code
+    can come back with mixed Z-bar signs and land in ``'unknown'``. Use
+    :func:`logical_basis_of` when only the basis matters (the reliable part) —
+    it does not share that fragility.
     """
-    from .code_identify import build_symplectic_logical
-    from .compute import _compute_logicals_css, _compute_symplectic_logicals
-
-    if Hx is not None and Hz is not None:
-        Lx, Lz = _compute_logicals_css(np.asarray(Hx), np.asarray(Hz), d)
-        logical = build_symplectic_logical(Lx, Lz, n=n, k=Lx.shape[0])
-    elif H is not None:
-        k = n - np.asarray(H).shape[0]
-        if k != 1:
-            return "unknown"
-        # Only the expectation (a ±1/0) is read off below, so skip the cosmetic
-        # minimum-weight reduction — any valid logical representative agrees.
-        logical = _compute_symplectic_logicals(np.asarray(H), n, k, minimize=False)
-    else:
-        raise ValueError("Provide (Hx, Hz) or H.")
-
-    k = logical.shape[0] // 2  # rows 0..k-1 are X-bars, k..2k-1 Z-bars
-
-    peek = _simulate(circuit, n)  # simulate in full; ancillas may route the data
-    x_exps = [peek(_row_support(logical[i], n)) for i in range(k)]
-    z_exps = [peek(_row_support(logical[k + i], n)) for i in range(k)]
+    exps = _logical_expectations(circuit, n, d, Hx=Hx, Hz=Hz, H=H)
+    if exps is None:
+        return "unknown"
+    x_exps, z_exps = exps
     if all(x == 0 for x in x_exps):
         if all(z == 1 for z in z_exps):
             return "zero"
@@ -272,10 +300,31 @@ def logical_basis_of(
     Hz: Optional[np.ndarray] = None,
     H: Optional[np.ndarray] = None,
 ) -> str:
-    """Sign-convention-free part of :func:`logical_state_of`: returns ``'z'``
-    (a Z-basis eigenstate, |0>/|1>), ``'x'`` (an X-basis eigenstate, |+>/|->),
-    or ``'unknown'``."""
-    return _STATE_BASIS.get(logical_state_of(circuit, n, d, Hx=Hx, Hz=Hz, H=H), "unknown")
+    """Which basis the prepared logical state lives in: ``'z'`` (|0>/|1>),
+    ``'x'`` (|+>/|->), or ``'unknown'``.
+
+    The sign-convention-free part of :func:`logical_state_of`, and computed
+    directly rather than derived from it. Deriving would inherit that function's
+    demand that the Z-bar signs be *unanimous*, which the sign-free logical
+    matrices cannot guarantee: a genuine |0...0_L> on a multi-k code routinely
+    comes back with mixed signs. A state with mixed Z-bar signs is still
+    unambiguously a Z-basis eigenstate, so the basis is well-defined in exactly
+    the cases the 0/1 label is not. Hence ``abs(e) == 1`` rather than ``e == 1``.
+
+    Meaningful for CSS codes, where X-bar is pure-X and Z-bar is pure-Z and the
+    labels are therefore intrinsic. For a non-CSS code both logical operators are
+    mixed-type Paulis, so which is called X-bar is a convention and the result
+    inherits that arbitrariness — callers should not use it there.
+    """
+    exps = _logical_expectations(circuit, n, d, Hx=Hx, Hz=Hz, H=H)
+    if exps is None:
+        return "unknown"
+    x_exps, z_exps = exps
+    if all(e == 0 for e in x_exps) and all(abs(e) == 1 for e in z_exps):
+        return "z"
+    if all(e == 0 for e in z_exps) and all(abs(e) == 1 for e in x_exps):
+        return "x"
+    return "unknown"
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_logical_state_multi_k.py
+++ b/scripts/tests/test_logical_state_multi_k.py
@@ -29,3 +29,40 @@ def test_zero_state_k2():
 def test_plus_state_k2():
     assert logical_state_of(PLUS_CIRCUIT, 4, 2, Hx=H422, Hz=H422) == "plus"
     assert logical_basis_of(PLUS_CIRCUIT, 4, 2, Hx=H422, Hz=H422) == "x"
+
+
+def test_basis_survives_mixed_logical_signs():
+    """The 0/1 label needs the Z-bar signs to be unanimous; the basis does not.
+
+    Flipping one logical qubit gives |01>_L — still unambiguously a Z-basis
+    eigenstate, but with one Z-bar at -1. logical_state_of must fall through to
+    'unknown', while logical_basis_of must still say 'z'. This is the case the
+    old wrapper implementation got wrong, and it is not exotic: because the
+    logicals are recomputed from sign-free matrices, a genuine |0...0>_L on a
+    multi-k code lands here routinely.
+    """
+    from scripts.add_circuit.compute import _compute_logicals_css
+
+    # Apply a logical X to one of the two logical qubits of |00>_L.
+    lx, _ = _compute_logicals_css(H422, H422, 2)
+    flip = "".join(f"X {i}\n" for i in range(4) if lx[0][i])
+    mixed = ZERO_CIRCUIT + flip
+
+    assert logical_state_of(mixed, 4, 2, Hx=H422, Hz=H422) == "unknown"
+    assert logical_basis_of(mixed, 4, 2, Hx=H422, Hz=H422) == "z"
+
+
+def test_no_uniform_basis_is_unknown():
+    """A state with no uniform single-basis logical label must still report
+    'unknown' — the sign tolerance must not swallow this case into 'z'/'x'."""
+    # A physical Hadamard on one data qubit leaves the codespace entirely.
+    assert logical_basis_of(ZERO_CIRCUIT + "H 0\n", 4, 2, Hx=H422, Hz=H422) == "unknown"
+
+
+def test_k0_has_no_logical_state():
+    """With no logical qubits there is no logical state; the all() guards would
+    otherwise be vacuously true and report 'zero'/'z'."""
+    # [[2,0,?]]: Hx = Hz = [1 1] leaves k = 0.
+    h = np.array([[1, 1]])
+    assert logical_state_of("H 0\nCX 0 1", 2, 1, Hx=h, Hz=h) == "unknown"
+    assert logical_basis_of("H 0\nCX 0 1", 2, 1, Hx=h, Hz=h) == "unknown"

--- a/scripts/tests/test_validate_circuits.py
+++ b/scripts/tests/test_validate_circuits.py
@@ -138,6 +138,65 @@ def test_logical_input_count_catches_what_codespace_check_cannot(tmp_path):
     assert results[0].passed is False
 
 
+# [[4,2,2]] code: Hx = Hz = [1 1 1 1], k = 2 — CSS, so the basis is meaningful.
+CODE_422 = {
+    "name": "422",
+    "n": 4,
+    "k": 2,
+    "d": 2,
+    "h": [[1, 1, 1, 1, 0, 0, 0, 0], [0, 0, 0, 0, 1, 1, 1, 1]],
+    "logical": [
+        [1, 1, 0, 0, 0, 0, 0, 0],
+        [1, 0, 1, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 1, 0, 1, 0],
+        [0, 0, 0, 0, 1, 1, 0, 0],
+    ],
+    "canonical_hash": "x",
+}
+
+ZERO_PREP_422 = "H 0\nCX 0 1 0 2 0 3\n"
+PLUS_PREP_422 = ZERO_PREP_422 + "H 0 1 2 3\n"
+
+
+def test_logical_basis_passes_on_correct_tag(tmp_path):
+    results = _build(
+        tmp_path, ZERO_PREP_422, code=CODE_422, tags=("state-preparation", "logical-state:zero")
+    )
+    assert _checks(results)["logical_basis"].status == "passed"
+
+
+def test_logical_basis_catches_wrong_basis_tag(tmp_path):
+    """The error class this check exists for: the body prepares |+>_L but the
+    circuit is filed as |0>_L. The codespace check cannot see it — every codeword
+    satisfies every stabilizer regardless of logical state."""
+    results = _build(
+        tmp_path, PLUS_PREP_422, code=CODE_422, tags=("state-preparation", "logical-state:zero")
+    )
+    checks = _checks(results)
+    assert checks["validate_state_prep"].status == "passed"  # blind to this
+    assert checks["logical_basis"].status == "failed"
+    assert "'x'-basis state" in checks["logical_basis"].detail
+    assert results[0].passed is False
+
+
+def test_logical_basis_skipped_for_non_css(tmp_path):
+    """Non-CSS: X-bar/Z-bar labeling is a convention, so there is no
+    convention-independent basis to check. Skipped explicitly, with a reason."""
+    results = _build(
+        tmp_path, _FIVE_QUBIT_ENCODER, tags=("state-preparation", "logical-state:zero")
+    )
+    check = _checks(results)["logical_basis"]
+    assert check.status == "skipped"
+    assert "convention" in check.detail
+
+
+def test_logical_basis_skipped_without_tag(tmp_path):
+    results = _build(tmp_path, ZERO_PREP_422, code=CODE_422, tags=("state-preparation",))
+    check = _checks(results)["logical_basis"]
+    assert check.status == "skipped"
+    assert "no logical-state" in check.detail
+
+
 def test_all_skipped_checks_count_as_skipped_not_failed():
     """A circuit whose only check is 'skipped' must report is_skipped=True and
     passed=False, so the summary counts it as skipped rather than a failure."""

--- a/scripts/validate_circuits.py
+++ b/scripts/validate_circuits.py
@@ -8,6 +8,8 @@ code's symplectic ``h`` — CSS and non-CSS codes alike:
   - Encoding: validate_encoding_h (circuit maps |0...0⟩ to the code space)
             + logical_input_count (the encoder has exactly k free inputs)
   - State-prep: validate_state_prep_h (all stabilizers satisfied)
+              + logical_basis (prepares the basis its logical-state tag claims;
+                CSS codes only)
 
 Usage:
     uv run python scripts/validate_circuits.py
@@ -34,6 +36,11 @@ from scripts.add_circuit.circuit_validate import (  # noqa: E402
     validate_encoding_h,
     validate_state_prep_h,
 )
+from scripts.add_circuit.code_identify import split_h_to_css  # noqa: E402
+from scripts.add_circuit.state_prep import logical_basis_of  # noqa: E402
+
+# logical-state tag -> the basis the prepared state must live in.
+_TAG_BASIS = {"zero": "z", "one": "z", "plus": "x", "minus": "x"}
 
 
 @dataclass
@@ -136,6 +143,7 @@ def validate_all(data_dir: str = "data_yaml") -> list[CircuitResult]:
             _check_logical_input_count(result, circuit_text, h, n, code_data.get("k"))
         elif circuit_type == "state-preparation":
             _check_state_prep(result, circuit_text, h, n)
+            _check_logical_basis(result, circuit_text, h, n, code_data.get("d"), tags)
 
         results.append(result)
 
@@ -162,6 +170,78 @@ def _check_state_prep(result: CircuitResult, circuit_text: str, h: np.ndarray, n
             result.checks.append(CheckResult("validate_state_prep", "failed", outcome))
     except Exception as e:
         result.checks.append(CheckResult("validate_state_prep", "error", str(e)))
+
+
+def _check_logical_basis(
+    result: CircuitResult,
+    circuit_text: str,
+    h: np.ndarray,
+    n: int,
+    d: int | None,
+    tags: list[str],
+) -> None:
+    """A state-prep must prepare a logical state in the basis its tag claims.
+
+    Complementary to the codespace check, which is basis-blind: every codeword is
+    a +1 eigenstate of every stabilizer, so ``validate_state_prep`` cannot tell
+    |0>_L from |+>_L. Only the logical operators distinguish them.
+
+    Basis, not the full 0/1 label: ``codes.logical`` is sign-free, so which
+    eigenstate is called |0> is not determined by stored data (see
+    :func:`logical_state_of`'s caveat). The basis is.
+
+    CSS only, on principle rather than as a gap: for a non-CSS code both logical
+    operators are mixed-type Paulis, so which is X-bar and which is Z-bar is a
+    labeling convention and the basis inherits that arbitrariness. There is no
+    convention-independent answer to check against.
+    """
+    tag = next((t.split(":", 1)[1] for t in tags if t.startswith("logical-state:")), "")
+    if not tag:
+        result.checks.append(CheckResult("logical_basis", "skipped", "no logical-state: tag"))
+        return
+    expected = _TAG_BASIS.get(tag)
+    if expected is None:
+        result.checks.append(
+            CheckResult("logical_basis", "skipped", f"logical-state:{tag} names no basis")
+        )
+        return
+    css = split_h_to_css(h, n)
+    if css is None:
+        result.checks.append(
+            CheckResult(
+                "logical_basis",
+                "skipped",
+                "non-CSS: X-bar/Z-bar labeling is a convention, so the basis is not well-defined",
+            )
+        )
+        return
+    if d is None:
+        result.checks.append(CheckResult("logical_basis", "error", "Code YAML missing d"))
+        return
+    try:
+        got = logical_basis_of(circuit_text, n, d, Hx=css[0], Hz=css[1])
+        if got == expected:
+            result.checks.append(CheckResult("logical_basis", "passed"))
+        elif got == "unknown":
+            result.checks.append(
+                CheckResult(
+                    "logical_basis",
+                    "failed",
+                    f"failed: tagged logical-state:{tag} (basis {expected!r}), but the circuit "
+                    "prepares no uniform single-basis logical state",
+                )
+            )
+        else:
+            result.checks.append(
+                CheckResult(
+                    "logical_basis",
+                    "failed",
+                    f"failed: tagged logical-state:{tag} (basis {expected!r}), "
+                    f"but the circuit prepares a {got!r}-basis state",
+                )
+            )
+    except Exception as e:
+        result.checks.append(CheckResult("logical_basis", "error", str(e)))
 
 
 def _check_logical_input_count(

--- a/uv.lock
+++ b/uv.lock
@@ -829,7 +829,7 @@ wheels = [
 
 [[package]]
 name = "qecirc-website"
-version = "0.5.3"
+version = "0.5.4"
 source = { virtual = "." }
 dependencies = [
     { name = "mqt-qecc" },


### PR DESCRIPTION
Implements #114, following #113.

## The gap

`validate_state_prep` is basis-blind. Every codeword is a `+1` eigenstate of every stabilizer, so it cannot tell `|0>_L` from `|+>_L` — only the logical operators distinguish them. A circuit filed as `logical-state:zero` that actually prepares `|+>_L` passes every check we have.

Demonstrated by appending a transversal `H` to a Steane `|0>_L` prep, turning it into `|+>_L` while leaving the tag alone:

```
validate_state_prep: ok
logical_basis: FAIL (failed: tagged logical-state:zero (basis 'z'), but the circuit prepares a 'x'-basis state)
```

## What's here

**1. A `logical_basis` check** on state-preps, comparing `logical_basis_of` against the `logical-state:` tag.

*Basis, not the full 0/1 label.* `codes.logical` is sign-free, so which eigenstate is called `|0>` isn't determined by stored data. I measured a `logical_state_of` check first: it would false-fail **43** circuits, all `tag=zero, got=one`. That approach is closed, not deferred (#114 has the numbers).

*CSS only, on principle rather than as a gap.* For a non-CSS code both logical operators are mixed-type Paulis (the five-qubit code's stored rows are `X_YY_` and `Z_XX_`), so which is X-bar and which is Z-bar is a labeling convention and the basis inherits that arbitrariness. There is no convention-independent answer to check against — the same reason `_readout_basis` already refuses non-CSS. Those 54 circuits skip **with that reason stated**, not silently.

**2. A fix to `logical_basis_of`, which the check depends on.** It advertised itself as the "sign-convention-free part" of `logical_state_of` but was implemented as a lookup on that function's *output*, inheriting its demand that the Z-bar signs be **unanimous**. Sign-free logicals cannot guarantee that: a genuine `|0...0>_L` on a multi-k code routinely returns mixed signs, and mixed signs are still unambiguously a **Z-basis** eigenstate. So it reported `unknown` in exactly the cases where the basis *is* well-defined. It now computes the basis directly (`abs(e) == 1`, not `e == 1`).

That single flaw accounted for all 53 CSS `unknown`s in #114's original table — which is why that issue's "57 unknown, must be reported honestly" is corrected there to full coverage. Two side effects:
- The ingestion path (`state_prep.py:533`) can now use the basis it already intends to for multi-k CSS codes, instead of silently falling back to the source label. No existing tag changes — all 357 agree either way.
- `k == 0` now reports `unknown` rather than `zero` (both `all()` guards were vacuously true).

**3. `validate_circuits.py` now runs in CI.** It was only a manual checkbox in the PR template, gated on *"if `data_yaml/` changed"* — so nothing in this PR, or in #113, ran automatically. That is half of how #134 survived: the checkbox relies on memory, and the validator skipped the circuit anyway. A full run is **27s**; I verified it exits 1 on a corrupted body and 0 once restored.

Flagging this as the one piece that is a judgment call rather than a bug fix — easy to drop if you would rather it landed separately.

## Results

| state-preps | checked | skipped (non-CSS) | failed |
|---|---|---|---|
| `logical_basis` | **357** | 54 | **0** |

Whole library still 479/479. 249 Python tests pass; ruff, Prettier, ESLint, and `validate:yaml` clean. Re-verified against current `main` (0.5.3) after #113/#115–#119 landed, not carried over from the earlier branch.

Version 0.5.3 → 0.5.4 (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)