### PR TITLE
feat(search): find circuits by paper, alias, and code tag

### DIFF
--- a/.claude/commands/add-circuit.md
+++ b/.claude/commands/add-circuit.md
@@ -186,6 +186,43 @@ If the code has a `zoo_url`, or if the user wants you to find one:
 3. **Map to existing tags**: Only propose tags that already exist in the library. If the Zoo mentions something not in the vocabulary, ask the user if they want to add it as a new tag.
 4. **Add `zoo_url`** to the code YAML if not already present.
 
+### 4c-bis. Paper lookup — the circuit's `source`
+
+If `source` is a link, the work it points at should be in `data_yaml/papers/` —
+that is what makes the circuit findable by title, author and arXiv id rather than
+by bare URL alone. **This is scripted; do not write the YAML yourself:**
+
+```bash
+npm run papers:add -- <the source link, arXiv id, or DOI>
+```
+
+It fetches from arXiv (or Crossref for a DOI-only source), writes
+`data_yaml/papers/<slug>.yaml`, and prints `HAVE …` and changes nothing if the
+paper is already catalogued — so it is always safe to run.
+
+**Never hand-write or recall paper metadata.** Author lists are facts about real
+people; a wrong one is a misattribution that renders on the page and in the
+circuit's JSON-LD. Papers are also routinely newer than your training data. If
+the script fails, read the publisher's page — do not fill the fields in from
+memory.
+
+Circuits do **not** reference papers: `create_database.mjs` matches `source`
+against each paper's url/arxiv_id/doi (tolerating http/https, trailing slashes,
+`dx.doi.org`, `/pdf/` vs `/abs/`, and version suffixes). So writing the paper file
+is the entire job — no circuit YAML changes, and every other circuit citing that
+work is enriched too.
+
+Then confirm it linked. `npm run db:create` prints:
+
+```
+Papers: 7, linked to 724 circuits.
+```
+
+and lists any source with no paper behind it. The new circuit must not be in that
+list. A source that is not arXiv/DOI (a bare tool name like `circuit-synth`, a
+free-form citation) has no paper and that is correct — not every circuit comes
+from a paper.
+
 ### 4d. Circuit tags — ask the user
 
 Circuit tags require user input. Ask explicitly:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,70 @@ the source-of-truth `package.json` version.
 
 ## Unreleased
 
+### Added
+
+- **Search aliases** (`data/migrations/017`). Codes and tools gain optional
+  `aliases:`, and codes `related:`, hand-written with the Error Correction Zoo as
+  reference. `laflamme` → the five-qubit code, `kitaev` → surface codes,
+  `bb codes` → 28 circuits instead of 824. `related` names a _different, adjacent_
+  code (`toric` → planar surface codes) and `/search` says so rather than
+  silently equating them. See
+  [docs/superpowers/plans/2026-07-15-search-aliases.md](docs/superpowers/plans/2026-07-15-search-aliases.md).
+- **Code tags reach `/search`** (`data/migrations/019`). `circuit_search.tags`
+  was built only from `taggable_type = 'circuit'`, so every code-level tag was
+  invisible: `LDPC`, `topological`, `self-dual`, `surface-code` and `color-code`
+  each matched zero circuits despite 4 codes being tagged LDPC and 10
+  surface-code. They now ride in their own `code_tags` column — separate from
+  `tags` so a name used at both levels cannot double-count. It failed silently
+  because `search_terms` already indexed code tags, so spelling correction
+  considered `topological` a real word and left the dead query alone.
+- **`scripts/add_paper.py`** — fetches paper metadata from arXiv/Crossref into
+  `data_yaml/papers/`, so it is never hand-written or recalled from memory.
+  `npm run papers:add -- <arXiv id | DOI | link>` for one;
+  `npm run papers:missing` scans every circuit `source` and fetches whatever has
+  no paper yet (idempotent — the one to run after a bulk import). Refuses to
+  write a record with no authors rather than emit a half-citation. Stdlib only,
+  no new dependency.
+  - This is the **only** part of the repo that touches the network, and it is a
+    maintainer tool whose output is committed — the same shape as
+    `annotate_circuits.py`. `db:create` and the site read committed YAML only and
+    build identically offline.
+- **Papers are searchable.** A circuit taken from a paper can now be found on
+  `/search` by the paper's title, authors and arXiv id — none of which existed
+  anywhere in the library before, since `circuits.source` holds only a link.
+  Searching `reinforcement learning`, `Forlivesi` or `boolean satisfiability`
+  now finds the circuits from those papers.
+  - New `data_yaml/papers/` (7 files) and a `papers` table, with `circuits.paper_id`.
+  - **Circuits do not declare their paper.** `db:create` resolves `source` against
+    each paper's `url`/`arxiv_id`/`doi`, tolerating http/https, trailing slashes,
+    `dx.doi.org`, `/pdf/` vs `/abs/`, and arXiv version suffixes. Adding a paper file
+    enriches every circuit citing it; no circuit YAML changes. 724 of 833 circuits
+    link; the remaining 109 carry `source: circuit-synth`, a tool rather than a work.
+  - `circuit_search` gains a weighted `paper` column (migration 017 recreates the
+    FTS5 table — it has no `ADD COLUMN`), and `search_terms` indexes paper titles and
+    authors so spelling correction knows author names.
+  - Paper text is `/search`-only. The header quick-search is for jumping to a known
+    thing, and one paper backs up to 370 circuits.
+
+### Changed
+
+- **BM25 weights and the strict column set are derived from the table**
+  (`src/lib/queries/search-schema.ts`), not restated by hand. Both drifted from
+  `circuit_search` while this branch was being built — a 7-entry weight array for
+  8 columns (silently scoring `paper` as `notes`), and a strict set missing
+  `paper` (which announced "no code goes by that name" for an exact author
+  match). Weights are now keyed by column name and ordered from
+  `PRAGMA table_info`; a column with no weight throws and names itself instead of
+  being silently scored 1.0. `scripts/smoke.sh` additionally asserts that a query
+  reaching each of `aliases`, `code_tags` and `paper` still returns circuits.
+- A circuit's source now renders as a citation ("Zen et al. (2024) · arXiv:2402.17761")
+  instead of a bare URL, on circuit rows, detail pages and the cite toast. Detail pages
+  emit the paper as a schema.org `ScholarlyArticle` with its real authors, rather than a
+  URL string.
+- The landing page's "Papers" stat counts the `papers` table instead of inferring papers
+  from distinct `source` values that are not a tool's own links. Same number today, but
+  it no longer guesses.
+
 ### Removed
 
 - The `Circuit-Synth Encoding (Gate-Optimized)` circuit for the Gottesman

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,28 +29,51 @@ Tags can be either **structured** (`key:value`, e.g. `distance:3`) or **free-for
 
 Circuits also have numeric **metrics** for filtering: `gate_count`, `depth`, `qubit_count`.
 
+A circuit taken from a published work also links to a **paper**, which is what makes it
+findable by title, author or arXiv id. The link is **derived, not declared**: `circuits.source`
+already holds the provenance link, so `create_database.mjs` matches it against each paper's
+`url`/`arxiv_id`/`doi` rather than making 833 circuit files repeat it. Add a paper and every
+circuit citing it is enriched at the next build; a source with no paper is not an error
+(`source: circuit-synth` names a tool, not a work), it just leaves the circuit searchable by
+URL alone. Both the build and `validate:yaml` report such sources.
+
 ### Database Schema
 
 ```
 codes
-  id, name, slug, n, k, d, zoo_url,
+  id, name, slug, n, k, d, zoo_url, aliases, related,
   h, logical, canonical_hash, created_at
   -- n, k, d: code parameters [[n,k,d]] for direct querying/sorting
   -- zoo_url: optional link to QEC Zoo
+  -- aliases: other names for THIS code, space-joined (e.g. "Laflamme code")
+  -- related: names of a DIFFERENT, adjacent code people use loosely (e.g.
+     "toric code" for a planar surface code). Matched only as a last resort,
+     and /search says so. See "Search" below.
   -- h: symplectic stabilizer matrix, shape (n−k) × 2n, JSON-encoded
   -- logical: symplectic logical operators, shape 2k × 2n, JSON-encoded
   -- For CSS codes, the Hx/Hz/Lx/Lz view is derived in the UI via splitHToCss
   -- canonical_hash: SHA256 of canonical form for dedup (indexed)
 
 tools
-  id, name, slug, description, homepage_url, github_url, paper_urls, created_at
+  id, name, slug, description, homepage_url, github_url, paper_urls, aliases, created_at
   -- software tools used to create circuits
   -- paper_urls: JSON-encoded array of associated paper URLs
+  -- aliases: other names, space-joined (e.g. "Munich Quantum Toolkit")
+
+papers
+  id, slug, title, authors, year, arxiv_id, doi, journal_ref, url, created_at
+  -- published works circuits are taken from; the ONLY place titles/authors exist
+  -- authors: JSON-encoded array of names, in author order
+  -- arxiv_id: bare id, no "arXiv:" prefix, no version suffix ("2402.17761")
+  --   MUST be quoted in YAML — unquoted it parses as a float and loses digits
+  -- url: canonical link, and the value circuits.source is matched against
 
 circuits
   id, qec_id, code_id → codes, name, slug, notes, source,
   gate_count, two_qubit_gate_count, depth, qubit_count,
-  crumble_url, quirk_url, tool_id → tools, created_at
+  crumble_url, quirk_url, tool_id → tools, paper_id → papers, created_at
+  -- paper_id: resolved from `source` at build time, NOT declared in YAML.
+  --   NULL when the source names a tool or cites an uncatalogued work.
   -- qec_id: permanent globally unique circuit identifier (displayed as #N, never reused)
   -- source: provenance (DOI, URL, or citation)
   -- gate_count, two_qubit_gate_count, depth, qubit_count: numeric metrics for filtering
@@ -130,25 +153,64 @@ A maintainer reviews the issue, then uses the ingestion pipeline to add the circ
 
 **Search — two engines, on purpose.** They share a spelling dictionary, nothing else.
 
-|          | header quick-search (`/api/search`)  | `/search`                 |
-| -------- | ------------------------------------ | ------------------------- |
-| Job      | jump to a known thing                | find things               |
-| Scope    | codes, circuits, tools               | circuits only             |
-| Matching | LIKE, **substring** — names and tags | FTS5 tokens, plus `notes` |
-| Order    | alphabetical, grouped by type        | BM25 relevance            |
+|          | header quick-search (`/api/search`)            | `/search`                                                  |
+| -------- | ---------------------------------------------- | ---------------------------------------------------------- |
+| Job      | jump to a known thing                          | find things                                                |
+| Scope    | codes, circuits, tools                         | circuits only                                              |
+| Matching | LIKE, **substring** — names, aliases, and tags | FTS5 tokens, plus `code_tags`, `paper`, `notes`, `related` |
+| Order    | alphabetical, grouped by type                  | BM25 relevance                                             |
 
 **Do not "unify" these by pointing the quick-search at the FTS index.** LIKE matches mid-word (`ycle` → Bivariate Bicycle Code), which token-based FTS cannot — that is what makes a type-ahead usable. There is also no FTS index for codes or tools, and pulling `notes` into a 10-item navigation list would surface circuits that merely mention the term. Enter with nothing highlighted hands over to `/search`; that is where the two meet.
 
-`/search` ranks by BM25 over the `circuit_search` FTS5 table (`data/migrations/016`), which `scripts/db/create_database.mjs` repopulates on every build, and is forgiving in three layers, applied in this order (`src/lib/queries/search.ts` → `resolveQuery`):
+**Paper text is `/search`-only, for the same reason.** One paper backs up to 370 circuits, so matching a title in a 10-item navigation dropdown would fill it with near-identical rows and bury the code or tool the user was actually jumping to. A paper is something you _find circuits by_, not something you navigate to — there is no paper page to land on.
+
+`/search` ranks by BM25 over the `circuit_search` FTS5 table (migrations `016`–`019`), which `scripts/db/create_database.mjs` repopulates on every build. Its **nine columns** are `circuit_id, name, code_name, aliases, related, tags, code_tags, paper, notes` — and that order is load-bearing (see `BM25_WEIGHTS` below).
+
+What a circuit is findable by, and where each comes from:
+
+| column      | holds                                     | so that                                       |
+| ----------- | ----------------------------------------- | --------------------------------------------- |
+| `aliases`   | the **code's** other names (017)          | `laflamme` reaches the five-qubit code        |
+| `related`   | a **different, adjacent** code's name     | `toric` reaches planar surface codes, flagged |
+| `tags`      | the **circuit's** own tags                | `flag`, `distance:3`                          |
+| `code_tags` | the **code's** tags (019)                 | `LDPC`, `topological`, `self-dual`            |
+| `paper`     | title, authors, ids of its source (018)   | `reinforcement learning`, `forlivesi`         |
+| `notes`     | prose + `source` + the **tool's** aliases | everything else                               |
+
+`/search` is forgiving in layers, applied in this order (`src/lib/queries/search.ts` → `resolveQuery`):
 
 1. **Stemming** — `circuit_search` uses the `porter` tokenizer, so `encodings`/`encode`/`encoding` meet at one term.
 2. **Spelling correction** — `src/lib/queries/spelling.ts` maps a token that matches _nothing_ to its nearest word in the `search_vocab` dictionary (Damerau-Levenshtein, Elasticsearch "AUTO" edit budget). Shared with the quick-search, so the two agree on what exists. Only unmatched tokens are touched, so a query that already works is never rewritten. Tokens containing digits are never corrected: `#508` is one edit from an arXiv `2508`, and `distance:3` from `distance:5`. `?literal=1` opts out.
-3. **OR fallback** — if no circuit matches _every_ term, the query is retried as "any term" and the page says so.
+3. **The resolution ladder** — `resolveQuery` tries four expressions and stops at the first with hits. Each rung concedes more than the one above it:
+   1. every term, over `STRICT_COLUMNS` — what was asked for
+   2. every term, allowing `related` — a neighbouring code, **flagged to the user**
+   3. any term, `STRICT_COLUMNS` — `partial`
+   4. any term, allowing `related`
+
+   (2) precedes (3) deliberately: widening `toric code` to "any term" matches every circuit containing "code" (824 of 833), whereas allowing `related` returns the 98 surface codes actually meant.
+
+**Column weights and the strict column set are DERIVED, not restated** (`src/lib/queries/search-schema.ts`). Both used to be hand-maintained constants, and both drifted from the table within a week despite shouty comments. `PRAGMA table_info(circuit_search)` returns the real columns in declaration order — which is exactly what `bm25()` wants — so:
+
+- **To add a column:** put it in the migration's `CREATE`, then give it a weight in `COLUMN_WEIGHTS` (keyed by name; order there is irrelevant). That is the whole checklist.
+- **Forget the weight and it throws**, naming the column, instead of FTS5 silently scoring it 1.0 and mis-ranking everything.
+- **The strict set needs no upkeep**: it is every column minus `circuit_id` (UNINDEXED — naming it in a filter is an FTS5 error) and minus `LOOSE_COLUMNS`. New columns are strict by default, which is the safe direction — wrongly-loose tells a user their exact query found nothing.
+
+**Aliases — a data layer, not a forgiveness layer** (`data/migrations/017`). Codes and tools carry optional `aliases:` (and codes, `related:`) in their YAML; a circuit inherits its code's. The layers above cannot substitute for it: `bb` is two characters, so `editBudget` allows it zero edits, and before this existed `bb codes` returned 824 of 833 circuits — the OR fallback firing on `codes`.
+
+- `aliases` = **another name for this code**. Matched silently; the gross code _is_ a BB code.
+- `related` = **a different, adjacent code** people reach for loosely. Matched only as a last resort, and `/search` says so. The quick-search ignores `related` entirely: a dropdown has no room to explain itself.
+- **Hand-written, not imported.** [errorcorrectionzoo.org](https://errorcorrectionzoo.org) publishes `alternative_names`, but `eczoo_data` is CC-BY-SA 4.0 and this repo is MIT. Use it as reference; do not add an import script. Its taxonomy is not an alias source either — two parents above the rotated surface code sits "Quantum Tanner code".
+- **Only alias what exists here.** An alias for a concept with no circuits behind it (`MWPM`, `lattice surgery`) resolves to nothing.
+- **Tool aliases ride in `notes`**, not `aliases`: every circuit from a tool would otherwise match its every alias at `code_name` weight.
 
 Gotchas if you touch this:
 
 - `search_vocab` must stay **unstemmed** (it indexes `search_terms`, not `circuit_search`) or suggestions become stems — porter stores "steane" as "stean".
-- `search_terms` must keep covering **codes and tools**, not just circuits: a tool with no circuits appears in no circuit text, so a circuit-only dictionary cannot fix `autqce` → `autqec`.
+- `search_terms` must keep covering **codes, tools and papers**, not just circuits: an entity with no circuits appears in no circuit text, so a circuit-only dictionary cannot fix `autqce` → `autqec`. It indexes aliases too, which is what stops a known alias being "corrected" into something else (`msd` → `msb`).
+- **A short, repeated column wants a LOW weight, not a high one.** This is the one thing `search-schema.ts` cannot check for you. BM25 normalizes term frequency by field length, so a hit in a ~25-token `paper` already outscores the same hit in long `notes` before any weight applies. `paper` at 3.0 put 140 `non-ft` circuits at the top of "fault tolerant" — matched on their paper's _title_ — above the genuinely FT circuits whose notes say so. It is 1.0 for that reason. The same trap awaits any future short column.
+- Adding a column to `circuit_search` means **dropping and recreating** it in a migration — FTS5 has no `ADD COLUMN`. That is cheap here because `create_database.mjs` repopulates the index on every build.
+- **Code tags are not circuit tags.** `taggings` keys on `taggable_type`, and `circuit_search.tags` only ever held `'circuit'` rows — so `LDPC`/`topological`/`self-dual` matched nothing until `code_tags` (019). They are kept in separate columns so a name used at both levels cannot double-count its own term frequency.
+- Diacritics fold, **`ß` does not**: `remove_diacritics 2` turns `Müller` into `muller`, but `Heußen` indexes as `heußen`, and `Mueller` is not `Müller` either. Both still resolve — via spelling correction, not the tokenizer (`heussen` is 2 edits from `heußen`, `mueller` 1 from `muller`) — so they show the "showing results for" banner. If you ever tighten the edit budget, check these still land.
 - The findability probe asks **both** indexes. `circuit_search` alone would call a tool name a typo; `search_terms` alone is unstemmed and would "correct" `encodings` → `encoding`. Neither answers both cases.
 - Results and facets must be built from the _same_ `ResolvedQuery`, or the filter counts describe a different search than the list.
 
@@ -176,6 +238,7 @@ This keeps the site fast and simple while scaling comfortably to thousands of ci
 │   └── qecirc.db          # SQLite database (gitignored, built from data_yaml/)
 ├── data_yaml/             # Source of truth for all library data (git-tracked)
 │   ├── tools/             # One YAML per tool (e.g. mqt-qecc.yaml)
+│   ├── papers/            # One YAML per cited paper (e.g. zen-2024-rl-state-prep.yaml)
 │   ├── codes/             # One YAML per code (e.g. steane-code.yaml)
 │   └── circuits/          # YAML + body files per circuit (e.g. steane-code--standard-encoding.yaml/.stim)
 │       └── originals/     # Original (pre-canonicalization) STIM and matrices per circuit
@@ -260,7 +323,12 @@ This project uses a dual-license model:
 
 - **YAML is the source of truth** — all library data in `data_yaml/`, SQLite is derived
 - **Minimal dependencies** — exhaust built-ins and stdlib before adding a package
-- **No external services** — SQLite only, no hosted DB, no third-party APIs
+- **No external services** — SQLite only, no hosted DB, no third-party APIs. This governs the
+  **site**: every build (`db:create`) and every request reads committed YAML, and both work
+  offline. The one exception is `scripts/add_paper.py`, a maintainer tool that fetches paper
+  metadata from arXiv/Crossref once and writes YAML you commit — the same shape as
+  `annotate_circuits.py`. Nothing at build or request time depends on it. Do not let a fetch
+  creep into the build.
 - **Hosting-agnostic** — use standard Node.js; avoid platform-specific APIs
 - **Standard tooling** — no niche or experimental libraries
 
@@ -275,6 +343,8 @@ npm run preview                     # Preview production build locally
 npm run lint                        # ESLint
 npm run format:check                # Check Prettier formatting
 npm run format                      # Auto-format with Prettier
+npm run papers:add -- 2402.17761    # Fetch a paper (arXiv id/DOI/link) into data_yaml/papers/
+npm run papers:missing              # Fetch every circuit source that has no paper yet
 npm run validate:yaml               # Validate data_yaml/ schemas
 npm run validate:circuits           # Validate encoding/state-prep circuits against the code's symplectic h (CSS and non-CSS alike)
 uv run ruff check scripts/          # Lint Python code

--- a/data/migrations/017_search_aliases.sql
+++ b/data/migrations/017_search_aliases.sql
@@ -1,0 +1,53 @@
+-- Alternative names for codes and tools.
+--
+-- Codes have many names and the catalogue stores one, so every other name a
+-- reader might type was a dead query: "laflamme", "checkerboard", "toric" and
+-- "kitaev" all returned nothing, and "bb codes" returned 824 of 833 circuits --
+-- `bb` matched nothing, the AND found zero, and the OR fallback then matched
+-- `codes` almost everywhere. None of these are typos, so migration 016's
+-- spelling layer could not reach them: `correctTokens` only rewrites a token
+-- that has a near neighbour in the dictionary, and `bb` is two characters, which
+-- `editBudget` gives zero edits. This is a data gap, not a tuning problem.
+--
+-- Two fields, because two different claims:
+--
+--   aliases -- other names for THIS code. "Laflamme code" IS the five-qubit
+--              code; the gross code IS a BB code. Matched silently.
+--   related -- names of a DIFFERENT but adjacent code that people use loosely.
+--              "toric" strictly means the k=2 code on a torus; ours are planar
+--              (k=1). Matched only when nothing else does, and /search says so.
+--
+-- Names are hand-written, using errorcorrectionzoo.org (which every code already
+-- links to via zoo_url) and the papers as reference. NOT imported: eczoo_data is
+-- CC-BY-SA 4.0 and this repo is MIT, and a bulk import also drags in taxonomy
+-- ancestors -- two hops up from the rotated surface code sits "Quantum Tanner
+-- code", which is a parent in a classification, not another name for it.
+
+-- Denormalised onto the entity for the header quick-search, which is LIKE over
+-- columns of `codes`/`tools` and has no FTS index to consult. Space-joined text
+-- rather than a child table: it is only ever matched as a whole, never queried
+-- by individual alias, and `tags` already sets the precedent for the FTS side.
+ALTER TABLE codes ADD COLUMN aliases TEXT;
+ALTER TABLE codes ADD COLUMN related TEXT;
+ALTER TABLE tools ADD COLUMN aliases TEXT;
+
+-- FTS5 has no ALTER TABLE ADD COLUMN, so the index is recreated rather than
+-- extended. Safe to drop: it holds no source data. create_database.mjs rebuilds
+-- it from `codes`/`circuits` on every build (see 016 -- plain, not
+-- external-content, tables), so this is a schema change only.
+DROP TABLE circuit_search;
+
+-- `related` is its own column, not folded into `aliases`, so a query can ask for
+-- one without the other: /search first matches the strict columns and only
+-- retries including `related` when that finds nothing. Column filter syntax
+-- ({name code_name aliases tags notes} : ...) needs them separated to do that.
+CREATE VIRTUAL TABLE circuit_search USING fts5(
+  circuit_id UNINDEXED,
+  name,
+  code_name,
+  aliases,
+  related,
+  tags,
+  notes,
+  tokenize = 'porter unicode61 remove_diacritics 2'
+);

--- a/data/migrations/018_papers.sql
+++ b/data/migrations/018_papers.sql
@@ -1,0 +1,70 @@
+-- Papers as first-class entities, so a circuit taken from a paper is findable
+-- by the paper's title, authors and arXiv id -- none of which existed anywhere
+-- in the library before. `circuits.source` held only a bare URL, which made
+-- "2402" a search token but "Zen" or "reinforcement learning" nothing at all.
+
+PRAGMA foreign_keys = OFF;
+
+CREATE TABLE papers (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  slug TEXT NOT NULL UNIQUE,
+  title TEXT NOT NULL,
+  authors TEXT NOT NULL,
+  year INTEGER,
+  arxiv_id TEXT,
+  doi TEXT,
+  journal_ref TEXT,
+  url TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  -- authors: JSON-encoded array of names IN AUTHOR ORDER (not a set) -- the
+  --   citation line renders "<first author> et al.", so order is meaning.
+  -- arxiv_id: bare id, no "arXiv:" prefix and no version suffix ("2402.17761",
+  --   or an old-style "quant-ph/9601029").
+  -- url: the canonical link, and the value a circuit's `source` is matched
+  --   against. arXiv abs page where there is one, publisher DOI otherwise.
+);
+
+-- Nullable on purpose, and NOT a replacement for `source`: a circuit's
+-- provenance is sometimes a tool rather than a paper (109 circuits carry
+-- `source: circuit-synth`), and such a row has no paper to point at. `source`
+-- stays the required, free-form provenance field; paper_id only enriches it
+-- where the source resolves to a paper we hold.
+--
+-- Populated by scripts/db/create_database.mjs, which matches each circuit's
+-- `source` against papers.url/arxiv_id/doi. Deliberately not declared in
+-- circuit YAML: the link is derivable from `source`, which every circuit
+-- already has, so duplicating it across 833 files would only add a second
+-- thing to keep in sync.
+ALTER TABLE circuits ADD COLUMN paper_id INTEGER REFERENCES papers(id);
+CREATE INDEX idx_circuits_paper ON circuits(paper_id);
+
+PRAGMA foreign_keys = ON;
+
+-- circuit_search gains a `paper` column (title + authors + ids). Rebuilt from
+-- scratch rather than altered: FTS5 has no ADD COLUMN, and create_database.mjs
+-- repopulates the whole index on every build anyway (see migration 016), so
+-- dropping it costs nothing. Carries forward 017's aliases/related columns.
+--
+-- `paper` is its own column rather than text appended to `notes` so it can be
+-- weighted independently -- which turned out to matter more than expected. See
+-- BM25_WEIGHTS in src/lib/queries/search.ts: it is weighted LOW (1.0), because
+-- paper text is short and identical across every circuit from that paper, and a
+-- higher weight let 140 `non-ft` circuits top a "fault tolerant" search purely
+-- on their paper's title.
+--
+-- Column order is load-bearing: BM25_WEIGHTS is positional, and `paper` must
+-- also be listed in STRICT_COLUMNS (queries/search.ts) or an author search would
+-- miss the strict rung and be reported to the user as a `related` fallback.
+DROP TABLE circuit_search;
+
+CREATE VIRTUAL TABLE circuit_search USING fts5(
+  circuit_id UNINDEXED,
+  name,
+  code_name,
+  aliases,
+  related,
+  tags,
+  paper,
+  notes,
+  tokenize = 'porter unicode61 remove_diacritics 2'
+);

--- a/data/migrations/019_code_tags.sql
+++ b/data/migrations/019_code_tags.sql
@@ -1,0 +1,33 @@
+-- Code tags reach /search.
+--
+-- `circuit_search.tags` is built from taggings where taggable_type = 'circuit',
+-- so tags attached to a CODE never entered the index at all. Every one of
+-- `LDPC`, `topological`, `self-dual`, `surface-code` and `color-code` is a code
+-- tag, and each matched exactly zero circuits -- while 4 codes are tagged LDPC
+-- and 10 are tagged surface-code.
+--
+-- It failed silently rather than loudly: `search_terms` DOES index code tags
+-- (create_database.mjs adds a row per code), so `correctTokens` sees
+-- "topological" as a real term, declines to correct it, and the strict rung
+-- returns nothing. A typo would have been rescued; a correct word was not.
+--
+-- A SEPARATE COLUMN, not folded into `tags`. Today no tag name is used on both a
+-- code and a circuit, so folding would not actually double-count -- but nothing
+-- enforces that, and the day someone tags a circuit `topological` the term would
+-- appear twice in one column and inflate its own term frequency. A code tag also
+-- is not the same claim as a circuit tag: it describes the code the circuit
+-- belongs to, exactly like code_name does, and is weighted to match.
+DROP TABLE circuit_search;
+
+CREATE VIRTUAL TABLE circuit_search USING fts5(
+  circuit_id UNINDEXED,
+  name,
+  code_name,
+  aliases,
+  related,
+  tags,
+  code_tags,
+  paper,
+  notes,
+  tokenize = 'porter unicode61 remove_diacritics 2'
+);

--- a/data_yaml/codes/108-8-10.yaml
+++ b/data_yaml/codes/108-8-10.yaml
@@ -3,6 +3,14 @@ n: 108
 k: 8
 d: 10
 zoo_url: https://errorcorrectionzoo.org/c/bb108
+aliases:
+  - "[[108,8,10]]"
+  - "bb108"
+  - "(9,6) BB6 code"
+  - "BB6 code"
+  - "BB code"
+  - "qLDPC code"
+  - "LDPC code"
 canonical_hash: d9ceb7eca9ef02594d2b6d4ea59342226a4ee7664aa8af0c51e8470144cd656e
 h:
   - [

--- a/data_yaml/codes/144-12-12.yaml
+++ b/data_yaml/codes/144-12-12.yaml
@@ -3,6 +3,14 @@ n: 144
 k: 12
 d: 12
 zoo_url: https://errorcorrectionzoo.org/c/gross
+aliases:
+  - "[[144,12,12]]"
+  - "(3,3) BB6 code"
+  - "BB6 code"
+  - "BB code"
+  - "bivariate bicycle code"
+  - "qLDPC code"
+  - "LDPC code"
 canonical_hash: 0f7eb5b6dab28018a289f880fdc62f2e1f636f034e1cb8d3ae5c8ddc0922ddae
 h:
   - [

--- a/data_yaml/codes/15-7-3.yaml
+++ b/data_yaml/codes/15-7-3.yaml
@@ -3,6 +3,8 @@ n: 15
 k: 7
 d: 3
 zoo_url: https://errorcorrectionzoo.org/c/stab_15_7_3
+aliases:
+  - "[[15,7,3]]"
 canonical_hash: 95454b1cf4f619fb39101bc98c57cff33e39786ba83460ae691c30ab4d3053a5
 h:
   - [1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]

--- a/data_yaml/codes/16-6-4.yaml
+++ b/data_yaml/codes/16-6-4.yaml
@@ -3,6 +3,11 @@ n: 16
 k: 6
 d: 4
 zoo_url: https://errorcorrectionzoo.org/c/stab_16_6_4
+aliases:
+  - "[[16,6,4]]"
+  - "tesseract color code"
+  - "hypercube code"
+  - "4D color code"
 canonical_hash: f3efb3784fb65bc83aa2f7e8fbc7b5a1abb36053c67bbd3d1228fc21ed24e210
 h:
   - [1, 0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]

--- a/data_yaml/codes/17-1-5.yaml
+++ b/data_yaml/codes/17-1-5.yaml
@@ -3,6 +3,9 @@ n: 17
 k: 1
 d: 5
 zoo_url: https://errorcorrectionzoo.org/c/stab_17_1_5
+aliases:
+  - "[[17,1,5]]"
+  - "square-octagon color code"
 canonical_hash: ec60d383bda5d7766d8baa590c2ba8567f79f03514b22a18b699acb0288cc56d
 h:
   - [

--- a/data_yaml/codes/19-1-5.yaml
+++ b/data_yaml/codes/19-1-5.yaml
@@ -3,6 +3,10 @@ n: 19
 k: 1
 d: 5
 zoo_url: https://errorcorrectionzoo.org/c/triangular_color
+aliases:
+  - "[[19,1,5]]"
+  - "honeycomb color code"
+  - "triangular color code"
 canonical_hash: 4d37337a447af8ceb7034975790a488664f5884fefe1e80bb33f747b2e4db554
 h:
   - [

--- a/data_yaml/codes/23-1-7.yaml
+++ b/data_yaml/codes/23-1-7.yaml
@@ -3,6 +3,10 @@ n: 23
 k: 1
 d: 7
 zoo_url: https://errorcorrectionzoo.org/c/qubit_golay
+aliases:
+  - "[[23,1,7]]"
+  - "qubit Golay code"
+  - "Golay code"
 canonical_hash: e268431e6b938eb17058f5aa86280ae743bcbc5070d26fcca973d7b49bb1df62
 h:
   - [

--- a/data_yaml/codes/31-1-7.yaml
+++ b/data_yaml/codes/31-1-7.yaml
@@ -3,6 +3,9 @@ n: 31
 k: 1
 d: 7
 zoo_url: https://errorcorrectionzoo.org/c/488_color
+aliases:
+  - "[[31,1,7]]"
+  - "square-octagon color code"
 canonical_hash: 1b5dc1be7fdf8253b645d9b2f7f588bb4cc10dc5b346987ff7a4364824268d9b
 h:
   - [

--- a/data_yaml/codes/31-21-3.yaml
+++ b/data_yaml/codes/31-21-3.yaml
@@ -3,6 +3,8 @@ n: 31
 k: 21
 d: 3
 zoo_url: https://errorcorrectionzoo.org/c/quantum_hamming_css
+aliases:
+  - "[[31,21,3]]"
 canonical_hash: 3263a7e064d77cb5ec2eea2111aeb27e76c85f416e20ad6b62cb68a17eb0b196
 h:
   - [

--- a/data_yaml/codes/37-1-7.yaml
+++ b/data_yaml/codes/37-1-7.yaml
@@ -3,6 +3,10 @@ n: 37
 k: 1
 d: 7
 zoo_url: https://errorcorrectionzoo.org/c/triangular_color
+aliases:
+  - "[[37,1,7]]"
+  - "honeycomb color code"
+  - "triangular color code"
 canonical_hash: cd9c58c2a3e789879e2a6f3712cdfead2ac36b1720a784b532d3f69e2796b293
 h:
   - [

--- a/data_yaml/codes/47-1-11.yaml
+++ b/data_yaml/codes/47-1-11.yaml
@@ -3,6 +3,10 @@ n: 47
 k: 1
 d: 11
 zoo_url: https://errorcorrectionzoo.org/c/galois_quad_residue
+aliases:
+  - "[[47,1,11]]"
+  - "quantum QR code"
+  - "quadratic residue code"
 canonical_hash: fe680a79655135c12b50d5ea5fe69701123eed888fe606b76da17b8962519132
 h:
   - [

--- a/data_yaml/codes/49-1-5.yaml
+++ b/data_yaml/codes/49-1-5.yaml
@@ -3,6 +3,8 @@ n: 49
 k: 1
 d: 5
 zoo_url: https://errorcorrectionzoo.org/c/triorthogonal
+aliases:
+  - "[[49,1,5]]"
 canonical_hash: b3493631e108460a487d8c56bafe024548421bd7ccbb6b3206d0f33bcacae9c2
 h:
   - [

--- a/data_yaml/codes/49-1-9.yaml
+++ b/data_yaml/codes/49-1-9.yaml
@@ -3,6 +3,9 @@ n: 49
 k: 1
 d: 9
 zoo_url: https://errorcorrectionzoo.org/c/488_color
+aliases:
+  - "[[49,1,9]]"
+  - "square-octagon color code"
 canonical_hash: 82631d0824c9f84a8976d027d51b40e88d2f61afb4096a673330ebbbf007b6c1
 h:
   - [

--- a/data_yaml/codes/71-1-11.yaml
+++ b/data_yaml/codes/71-1-11.yaml
@@ -3,6 +3,9 @@ n: 71
 k: 1
 d: 11
 zoo_url: https://errorcorrectionzoo.org/c/488_color
+aliases:
+  - "[[71,1,11]]"
+  - "square-octagon color code"
 canonical_hash: 282dd692475d9730e07aac06b0786e495bb1751e9848c5ad7c2287c102db1477
 h:
   - [

--- a/data_yaml/codes/72-12-6.yaml
+++ b/data_yaml/codes/72-12-6.yaml
@@ -3,6 +3,14 @@ n: 72
 k: 12
 d: 6
 zoo_url: https://errorcorrectionzoo.org/c/bb72
+aliases:
+  - "[[72,12,6]]"
+  - "bb72"
+  - "(6,6) BB6 code"
+  - "BB6 code"
+  - "BB code"
+  - "qLDPC code"
+  - "LDPC code"
 canonical_hash: 6c063cd873cc43fdeb309d3a8184f897e5c713e2dd1b947f48d80dbf4e0189ca
 h:
   - [

--- a/data_yaml/codes/90-8-10.yaml
+++ b/data_yaml/codes/90-8-10.yaml
@@ -3,6 +3,14 @@ n: 90
 k: 8
 d: 10
 zoo_url: https://errorcorrectionzoo.org/c/bb90
+aliases:
+  - "[[90,8,10]]"
+  - "bb90"
+  - "(15,3) BB6 code"
+  - "BB6 code"
+  - "BB code"
+  - "qLDPC code"
+  - "LDPC code"
 canonical_hash: c738368574c9f6d9bb1d58b92e332b71332a585d365cfe29885344ff919d9d33
 h:
   - [

--- a/data_yaml/codes/95-1-7.yaml
+++ b/data_yaml/codes/95-1-7.yaml
@@ -3,6 +3,8 @@ n: 95
 k: 1
 d: 7
 zoo_url: https://errorcorrectionzoo.org/c/triorthogonal
+aliases:
+  - "[[95,1,7]]"
 canonical_hash: 70f239e80beb873426d52316a6f32b297fa0344e0d1ae59673311d6a567e6531
 h:
   - [

--- a/data_yaml/codes/carbon-code.yaml
+++ b/data_yaml/codes/carbon-code.yaml
@@ -3,6 +3,9 @@ n: 12
 k: 2
 d: 4
 zoo_url: https://errorcorrectionzoo.org/c/carbon
+aliases:
+  - "[[12,2,4]]"
+  - "C12 code"
 canonical_hash: 867b5b91d25d0e6057624e51277717b6becc5776ff2f8d2b9020527765c10777
 h:
   - [1, 0, 0, 1, 0, 1, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]

--- a/data_yaml/codes/five-qubit-code.yaml
+++ b/data_yaml/codes/five-qubit-code.yaml
@@ -3,6 +3,11 @@ n: 5
 k: 1
 d: 3
 zoo_url: https://errorcorrectionzoo.org/c/stab_5_1_3
+aliases:
+  - "[[5,1,3]]"
+  - "Laflamme code"
+  - "perfect code"
+  - "five-qubit code"
 canonical_hash: c4e6bc522a4a3256a62b41da6f3e225c26e3d5728ef240c3e9564de529d9be1b
 h:
   - [1, 0, 0, 0, 1, 1, 1, 0, 1, 1]

--- a/data_yaml/codes/gottesman-8-3-3-code.yaml
+++ b/data_yaml/codes/gottesman-8-3-3-code.yaml
@@ -3,6 +3,9 @@ n: 8
 k: 3
 d: 3
 zoo_url: https://errorcorrectionzoo.org/c/stab_8_3_3
+aliases:
+  - "[[8,3,3]]"
+  - "eight-qubit Gottesman code"
 canonical_hash: d50681ae8ac254e7648b98c88e63434fb273877f98106ac214b637a349b53d5f
 h:
   - [1, 0, 0, 1, 0, 1, 1, 0, 0, 0, 1, 1, 1, 1, 0, 0]

--- a/data_yaml/codes/rotated-surface-code-d-11.yaml
+++ b/data_yaml/codes/rotated-surface-code-d-11.yaml
@@ -3,6 +3,15 @@ n: 121
 k: 1
 d: 11
 zoo_url: https://errorcorrectionzoo.org/c/rotated_surface
+aliases:
+  - "[[121,1,11]]"
+  - "checkerboard code"
+  - "medial surface code"
+  - "rectified surface code"
+  - "Kitaev surface code"
+  - "planar code"
+related:
+  - "toric code"
 canonical_hash: 13c01c4be7ad4bad8a89e02c1c005a517d352d74bf42f7e63cf3c72e338b758a
 h:
   - [

--- a/data_yaml/codes/rotated-surface-code-d-3.yaml
+++ b/data_yaml/codes/rotated-surface-code-d-3.yaml
@@ -3,6 +3,16 @@ n: 9
 k: 1
 d: 3
 zoo_url: https://errorcorrectionzoo.org/c/rotated_surface
+aliases:
+  - "[[9,1,3]]"
+  - "Surface-17"
+  - "checkerboard code"
+  - "medial surface code"
+  - "rectified surface code"
+  - "Kitaev surface code"
+  - "planar code"
+related:
+  - "toric code"
 canonical_hash: 44a2b880da49802495f3488a4ec488594d2bf99b8f22d9e032d93061a0139bfe
 h:
   - [1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0]

--- a/data_yaml/codes/rotated-surface-code-d-5.yaml
+++ b/data_yaml/codes/rotated-surface-code-d-5.yaml
@@ -3,6 +3,15 @@ n: 25
 k: 1
 d: 5
 zoo_url: https://errorcorrectionzoo.org/c/rotated_surface
+aliases:
+  - "[[25,1,5]]"
+  - "checkerboard code"
+  - "medial surface code"
+  - "rectified surface code"
+  - "Kitaev surface code"
+  - "planar code"
+related:
+  - "toric code"
 canonical_hash: b5827bf49d685907afebdf420860c19230763aa93ab642c53cf0dcb9b35c4dbc
 h:
   - [

--- a/data_yaml/codes/rotated-surface-code-d-7.yaml
+++ b/data_yaml/codes/rotated-surface-code-d-7.yaml
@@ -3,6 +3,15 @@ n: 49
 k: 1
 d: 7
 zoo_url: https://errorcorrectionzoo.org/c/rotated_surface
+aliases:
+  - "[[49,1,7]]"
+  - "checkerboard code"
+  - "medial surface code"
+  - "rectified surface code"
+  - "Kitaev surface code"
+  - "planar code"
+related:
+  - "toric code"
 canonical_hash: 6b05932a73c586febc8549d999e1a5543714a161f4a51709ea124cfd79eaa4ed
 h:
   - [

--- a/data_yaml/codes/rotated-surface-code-d-9.yaml
+++ b/data_yaml/codes/rotated-surface-code-d-9.yaml
@@ -3,6 +3,15 @@ n: 81
 k: 1
 d: 9
 zoo_url: https://errorcorrectionzoo.org/c/rotated_surface
+aliases:
+  - "[[81,1,9]]"
+  - "checkerboard code"
+  - "medial surface code"
+  - "rectified surface code"
+  - "Kitaev surface code"
+  - "planar code"
+related:
+  - "toric code"
 canonical_hash: 3f54b2d58cb6cf72e918e2735071a62e4aae5e9fd094cddfd57edbcb20edbb26
 h:
   - [

--- a/data_yaml/codes/shor-code.yaml
+++ b/data_yaml/codes/shor-code.yaml
@@ -3,6 +3,9 @@ n: 9
 k: 1
 d: 3
 zoo_url: https://errorcorrectionzoo.org/c/shor_nine
+aliases:
+  - "[[9,1,3]]"
+  - "nine-qubit code"
 canonical_hash: 9d2910fada2d925f502df9e5fbf0cc2400fe0c676ae4a1efa3511280f671e050
 h:
   - [1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0]

--- a/data_yaml/codes/steane-code.yaml
+++ b/data_yaml/codes/steane-code.yaml
@@ -3,6 +3,12 @@ n: 7
 k: 1
 d: 3
 zoo_url: https://errorcorrectionzoo.org/c/steane
+aliases:
+  - "[[7,1,3]]"
+  - "seven-qubit code"
+  - "triangular color code"
+  - "honeycomb color code"
+  - "6.6.6 color code"
 canonical_hash: d326fbcca125a5c717a7d4d1d0b4acc8da8e3b9d3ad123bfc705bc14d85f9ca4
 h:
   - [1, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0]

--- a/data_yaml/codes/tetrahedral-code.yaml
+++ b/data_yaml/codes/tetrahedral-code.yaml
@@ -3,6 +3,10 @@ n: 15
 k: 1
 d: 3
 zoo_url: https://errorcorrectionzoo.org/c/stab_15_1_3
+aliases:
+  - "[[15,1,3]]"
+  - "quantum Reed-Muller code"
+  - "quantum RM code"
 canonical_hash: cecd22de8d9e10f54835c518d8a468970de3abbd8a9e8d49e3d121d25d012dbe
 h:
   - [1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]

--- a/data_yaml/codes/unrotated-surface-code-d-11.yaml
+++ b/data_yaml/codes/unrotated-surface-code-d-11.yaml
@@ -3,6 +3,12 @@ n: 221
 k: 1
 d: 11
 zoo_url: https://errorcorrectionzoo.org/c/surface
+aliases:
+  - "[[221,1,11]]"
+  - "Kitaev surface code"
+  - "planar code"
+related:
+  - "toric code"
 canonical_hash: 0269f9279bb72c252592a9544b251040c6ee3d4d177c40767d56b02b498521b8
 h:
   - [

--- a/data_yaml/codes/unrotated-surface-code-d-3.yaml
+++ b/data_yaml/codes/unrotated-surface-code-d-3.yaml
@@ -3,6 +3,12 @@ n: 13
 k: 1
 d: 3
 zoo_url: https://errorcorrectionzoo.org/c/surface
+aliases:
+  - "[[13,1,3]]"
+  - "Kitaev surface code"
+  - "planar code"
+related:
+  - "toric code"
 canonical_hash: c31edaa94ace8112b76fe3a2560d9c92cb2472f41a2e13fca469db38fd301720
 h:
   - [1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]

--- a/data_yaml/codes/unrotated-surface-code-d-5.yaml
+++ b/data_yaml/codes/unrotated-surface-code-d-5.yaml
@@ -3,6 +3,12 @@ n: 41
 k: 1
 d: 5
 zoo_url: https://errorcorrectionzoo.org/c/surface
+aliases:
+  - "[[41,1,5]]"
+  - "Kitaev surface code"
+  - "planar code"
+related:
+  - "toric code"
 canonical_hash: 3118d1a15f14f4d069848e656353100f61608996821b49320ac5114bc8a1bbfb
 h:
   - [

--- a/data_yaml/codes/unrotated-surface-code-d-7.yaml
+++ b/data_yaml/codes/unrotated-surface-code-d-7.yaml
@@ -3,6 +3,12 @@ n: 85
 k: 1
 d: 7
 zoo_url: https://errorcorrectionzoo.org/c/surface
+aliases:
+  - "[[85,1,7]]"
+  - "Kitaev surface code"
+  - "planar code"
+related:
+  - "toric code"
 canonical_hash: 646a0a75f2804889557b6ca5954dca63e1af58860c99f26924cfa831435176c4
 h:
   - [

--- a/data_yaml/codes/unrotated-surface-code-d-9.yaml
+++ b/data_yaml/codes/unrotated-surface-code-d-9.yaml
@@ -3,6 +3,12 @@ n: 145
 k: 1
 d: 9
 zoo_url: https://errorcorrectionzoo.org/c/surface
+aliases:
+  - "[[145,1,9]]"
+  - "Kitaev surface code"
+  - "planar code"
+related:
+  - "toric code"
 canonical_hash: 593b693778ed1cf69e20f09389365e9d985955358e68fa044ad24488772decbd
 h:
   - [

--- a/data_yaml/papers/colmenarez-2026-unitary-surface-encoding.yaml
+++ b/data_yaml/papers/colmenarez-2026-unitary-surface-encoding.yaml
@@ -1,0 +1,5 @@
+title: Unitary fault-tolerant encoding of Pauli states in surface codes
+authors: [Luis Colmenarez, Remmy Zen, Jan Olle, Florian Marquardt, Markus Müller]
+year: 2026
+arxiv_id: "2601.05113"
+url: https://arxiv.org/abs/2601.05113

--- a/data_yaml/papers/forlivesi-2025-flag-at-origin.yaml
+++ b/data_yaml/papers/forlivesi-2025-flag-at-origin.yaml
@@ -1,0 +1,5 @@
+title: "Flag at origin: a modular fault-tolerant preparation for CSS codes"
+authors: [Diego Forlivesi, David Amaro]
+year: 2025
+arxiv_id: "2508.14200"
+url: https://arxiv.org/abs/2508.14200

--- a/data_yaml/papers/peham-2024-ft-state-prep-synthesis.yaml
+++ b/data_yaml/papers/peham-2024-ft-state-prep-synthesis.yaml
@@ -1,0 +1,7 @@
+title: Automated Synthesis of Fault-Tolerant State Preparation Circuits for Quantum Error Correction Codes
+authors: [Tom Peham, Ludwig Schmid, Lucas Berent, Markus Müller, Robert Wille]
+year: 2024
+arxiv_id: "2408.11894"
+doi: 10.1103/PRXQuantum.6.020330
+journal_ref: PRX Quantum 6, 020330 (2025)
+url: https://arxiv.org/abs/2408.11894

--- a/data_yaml/papers/peham-2026-encoding-circuit-synthesis.yaml
+++ b/data_yaml/papers/peham-2026-encoding-circuit-synthesis.yaml
@@ -1,0 +1,5 @@
+title: Synthesis and Optimization of Encoding Circuits for Fault-Tolerant Quantum Computation
+authors: [Tom Peham, Matthew Steinberg, Robert Wille, Sascha Heußen]
+year: 2026
+arxiv_id: "2605.15266"
+url: https://arxiv.org/abs/2605.15266

--- a/data_yaml/papers/schmid-2025-deterministic-ft-state-prep.yaml
+++ b/data_yaml/papers/schmid-2025-deterministic-ft-state-prep.yaml
@@ -1,0 +1,5 @@
+title: "Deterministic Fault-Tolerant State Preparation for Near-Term Quantum Error Correction: Automatic Synthesis Using Boolean Satisfiability"
+authors: [Ludwig Schmid, Tom Peham, Lucas Berent, Markus Müller, Robert Wille]
+year: 2025
+arxiv_id: "2501.05527"
+url: https://arxiv.org/abs/2501.05527

--- a/data_yaml/papers/steane-1996-multiple-particle-interference.yaml
+++ b/data_yaml/papers/steane-1996-multiple-particle-interference.yaml
@@ -1,0 +1,7 @@
+title: Multiple Particle Interference and Quantum Error Correction
+authors: [Andrew Steane]
+year: 1996
+arxiv_id: quant-ph/9601029
+doi: 10.1098/rspa.1996.0136
+journal_ref: Proc. R. Soc. Lond. A 452, 2551-2577 (1996)
+url: https://doi.org/10.1098/rspa.1996.0136

--- a/data_yaml/papers/zen-2024-rl-state-prep.yaml
+++ b/data_yaml/papers/zen-2024-rl-state-prep.yaml
@@ -1,0 +1,6 @@
+title: Quantum Circuit Discovery for Fault-Tolerant Logical State Preparation with Reinforcement Learning
+authors: [Remmy Zen, Jan Olle, Luis Colmenarez, Matteo Puviani, Markus Müller, Florian Marquardt]
+year: 2024
+arxiv_id: "2402.17761"
+doi: 10.1103/gqpr-dgz7
+url: https://arxiv.org/abs/2402.17761

--- a/data_yaml/tools/autqec.yaml
+++ b/data_yaml/tools/autqec.yaml
@@ -1,5 +1,7 @@
 name: autqec
 description: Finds fault-tolerant logical Clifford gates of stabilizer codes from code automorphisms and converts them to physical Clifford circuits.
 github_url: https://github.com/hsayginel/autqec
+aliases:
+  - "code automorphism gates"
 paper_urls: [https://arxiv.org/abs/2409.18175]
 tags: [Python, logical-gates, Clifford, fault-tolerant]

--- a/data_yaml/tools/cliffordopt.yaml
+++ b/data_yaml/tools/cliffordopt.yaml
@@ -1,5 +1,8 @@
 name: CliffordOpt
 description: Heuristic and optimal synthesis of CNOT and Clifford circuits from parity-check or symplectic matrices, minimizing two-qubit gate count or circuit depth.
 github_url: https://github.com/m-webster/CliffordOpt
+aliases:
+  - "Clifford optimisation"
+  - "Clifford optimization"
 paper_urls: [https://arxiv.org/abs/2503.14660]
 tags: [Python, optimization, Clifford, encoding]

--- a/data_yaml/tools/flag-at-origin.yaml
+++ b/data_yaml/tools/flag-at-origin.yaml
@@ -1,5 +1,7 @@
 name: Flag at Origin
 description: Code and circuits for modular fault-tolerant state preparation of CSS codes using flag gadgets, with results on Quantinuum H2-1.
 github_url: https://github.com/Quantinuum/flag_at_origin_paper
+aliases:
+  - "flag_at_origin"
 paper_urls: [https://arxiv.org/abs/2508.14200]
 tags: [Python, fault-tolerant, state-preparation, flag]

--- a/data_yaml/tools/mqt-qecc.yaml
+++ b/data_yaml/tools/mqt-qecc.yaml
@@ -2,6 +2,10 @@ name: MQT QECC
 description: Tools for quantum error correcting codes, including automated synthesis of fault-tolerant state-preparation and encoding circuits; part of the Munich Quantum Toolkit.
 homepage_url: https://mqt.readthedocs.io/projects/qecc/en/latest/
 github_url: https://github.com/munich-quantum-toolkit/qecc
+aliases:
+  - "mqt.qecc"
+  - "Munich Quantum Toolkit"
+  - "QECC"
 paper_urls:
   [
     https://arxiv.org/abs/2408.11894,

--- a/data_yaml/tools/quits.yaml
+++ b/data_yaml/tools/quits.yaml
@@ -1,5 +1,7 @@
 name: QUITS
 description: Modular circuit-level simulator for qLDPC codes that constructs Stim syndrome-extraction circuits for hypergraph-product, lifted-product, balanced-product, and bivariate-bicycle codes.
 github_url: https://github.com/mkangquantum/quits
+aliases:
+  - "qLDPC circuit simulator"
 paper_urls: [https://arxiv.org/abs/2504.02673]
 tags: [Python, syndrome-extraction, qLDPC]

--- a/data_yaml/tools/rlftqc.yaml
+++ b/data_yaml/tools/rlftqc.yaml
@@ -2,5 +2,8 @@ name: rlftqc
 description: Reinforcement-learning discovery of fault-tolerant logical state preparation circuits for stabilizer codes, with customizable gate sets and qubit connectivity, producing Stim circuits.
 homepage_url: https://remmyzen.github.io/rlftqc/
 github_url: https://github.com/remmyzen/rlftqc
+aliases:
+  - "reinforcement learning fault-tolerant quantum circuits"
+  - "RL state preparation"
 paper_urls: [https://arxiv.org/abs/2402.17761]
 tags: [Python, state-preparation, fault-tolerant, reinforcement-learning]

--- a/data_yaml/tools/rustiq.yaml
+++ b/data_yaml/tools/rustiq.yaml
@@ -1,5 +1,7 @@
 name: Rustiq
 description: Rust-based synthesis engine for Clifford operators and isometries, stabilizer and graph states, and Pauli networks, producing gate-count- or depth-optimized circuits such as encoders from stabilizers.
 github_url: https://github.com/qiskit-community/rustiq
+aliases:
+  - "rustiq-core"
 paper_urls: [https://arxiv.org/abs/2212.06928, https://arxiv.org/abs/2404.03280]
 tags: [Rust, Python, encoding, state-preparation, Clifford]

--- a/docs/adding-circuits-agent.md
+++ b/docs/adding-circuits-agent.md
@@ -39,9 +39,17 @@ You confirm before anything is written.
 
 The agent calls the Python API to write the code YAML, circuit YAML, and body files (`.stim`, `.qasm`, `.cirq`) to `data_yaml/`. For state-prep and encoding circuits, run `uv run python scripts/annotate_circuits.py` afterwards to add the `.stim-annotated` body. Each circuit is automatically assigned a unique `qec_id` (displayed as `#N` in the UI). This ID is permanent and must never be reused.
 
-### Phase 4: Zoo lookup and tagging
+### Phase 4: Zoo lookup, paper lookup, and tagging
 
-The agent enriches the generated YAML with tags:
+If the circuit's `source` is a paper link, the agent runs `npm run papers:add -- <link>`,
+which fetches the title and authors from arXiv (or Crossref) into `data_yaml/papers/`. That
+is what makes the circuit findable by paper title, author and arXiv id instead of by its bare
+URL. It is skipped automatically if the paper is already catalogued, and neither the agent nor
+you ever type the metadata: author lists are facts about real people, and papers are often
+newer than the model's training data. Nothing references the paper from the circuit — the link
+is derived from `source` at build time.
+
+The agent then enriches the generated YAML with tags:
 
 - **Auto-tags** (already applied): `CSS`, `self-dual` — mathematically verified
 - **Zoo lookup**: if a Zoo URL is available, the agent fetches the page and proposes tags based on the code's properties (family, structure). It only suggests tags that already exist in the library.

--- a/docs/adding-circuits.md
+++ b/docs/adding-circuits.md
@@ -372,6 +372,12 @@ n: 7
 k: 1
 d: 3
 zoo_url: https://errorcorrectionzoo.org/c/steane
+aliases:
+  - "[[7,1,3]]"
+  - "seven-qubit code"
+  - "6.6.6 color code"
+related:
+  - "triangular color code"
 canonical_hash: d326fbcca125a5c717a7d4d1d0b4acc8da8e3b9d3ad123bfc705bc14d85f9ca4
 h:
   - [1, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0]
@@ -385,6 +391,12 @@ logical:
   - [0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1]
 tags: [CSS, stabilizer, color-code]
 ```
+
+`aliases` are **other names for this same code** — every name a reader might type for it. They are matched silently, exactly as the stored `name` is, by both `/search` and the header quick-search. `tags` are code-level tags (`CSS`, `topological`, `LDPC`); these reach `/search` too, via the `code_tags` column.
+
+`related` is **a different, adjacent code** people commonly mean by a name that is not strictly this code — `toric` for a planar surface code. It matches only when nothing else does, and `/search` tells the user the results are a related code. Do not put a true alias here, or a taxonomy ancestor there: two parents above the rotated surface code sits "Quantum Tanner code", which is neither.
+
+Both are **hand-written**. The [Error Correction Zoo](https://errorcorrectionzoo.org) publishes `alternative_names` and is the right reference, but `eczoo_data` is CC-BY-SA 4.0 while this repo is MIT — use it to research, never add an import script. Only alias something the library actually holds: an alias for a concept with no circuits behind it resolves to nothing.
 
 `h` is the symplectic stabilizer matrix of shape `(n−k) × 2n`: columns `0..n-1` are the X-half, columns `n..2n-1` are the Z-half. `logical` has shape `2k × 2n`; for CSS codes the top `k` rows are X-bar logicals (Z-half zero) and the bottom `k` rows are Z-bar logicals (X-half zero). The Hx/Hz/Lx/Lz view shown in the UI is derived from `h` and `logical` at render time.
 
@@ -443,10 +455,75 @@ description: Tools for quantum error correcting codes.
 homepage_url: https://mqt.readthedocs.io/projects/qecc/en/latest/
 github_url: https://github.com/munich-quantum-toolkit/qecc
 paper_urls: [https://arxiv.org/abs/2408.11894]
+aliases: ["mqt.qecc", "Munich Quantum Toolkit", "QECC"]
 tags: [Python, encoding, state-preparation]
 ```
 
 Tools must be added manually before circuits can reference them.
+
+Tool `aliases` work like a code's, with one difference in how they are indexed: they ride in the low-weight `notes` column of `circuit_search`, because every circuit a tool produced would otherwise match every one of that tool's aliases as strongly as its own name. Tools have no `related`.
+
+### Paper (`data_yaml/papers/<slug>.yaml`)
+
+**Do not write these by hand — fetch them:**
+
+```bash
+npm run papers:add -- 2402.17761                 # arXiv id, DOI, or any abs/pdf/doi.org link
+npm run papers:missing                           # every circuit source with no paper yet
+npm run papers:missing -- --dry-run              # ...report without writing
+npm run db:create                                # link circuits to the new papers
+```
+
+`papers:missing` is the one to reach for after a bulk import: it scans every
+circuit's `source`, skips the ones already covered, and fetches the rest from
+arXiv (or Crossref for a DOI-only source). It is idempotent, so running it again
+costs nothing.
+
+The result looks like this — `scripts/add_paper.py` writes it:
+
+```yaml
+title: Quantum Circuit Discovery for Fault-Tolerant Logical State Preparation with Reinforcement Learning
+authors: [Remmy Zen, Jan Olle, Luis Colmenarez, Matteo Puviani, Markus Müller, Florian Marquardt]
+year: 2024
+arxiv_id: "2402.17761"
+doi: 10.1103/gqpr-dgz7
+url: https://arxiv.org/abs/2402.17761
+```
+
+Required: `title`, `authors` (a non-empty list, **in author order**), `url`.
+Optional: `year`, `arxiv_id`, `doi`, `journal_ref`.
+
+**Why fetched and not typed:** author lists are facts about real people, and a
+wrong one is a misattribution that then renders on the page and in the circuit's
+schema.org JSON-LD. They are also often newer than any given model's training
+data, and second-hand sources drift — one import README in this repo paraphrases
+its own paper's title inaccurately. If the script cannot fetch a work, add it by
+hand from the publisher's page, not from memory.
+
+The script refuses to write a paper with no authors rather than emit a half
+record. Crossref genuinely lacks authors on some older DOIs (the 1996 Steane
+paper among them) — pass the arXiv id instead, which has them.
+
+This is the **only** part of the repo that touches the network, and it is a
+maintainer tool whose output you commit. `npm run db:create` and the site itself
+read committed YAML only, and build identically offline.
+
+A paper makes its circuits findable on `/search` by title, author and arXiv id — none of
+which appear anywhere else, since a circuit's `source` is just a link. It also turns the
+bare URL in the UI into a real citation ("Zen et al. (2024)").
+
+**Circuits do not reference papers.** There is no `paper:` key. `npm run db:create` matches
+each circuit's `source` against every paper's `url`, `arxiv_id` and `doi`, tolerating
+http/https, a trailing slash, `dx.doi.org`, `/pdf/` vs `/abs/`, and arXiv version suffixes
+(`2402.17761v2`). So:
+
+- To make an existing circuit's paper searchable, just add the paper file — nothing else.
+- A `source` that matches no paper is fine, not an error. `npm run db:create` and
+  `npm run validate:yaml` both list such sources so you know what is missing.
+
+**Quote `arxiv_id`.** Unquoted, `arxiv_id: 2402.17761` is a YAML float, and an id ending in
+`0` would silently lose it. `validate:yaml` rejects a non-string, so this fails loudly — but
+quote it and save yourself the round trip.
 
 ## Notes
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -28,6 +28,7 @@ All library data lives in `data_yaml/` as human-editable YAML files:
 ```
 data_yaml/
 ├── tools/              # one YAML file per tool
+├── papers/             # one YAML file per cited paper
 ├── codes/              # one YAML file per code
 └── circuits/           # YAML metadata + body files per circuit
     └── originals/      # original (pre-canonicalization) STIM and matrices
@@ -52,6 +53,23 @@ npm run db:clear:tools -- --yes     # Remove tools only from DB
 ```
 
 After any of these commands, run `npm run db:create` to restore data from YAML, then restart the dev server.
+
+## Papers
+
+`data_yaml/papers/` holds one file per published work the library's circuits are taken from.
+Circuits are linked to them by **matching `circuits.source` against each paper's
+`url`/`arxiv_id`/`doi`** during `npm run db:create` — circuit YAML carries no paper
+reference, so adding a paper file is enough to enrich every circuit that cites it.
+
+The build prints how many circuits linked, and lists any link-shaped `source` with no paper
+behind it:
+
+```
+Papers: 7, linked to 724 circuits.
+```
+
+Those unlinked circuits still render and still search by URL; they just cannot be found by
+title or author. `npm run validate:yaml` reports the same thing as a warning.
 
 ## Original Circuit Data
 

--- a/docs/superpowers/plans/2026-07-15-search-aliases.md
+++ b/docs/superpowers/plans/2026-07-15-search-aliases.md
@@ -1,0 +1,210 @@
+# Search aliases: alternative names for codes and tools
+
+**Status:** implemented. Aliases are **hand-written** with the zoo as reference (not
+imported — see Licensing), and loose usage is **allowed but surfaced to the user** (see
+Strictness).
+
+Measured on the built site (`/search` over HTTP, 833 circuits), before → after:
+
+| query          | before |  after | note                                    |
+| -------------- | -----: | -----: | --------------------------------------- |
+| `bb codes`     |    824 | **28** | all 4 BB codes incl. gross              |
+| `bb72`         |      0 |      7 | resolves to `[[72,12,6]]` alone         |
+| `laflamme`     |      0 |     54 | five-qubit code                         |
+| `checkerboard` |      0 |     78 | rotated surface only                    |
+| `kitaev`       |      0 |     98 | all surface codes, silent (true alias)  |
+| `qldpc`        |      0 |     28 | code-level tags never reached the index |
+| `reed-muller`  |      0 |     52 | tetrahedral                             |
+| `surface-17`   |      0 |     50 | exactly the `[[9,1,3]]` rotated surface |
+| `[[7,1,3]]`    |      0 |     71 | Steane                                  |
+| `toric`        |      0 |     98 | **with the `related` notice**           |
+| `steane`       |     71 |     71 | unchanged                               |
+| `staene`       |     71 |     71 | unchanged, still spell-corrected        |
+
+**Known, not fixed: `msd` still returns 18 wrong results.** It corrects to `msb`, a real
+dictionary term one edit away. An alias would suppress it — `correctTokens` only rewrites
+tokens that match nothing — but there is nothing here to alias it _to_: the catalogue has
+no magic-state circuits, and "magic state distillation" is an application of the
+triorthogonal codes, not another name for them. Putting it in `aliases` would be a false
+claim. Left alone deliberately; revisit if magic-state circuits are ingested.
+
+**Found along the way: code-level tags are invisible to `/search`.** `circuit_search.tags`
+holds only _circuit_ tags, so `LDPC`, `surface-code` and `color-code` — all code tags —
+matched zero circuits. Aliases cover the important cases (`qldpc` now returns 28), but the
+underlying gap is separate and still open.
+
+## The problem
+
+Codes have many names. The catalogue stores exactly one each, so every other name a
+reader might type is a dead query. Measured against the current index (833 circuits,
+778 dictionary terms):
+
+| query               | hits today | what the user sees                         |
+| ------------------- | ---------: | ------------------------------------------ |
+| `bb codes`          |    **824** | near the whole catalogue — pure noise      |
+| `toric`             |          0 | nothing                                    |
+| `kitaev`            |          0 | nothing                                    |
+| `laflamme`          |          0 | nothing                                    |
+| `checkerboard`      |          0 | nothing                                    |
+| `reed-muller`       |          0 | nothing                                    |
+| `msd`               |         18 | **wrong results** — silently read as `msb` |
+| `bivariate bicycle` |         21 | works                                      |
+| `gross`             |          7 | works                                      |
+
+Three distinct failure modes, and none is a typo — so the existing spelling layer
+cannot reach any of them:
+
+1. **`bb codes` is worse than empty.** `bb` matches nothing, so the AND finds zero and
+   the OR fallback fires; `codes` then matches essentially every circuit. The
+   forgiveness layer designed for typos actively converts a precise query into a
+   firehose. `bb` is also 2 characters, so `editBudget` gives it 0 edits and the
+   corrector will never touch it — this can only be fixed with data, not tuning.
+2. **`toric`/`laflamme`/`checkerboard` are correctly left alone.** `correctTokens`
+   only rewrites a token when it matches nothing _and_ a near neighbour exists. These
+   are real words with no near neighbour, so they stay dead. Correct behaviour, wrong
+   outcome.
+3. **`msd` → `msb` is a false friend.** `msb` is a genuine dictionary term (18 docs),
+   one edit away, so magic-state-distillation gets silently answered with something
+   unrelated. An alias entry for `msd` makes it findable and, because `correctTokens`
+   only fires on tokens that match _nothing_, simultaneously stops the mis-correction.
+
+## Where the names come from
+
+The [Error Correction Zoo](https://errorcorrectionzoo.org) — which every code already
+links to via `zoo_url` — publishes `alternative_names`, `short_name`, and its own
+canonical `name` per code, in machine-readable YAML
+([errorcorrectionzoo/eczoo_data](https://github.com/errorcorrectionzoo/eczoo_data)).
+33 of our 38 code files carry a `zoo_url`; **25 of them gain a name we do not have.**
+
+Highlights, extracted from their YAML:
+
+| our code                | zoo gives us                                                         |
+| ----------------------- | -------------------------------------------------------------------- |
+| Gross Code              | `(3,3) BB6 code`; parent is _Bivariate bicycle (BB) code_ `[BB]`     |
+| Bivariate Bicycle Code  | `(6,6)/(15,3)/(9,6) BB6 code`, zoo names them `[[72,12,6]] BB6 code` |
+| Five-Qubit Perfect Code | **`Laflamme code`**                                                  |
+| Rotated Surface Code    | `Checkerboard code`, `Medial surface code`, `Rectified surface code` |
+| Unrotated Surface Code  | zoo's canonical name is **`Kitaev surface code`**                    |
+| Tesseract Code          | `[[16,6,4]] hypercube code`, `[[16,6,4]] 4D color code`              |
+| Tetrahedral Code        | zoo's canonical name is **`[[15,1,3]] quantum RM code`**             |
+| Quantum Golay Code      | `Qubit Golay code`                                                   |
+| Carbon Code             | `C_{12} code`                                                        |
+
+**The parent chain is not an alias source.** Walking it does yield `BB code` for gross
+and `Quantum Reed-Muller` for the tetrahedral code, but it degrades fast: two hops up
+from the rotated surface code sits _Quantum Tanner code_, and from Steane sits
+_Lifted-product code_. Those are ancestors in a taxonomy, not other names for the
+thing. Depth-1 parents are worth reading by hand as candidate **tags**; they must not
+be poured into an alias field.
+
+## Shape as built
+
+Aliases are a property of the entity, not of the query, so they live in the data and the
+index rather than a query-rewrite layer. Both engines then work from one source.
+
+1. **`data_yaml/codes/*.yaml` gains optional `aliases:` and `related:`; tools gain
+   `aliases:`.** Hand-written. `scripts/validate-yaml.mjs` rejects unknown keys, so its
+   schema had to learn them.
+2. **Migration `017`** adds `aliases`/`related` to `codes`, `aliases` to `tools`, and
+   recreates `circuit_search` with both as indexed columns. FTS5 has no `ALTER TABLE ADD
+COLUMN`, so the index is dropped and rebuilt — safe, since it holds no source data.
+3. **`create_database.mjs`** folds them into `SEARCH_TEXT` and the `search_terms`
+   inserts, so the spelling dictionary learns alias vocabulary (778 → 809 terms) and
+   `bivarient bicycle` corrects like anything else.
+4. **`resolveQuery` gained a fourth rung**, and `ResolvedQuery` a `relatedOnly` flag.
+5. **`BM25_WEIGHTS` is now `[0.0, 10.0, 4.0, 4.0, 0.5, 6.0, 1.0]`** — `aliases` matches
+   `code_name` (an alias _is_ a code name), and `related` sits lowest since it only ever
+   decides a query nothing else answered.
+6. **`searchByType`/`searchCircuits`** match `aliases` but deliberately not `related`.
+
+### The resolution ladder
+
+`resolveQuery` tries four expressions in order, stopping at the first with hits:
+
+1. every term, over name/code_name/aliases/tags/notes — what was asked for
+2. every term, allowing `related` — a neighbouring code, **flagged to the user**
+3. any term, strict columns — `partial`
+4. any term, allowing `related`
+
+(2) precedes (3) because dropping to "any term" concedes more: `toric code` widened to
+any-term matches every circuit containing "code" (824 of 833), whereas allowing
+`related` returns the 98 surface codes actually meant. FTS5 column filters
+(`{name code_name aliases tags notes} : (...)`) express the strict rungs; the filter
+wraps the whole group, since applying it per token would change what AND/OR bind to.
+`circuit_id` is UNINDEXED and cannot appear in a filter.
+
+### On hyphens
+
+No folding was needed. FTS5's `unicode61` splits `Reed-Muller` into `reed`+`muller`, so
+both `reed muller` and `reed-muller` match; the quick-search's LIKE is substring-based
+and matches either way. Storing the hyphenated form verbatim is strictly better than
+folding, which would break LIKE for anyone who types the hyphen.
+
+## Decisions taken
+
+### 1. Licensing → hand-curate, zoo as reference
+
+`eczoo_data` is **CC-BY-SA 4.0**; this repo is **MIT**. Bulk-importing their curated
+alias lists would arguably make that data a derivative under a share-alike licence
+inside an MIT repo. Instead: aliases are written by hand, using the zoo and the papers
+as research. Individual code names are facts rather than creative expression, and there
+are only ~33 codes. This sidesteps the licence question and the precision problem at
+once — we can reject the taxonomy junk (`Quantum Tanner code` for a surface code) that
+an import would drag in.
+
+Do **not** add a script that pulls `eczoo_data` into `data_yaml/`.
+
+### 2. Strictness → loose, but surfaced
+
+Two fields, not one:
+
+- **`aliases:`** — true alternative names. Match silently; these _are_ the thing.
+  `Laflamme code` → five-qubit, `Checkerboard code` → rotated surface.
+- **`related:`** — common loose usage. Match, but tell the user: _"No exact match for
+  toric — showing surface codes."_ Mirrors the existing `corrected`/`partial` notices
+  on `/search`, which already exist to say "we changed your query".
+
+`ResolvedQuery` gains a third flag alongside `corrected`/`partial`. Note `display` and
+`?literal=1` already exist for exactly this "we rewrote your query" purpose.
+
+**On `toric` specifically:** the loose reading is better supported than assumed. The
+zoo's own `toric` page states verbatim that _"toric code" is often an alternative name
+for the general construction_, and its `surface` entry is canonically named **Kitaev
+surface code** with toric/planar as the periodic/planar boundary cases. So `toric` is
+arguably a true alias. It stays in `related:` anyway — the catalogue's codes are planar
+(k=1), and saying so costs one line of UI copy and asserts nothing false.
+
+## Curation notes
+
+Worth knowing before writing the lists — all from the research pass:
+
+- **Steane = the smallest 6.6.6 / triangular color code.** High-value alias, and _not_
+  in the zoo's `alternative_names` field — it comes from prose plus the literature.
+  Our `19-1-5`/`37-1-7` are already "6.6.6 Color Code", so this links them to Steane.
+- **Bare digit forms (`713`, `513`) are UNVERIFIED.** The research pass could not find
+  them in the zoo, in paper titles, or anywhere else. Do not ship them as asserted
+  aliases. If digit-run matching is wanted, do it as a normalization rule (strip
+  non-digits from `[[7,1,3]]`), which is a different mechanism with a different failure
+  mode — and worth its own decision.
+- **Notation must not be collapsed.** `[[n,k,d]]` is a stabilizer code, `[n,k,d]`
+  single-bracket is _classical_, `((n,K,d))` double-parens is a **non-additive** code
+  where `K` is a dimension not a qubit count, and `[[n,k,r,d]]` is a subsystem code with
+  `r` gauge qubits. `((5,6,2))` is not `[[5,6,2]]`.
+- **Parameters do not identify a code.** The zoo notes a _different_ BB code with the
+  same `[[144,12,12]]` parameters as gross (arXiv:2407.16336). An alias keyed on
+  parameters alone can be wrong.
+- **Genuinely overloaded, needs disambiguation rather than aliasing:** "Floquet code"
+  (→ both the dynamical-automorphism and honeycomb entries), "Floquet color code" (→ two
+  distinct entries), "gross code" (above). None are in our catalogue today; the point is
+  not to alias them reflexively if they arrive.
+- **`msd` is the one non-code alias worth adding** — it stops the `msd` → `msb`
+  mis-correction. It only pays off if magic-state circuits exist here; today they don't.
+
+## Not in scope
+
+Aliases for concepts with no entity behind them (`MWPM`, `union-find`, `lattice
+surgery`) would resolve to nothing — the catalogue is state-prep focused. Only add an
+alias for something that exists here. The tool aliases worth having are narrower than
+they look: `MQT QECC` → Munich Quantum Toolkit is confirmed and useful; `Circuit-Synth`
+has no public repo or paper, so only casing variants are safe; `stac` collides with
+`staq` and is fuzzy-close to `Stim`, so it should stay exact-match only.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qecirc-website",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qecirc-website",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "license": "MIT",
       "dependencies": {
         "@astrojs/node": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qecirc-website",
   "type": "module",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "license": "MIT",
   "scripts": {
     "dev": "astro dev",
@@ -14,6 +14,8 @@
     "db:clear:circuits": "node scripts/db/clear.mjs --circuits-only",
     "db:clear:tools": "node scripts/db/clear.mjs --tools-only",
     "generate": "python -m scripts.add_circuit.generate",
+    "papers:add": "uv run python scripts/add_paper.py",
+    "papers:missing": "uv run python scripts/add_paper.py --missing",
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qecirc-website"
-version = "0.5.4"
+version = "0.5.5"
 description = "QECirc — quantum error correction circuit library"
 license = "MIT"
 requires-python = ">=3.13"

--- a/scripts/add_paper.py
+++ b/scripts/add_paper.py
@@ -1,0 +1,344 @@
+"""Fetch paper metadata from arXiv/Crossref and write data_yaml/papers/<slug>.yaml.
+
+    uv run python scripts/add_paper.py 2402.17761
+    uv run python scripts/add_paper.py https://arxiv.org/abs/2508.14200 10.1098/rspa.1996.0136
+    uv run python scripts/add_paper.py --missing            # every unlinked circuit source
+    uv run python scripts/add_paper.py --missing --dry-run  # show what it would write
+
+WHY THIS FETCHES, WHEN NOTHING ELSE IN THE REPO DOES
+----------------------------------------------------
+"No external services / no third-party APIs" governs the SITE: the build
+(`npm run db:create`) and every request must read only committed YAML, and they
+still do. This is a maintainer tool, run once per paper, whose output is a file
+you commit -- the same shape as `annotate_circuits.py`. Nothing at build or
+request time depends on the network, and the site builds identically offline.
+
+WHY IT IS NOT A HAND-WRITTEN YAML STEP
+--------------------------------------
+Titles and author lists are facts about real people; a wrong one is a
+misattribution that then renders on the page and in schema.org JSON-LD. They are
+also routinely newer than any model's training data -- two of the first seven
+papers here postdate a recent cutoff -- and second-hand sources are unreliable:
+one import README paraphrased its own paper's title inaccurately. So the rule is
+fetch, never recall. This script exists to make the correct path the easy one.
+
+Linking is by `source`, not by a key in circuit YAML: `create_database.mjs`
+matches each circuit's `source` against every paper's url/arxiv_id/doi. So
+writing the paper file IS the whole job -- no circuit is edited, and every
+circuit already citing that work is enriched at the next build.
+
+Stdlib only (urllib + xml.etree + yaml, all already present); no new dependency.
+"""
+
+import argparse
+import json
+import re
+import sys
+import unicodedata
+import urllib.error
+import urllib.request
+from pathlib import Path
+from xml.etree import ElementTree
+
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+PAPERS_DIR = ROOT / "data_yaml" / "papers"
+CIRCUITS_DIR = ROOT / "data_yaml" / "circuits"
+
+# Crossref asks for a contact so it can reach you about a misbehaving client, and
+# routes politely-identified traffic to a better-served pool.
+USER_AGENT = "qecirc-website (+https://github.com/qecirc/qecirc-website)"
+
+ARXIV_API = "https://export.arxiv.org/api/query"
+CROSSREF_API = "https://api.crossref.org/works"
+
+ATOM = {"a": "http://www.w3.org/2005/Atom", "arxiv": "http://arxiv.org/schemas/atom"}
+
+# Dropped from generated slugs -- they carry no identifying signal and only make
+# the filename longer.
+STOPWORDS = {
+    "a", "an", "and", "for", "from", "in", "into", "of", "on", "the", "to", "with",
+    "using", "via", "quantum",
+}  # fmt: skip
+
+
+class FetchError(Exception):
+    """Metadata could not be retrieved or was too incomplete to write."""
+
+
+def get(url: str) -> bytes:
+    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return resp.read()
+    except urllib.error.HTTPError as e:
+        raise FetchError(f"HTTP {e.code} from {url}") from e
+    except Exception as e:  # URLError, timeout, SSL...
+        raise FetchError(f"{type(e).__name__} from {url}: {e}") from e
+
+
+def extract_ref(text: str) -> tuple[str, str] | None:
+    """Reduce a source string to ("arxiv", id) or ("doi", doi), or None.
+
+    Accepts what actually appears in `source`: an abs/pdf link, a doi.org link, or
+    a bare id. Version suffixes are stripped -- v1 and v2 are the same paper, and
+    the stored id is the bare one.
+    """
+    s = text.strip()
+    m = re.search(r"arxiv\.org/(?:abs|pdf)/([^\s?#]+?)(?:\.pdf)?(?:v\d+)?/?$", s, re.I)
+    if m:
+        return ("arxiv", m.group(1))
+    m = re.search(r"(?:doi\.org/|^doi:)(10\.\d{4,}/\S+?)/?$", s, re.I)
+    if m:
+        return ("doi", m.group(1))
+    if re.fullmatch(r"\d{4}\.\d{4,5}(v\d+)?", s):
+        return ("arxiv", re.sub(r"v\d+$", "", s))
+    # Old-style arXiv id, e.g. quant-ph/9601029
+    if re.fullmatch(r"[a-z-]+(\.[A-Z]{2})?/\d{7}(v\d+)?", s):
+        return ("arxiv", re.sub(r"v\d+$", "", s))
+    if re.fullmatch(r"10\.\d{4,}/\S+", s):
+        return ("doi", s)
+    return None
+
+
+def fetch_arxiv(arxiv_id: str) -> dict:
+    root = ElementTree.fromstring(get(f"{ARXIV_API}?id_list={arxiv_id}&max_results=1"))
+    entry = root.find("a:entry", ATOM)
+    # arXiv answers an unknown id with an entry whose title is "Error"; a real
+    # entry always carries an <id> pointing at the abs page.
+    if entry is None or entry.find("a:id", ATOM) is None:
+        raise FetchError(f"arXiv returned no entry for {arxiv_id}")
+    title_el = entry.find("a:title", ATOM)
+    if title_el is None or not (title_el.text or "").strip():
+        raise FetchError(f"arXiv entry for {arxiv_id} has no title")
+    if (title_el.text or "").strip() == "Error":
+        raise FetchError(f"arXiv rejected id {arxiv_id} (no such paper?)")
+
+    authors = [
+        " ".join((n.text or "").split())
+        for n in entry.findall("a:author/a:name", ATOM)
+        if (n.text or "").strip()
+    ]
+    published = entry.findtext("a:published", default="", namespaces=ATOM)
+
+    paper = {
+        # arXiv wraps long titles across lines; collapse to one.
+        "title": " ".join((title_el.text or "").split()),
+        "authors": authors,
+        "url": f"https://arxiv.org/abs/{arxiv_id}",
+        "arxiv_id": arxiv_id,
+    }
+    if published[:4].isdigit():
+        paper["year"] = int(published[:4])
+    doi = entry.findtext("arxiv:doi", default="", namespaces=ATOM).strip()
+    if doi:
+        paper["doi"] = doi
+    journal = entry.findtext("arxiv:journal_ref", default="", namespaces=ATOM).strip()
+    if journal:
+        paper["journal_ref"] = " ".join(journal.split())
+    return paper
+
+
+def fetch_crossref(doi: str) -> dict:
+    msg = json.loads(get(f"{CROSSREF_API}/{doi}"))["message"]
+    title = (msg.get("title") or [""])[0]
+    if not title:
+        raise FetchError(f"Crossref has no title for {doi}")
+
+    authors = []
+    for a in msg.get("author") or []:
+        name = " ".join(x for x in (a.get("given"), a.get("family")) if x) or a.get("name") or ""
+        if name:
+            authors.append(name)
+
+    paper = {"title": " ".join(title.split()), "authors": authors, "url": f"https://doi.org/{doi}",
+             "doi": doi}  # fmt: skip
+    for key in ("published-print", "published-online", "issued"):
+        parts = (msg.get(key) or {}).get("date-parts") or []
+        if parts and parts[0] and parts[0][0]:
+            paper["year"] = int(parts[0][0])
+            break
+    container = (msg.get("container-title") or [""])[0]
+    if container:
+        ref = container
+        if msg.get("volume"):
+            ref += f" {msg['volume']}"
+        if msg.get("page"):
+            ref += f", {msg['page']}"
+        if paper.get("year"):
+            ref += f" ({paper['year']})"
+        paper["journal_ref"] = ref
+    return paper
+
+
+def fetch(kind: str, ident: str) -> dict:
+    paper = fetch_arxiv(ident) if kind == "arxiv" else fetch_crossref(ident)
+    # Refuse to write a paper with no authors rather than emit a half-record that
+    # renders as an empty citation. Crossref genuinely lacks authors on some older
+    # records (the 1996 Steane paper among them) -- for those, pass the arXiv id
+    # instead, which has them. Guessing the names here is not an option.
+    if not paper["authors"]:
+        raise FetchError(
+            f"no authors in {kind} metadata for {ident} -- "
+            f"if this work has an arXiv preprint, pass its id instead"
+        )
+    return paper
+
+
+def surname(full_name: str) -> str:
+    return full_name.strip().split()[-1] if full_name.strip() else ""
+
+
+def ascii_fold(text: str) -> str:
+    """Latin text to its ASCII skeleton, for slugs only.
+
+    Dropping non-ASCII instead of folding it silently mangles exactly the names
+    this catalogue is full of: "Brugière" -> "brugire", "Müller" -> "mller".
+    NFKD splits a letter from its accent so the accent can be dropped and the
+    letter kept -- but it does NOT decompose ligature-like letters, so "Heußen"
+    would become "heuen". Those are mapped first, by hand.
+    """
+    for src, dst in (("ß", "ss"), ("æ", "ae"), ("œ", "oe"), ("ø", "o"), ("đ", "d"), ("ł", "l")):
+        text = text.replace(src, dst).replace(src.upper(), dst.upper())
+    decomposed = unicodedata.normalize("NFKD", text)
+    return "".join(c for c in decomposed if not unicodedata.combining(c))
+
+
+def slugify(paper: dict) -> str:
+    """<first-author>-<year>-<a few title words>, matching the existing files."""
+    parts = [re.sub(r"[^a-z0-9]+", "", ascii_fold(surname(paper["authors"][0])).lower())]
+    if paper.get("year"):
+        parts.append(str(paper["year"]))
+    title = ascii_fold(paper["title"]).lower()
+    words = [w for w in re.findall(r"[a-z0-9]+", title) if w not in STOPWORDS]
+    parts.extend(words[:4])
+    return "-".join(p for p in parts if p)
+
+
+def existing_refs() -> dict[tuple[str, str], str]:
+    """Every (kind, id) the library already holds -> the file holding it.
+
+    Keyed on the identifiers rather than on URL shape: an arXiv id is an arXiv id
+    however it is written, so this needs none of the URL normalization that
+    scripts/paper-links.mjs does at build time. That normalizer stays the single
+    authority on whether a `source` actually links -- and `db:create` reports any
+    that does not, which is the backstop if these two ever disagree.
+    """
+    refs: dict[tuple[str, str], str] = {}
+    for path in sorted(PAPERS_DIR.glob("*.yaml")):
+        data = yaml.safe_load(path.read_text()) or {}
+        if data.get("arxiv_id"):
+            refs[("arxiv", str(data["arxiv_id"]))] = path.name
+        if data.get("doi"):
+            refs[("doi", str(data["doi"]))] = path.name
+        ref = extract_ref(str(data.get("url", "")))
+        if ref:
+            refs[ref] = path.name
+    return refs
+
+
+def circuit_sources() -> dict[str, int]:
+    """Every link-shaped `source` in circuit YAML -> how many circuits use it."""
+    counts: dict[str, int] = {}
+    for path in sorted(CIRCUITS_DIR.glob("*.yaml")):
+        data = yaml.safe_load(path.read_text()) or {}
+        source = str(data.get("source", ""))
+        # A non-link source names a tool ("circuit-synth"), which is provenance
+        # but not a paper.
+        if source.startswith(("http://", "https://")):
+            counts[source] = counts.get(source, 0) + 1
+    return counts
+
+
+def write_paper(paper: dict, dry_run: bool) -> Path:
+    slug = slugify(paper)
+    path = PAPERS_DIR / f"{slug}.yaml"
+    # Field order mirrors the hand-written files.
+    ordered = {k: paper[k] for k in
+               ("title", "authors", "year", "arxiv_id", "doi", "journal_ref", "url")
+               if k in paper}  # fmt: skip
+    text = yaml.safe_dump(ordered, sort_keys=False, allow_unicode=True, width=1000)
+    # `arxiv_id: 2402.17761` unquoted is a YAML FLOAT and an id ending in 0 loses
+    # it. safe_dump quotes it because it is a str -- assert that rather than trust
+    # it, since the failure is silent and validate:yaml would only catch it later.
+    if "arxiv_id" in ordered:
+        assert re.search(r"arxiv_id: ['\"]", text), f"arxiv_id must be quoted, got:\n{text}"
+    if not dry_run:
+        path.write_text(text)
+    return path
+
+
+def add(ref_text: str, existing: dict[tuple[str, str], str], dry_run: bool) -> str:
+    ref = extract_ref(ref_text)
+    if ref is None:
+        return f"SKIP  {ref_text}\n      not an arXiv or DOI reference — add this paper by hand"
+    if ref in existing:
+        return f"HAVE  {ref[1]} — already in papers/{existing[ref]}"
+
+    paper = fetch(*ref)
+    path = write_paper(paper, dry_run)
+    # Register both identities so a --missing run cannot fetch the same work twice
+    # under its arXiv id and its DOI.
+    existing[ref] = path.name
+    if paper.get("arxiv_id"):
+        existing[("arxiv", paper["arxiv_id"])] = path.name
+    if paper.get("doi"):
+        existing[("doi", paper["doi"])] = path.name
+
+    verb = "WOULD" if dry_run else "WROTE"
+    authors = paper["authors"]
+    credit = authors[0] if len(authors) == 1 else f"{surname(authors[0])} et al."
+    year = paper.get("year", "?")
+    return f"{verb} papers/{path.name}\n      {credit} ({year}) — {paper['title']}"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Fetch paper metadata into data_yaml/papers/.",
+        epilog="Run `npm run db:create` afterwards to link circuits to the new papers.",
+    )
+    ap.add_argument("refs", nargs="*", help="arXiv id, DOI, or link (abs/pdf/doi.org)")
+    ap.add_argument(
+        "--missing",
+        action="store_true",
+        help="add every circuit `source` that has no paper yet",
+    )
+    ap.add_argument("--dry-run", action="store_true", help="report without writing")
+    args = ap.parse_args()
+
+    if not args.refs and not args.missing:
+        ap.error("give at least one reference, or --missing")
+
+    PAPERS_DIR.mkdir(parents=True, exist_ok=True)
+    existing = existing_refs()
+    refs = list(args.refs)
+
+    if args.missing:
+        for source, count in sorted(circuit_sources().items(), key=lambda kv: -kv[1]):
+            ref = extract_ref(source)
+            if ref is None:
+                print(f"SKIP  {source} ({count} circuits)\n      not arXiv/DOI — add by hand")
+                continue
+            if ref in existing:
+                continue
+            refs.append(source)
+        if not refs:
+            print("Nothing missing: every circuit source already has a paper.")
+            return 0
+
+    failed = 0
+    for ref_text in refs:
+        try:
+            print(add(ref_text, existing, args.dry_run))
+        except FetchError as e:
+            print(f"FAIL  {ref_text}\n      {e}", file=sys.stderr)
+            failed += 1
+
+    if not args.dry_run and failed == 0:
+        print("\nNow run: npm run db:create")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/db/create_database.mjs
+++ b/scripts/db/create_database.mjs
@@ -6,7 +6,7 @@
  * Steps:
  *   1. Delete existing DB
  *   2. Run migrations
- *   3. Read YAML files (tools → codes → circuits)
+ *   3. Read YAML files (tools → papers → codes → circuits)
  *   4. Insert into DB
  */
 
@@ -16,6 +16,7 @@ import path from "node:path";
 import { execSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import * as yaml from "js-yaml";
+import { paperKey, paperLinks, isPaperSource } from "../paper-links.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const dbPath = path.join(root, "data", "qecirc.db");
@@ -32,14 +33,17 @@ db.pragma("foreign_keys = ON");
 // Prepared statements
 const stmts = {
   insertTool: db.prepare(`
-    INSERT INTO tools (name, slug, description, homepage_url, github_url, paper_urls)
-    VALUES (?, ?, ?, ?, ?, ?)`),
+    INSERT INTO tools (name, slug, description, homepage_url, github_url, paper_urls, aliases)
+    VALUES (?, ?, ?, ?, ?, ?, ?)`),
+  insertPaper: db.prepare(`
+    INSERT INTO papers (slug, title, authors, year, arxiv_id, doi, journal_ref, url)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)`),
   insertCode: db.prepare(`
-    INSERT INTO codes (name, slug, n, k, d, zoo_url, h, logical, canonical_hash)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`),
+    INSERT INTO codes (name, slug, n, k, d, zoo_url, aliases, related, h, logical, canonical_hash)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`),
   insertCircuit: db.prepare(`
-    INSERT INTO circuits (qec_id, code_id, name, slug, notes, source, gate_count, two_qubit_gate_count, depth, qubit_count, weight, crumble_url, crumble_url_annotated, quirk_url, tool_id)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`),
+    INSERT INTO circuits (qec_id, code_id, name, slug, notes, source, gate_count, two_qubit_gate_count, depth, qubit_count, weight, crumble_url, crumble_url_annotated, quirk_url, tool_id, paper_id)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`),
   insertBody: db.prepare(`
     INSERT INTO circuit_bodies (circuit_id, format, body)
     VALUES (?, ?, ?)`),
@@ -52,6 +56,18 @@ const stmts = {
     INSERT OR IGNORE INTO taggings (tag_id, taggable_id, taggable_type)
     VALUES (?, ?, ?)`),
 };
+
+/** Alias lists collapse to one space-joined string per entity.
+ *
+ * Stored verbatim, hyphens and all: FTS5's unicode61 splits "Reed-Muller" into
+ * `reed`+`muller`, so both "reed muller" and "reed-muller" match it, while the
+ * quick-search's LIKE is substring-based and matches either way too. Folding the
+ * hyphens out would only break the LIKE path for a user who types one.
+ */
+function joinAliases(list) {
+  const text = (list || []).join(" ").trim();
+  return text === "" ? null : text;
+}
 
 function addTag(name, taggableId, taggableType) {
   stmts.insertTag.run(name);
@@ -79,6 +95,11 @@ const BODY_EXTENSIONS = new Set(["stim", "qasm", "cirq", "stim-annotated"]);
 // --- 4. Insert data ---
 const toolSlugToId = new Map();
 const codeSlugToId = new Map();
+/** paperKey(link) → papers.id, for every link a paper answers to. */
+const paperKeyToId = new Map();
+/** Link-shaped circuit sources that matched no paper → how many circuits. Not
+ *  fatal; reported after the build as a nudge to add the missing paper. */
+const unmatchedSources = new Map();
 const errors = [];
 
 try {
@@ -107,6 +128,7 @@ try {
         Array.isArray(data.paper_urls) && data.paper_urls.length > 0
           ? JSON.stringify(data.paper_urls)
           : null,
+        joinAliases(data.aliases),
       );
       toolSlugToId.set(slug, Number(lastInsertRowid));
 
@@ -115,6 +137,50 @@ try {
       }
 
       console.log(`  Tool: ${data.name} (${slug})`);
+    }
+
+    // --- Papers ---
+    const papersDir = path.join(dataDir, "papers");
+    for (const file of listYamlFiles(papersDir)) {
+      const slug = file.replace(/\.yaml$/, "");
+      const data = readYaml(path.join(papersDir, file));
+
+      if (!data.title) {
+        errors.push(`Paper ${file}: missing required field 'title'`);
+        continue;
+      }
+      if (!Array.isArray(data.authors) || data.authors.length === 0) {
+        errors.push(`Paper ${file}: 'authors' must be a non-empty list`);
+        continue;
+      }
+      if (!data.url) {
+        errors.push(`Paper ${file}: missing required field 'url'`);
+        continue;
+      }
+
+      const { lastInsertRowid } = stmts.insertPaper.run(
+        slug,
+        data.title,
+        JSON.stringify(data.authors),
+        data.year ?? null,
+        data.arxiv_id ? String(data.arxiv_id) : null,
+        data.doi || null,
+        data.journal_ref || null,
+        data.url,
+      );
+      const paperId = Number(lastInsertRowid);
+
+      for (const link of paperLinks(data)) {
+        const key = paperKey(link);
+        const claimed = paperKeyToId.get(key);
+        if (claimed != null && claimed !== paperId) {
+          errors.push(`Paper ${file}: link '${link}' is already claimed by another paper`);
+          continue;
+        }
+        paperKeyToId.set(key, paperId);
+      }
+
+      console.log(`  Paper: ${data.title} (${slug})`);
     }
 
     // --- Codes ---
@@ -143,6 +209,8 @@ try {
         data.k,
         data.d || null,
         data.zoo_url || null,
+        joinAliases(data.aliases),
+        joinAliases(data.related),
         data.h == null ? null : JSON.stringify(data.h),
         data.logical == null ? null : JSON.stringify(data.logical),
         data.canonical_hash || null,
@@ -228,13 +296,25 @@ try {
         }
       }
 
+      // Resolve paper from `source`. Only link-shaped sources are candidates:
+      // the rest name a tool ("circuit-synth"), which is provenance but not a
+      // paper. A link that matches no paper is NOT an error -- papers are
+      // optional enrichment, and a circuit may cite a work we hold no record of
+      // -- so the circuit keeps its bare `source` and is reported at the end.
+      const source = data.source || "";
+      let paperId = null;
+      if (isPaperSource(source)) {
+        paperId = paperKeyToId.get(paperKey(source)) ?? null;
+        if (paperId == null) unmatchedSources.set(source, (unmatchedSources.get(source) ?? 0) + 1);
+      }
+
       const { lastInsertRowid } = stmts.insertCircuit.run(
         data.qec_id,
         codeId,
         data.name,
         circuitSlug,
         data.notes || null,
-        data.source || "",
+        source,
         data.gate_count ?? null,
         data.two_qubit_gate_count ?? null,
         data.depth ?? null,
@@ -244,6 +324,7 @@ try {
         data.crumble_url_annotated || null,
         data.quirk_url || null,
         toolId,
+        paperId,
       );
       const circuitId = Number(lastInsertRowid);
 
@@ -303,22 +384,54 @@ try {
   throw e;
 }
 
-// --- 4. Populate the full-text search index (data/migrations/016) ---
+// --- 4. Populate the full-text search index (migrations 016 → 019) ---
 // Derived entirely from the rows just inserted, so it is rebuilt from scratch
 // here rather than maintained by triggers. `source` rides along in the notes
 // column: it is provenance prose (DOI/citation) and shares its low weight.
+//
+// A circuit inherits its code's aliases and related names (migration 017), which
+// is what lets "laflamme" or "bb codes" reach circuits whose own text says
+// neither. Tool aliases ride in `notes`: they are weak evidence about a circuit
+// (every circuit from a tool would otherwise match its every alias equally) and
+// `notes` is the low-weight column for exactly that kind of term.
+//
+// `code_tags` (migration 019) carries the tags of the code the circuit belongs
+// to. Without it `LDPC`, `topological` and `self-dual` -- all code-level tags --
+// matched no circuit at all. Kept apart from `tags` so the two can be weighted
+// separately and so a name used at both levels cannot double-count.
+//
+// `paper` (migration 018) carries the paper's title, authors and ids, which is
+// the only place that text exists -- `source` is a bare link. json_each flattens
+// papers.authors (a JSON array) back into words so an author surname is a term.
+// The arXiv id is indexed as written: unicode61 splits "2402.17761" into "2402"
+// and "17761", so both halves stay searchable.
 const SEARCH_TEXT = `
   SELECT c.id AS circuit_id, c.name AS name, co.name AS code_name,
+         COALESCE(co.aliases, '') AS aliases,
+         COALESCE(co.related, '') AS related,
          COALESCE((SELECT group_concat(t.name, ' ')
                    FROM taggings tg JOIN tags t ON t.id = tg.tag_id
                    WHERE tg.taggable_id = c.id AND tg.taggable_type = 'circuit'), '') AS tags,
-         TRIM(COALESCE(c.notes, '') || ' ' || COALESCE(c.source, '')) AS notes
+         COALESCE((SELECT group_concat(t.name, ' ')
+                   FROM taggings tg JOIN tags t ON t.id = tg.tag_id
+                   WHERE tg.taggable_id = co.id AND tg.taggable_type = 'code'), '') AS code_tags,
+         COALESCE((SELECT TRIM(p.title || ' ' ||
+                          COALESCE((SELECT group_concat(a.value, ' ')
+                                    FROM json_each(p.authors) a), '') || ' ' ||
+                          COALESCE(p.arxiv_id, '') || ' ' ||
+                          COALESCE(p.doi, '') || ' ' ||
+                          COALESCE(p.journal_ref, '') || ' ' ||
+                          COALESCE(CAST(p.year AS TEXT), ''))
+                   FROM papers p WHERE p.id = c.paper_id), '') AS paper,
+         TRIM(COALESCE(c.notes, '') || ' ' || COALESCE(c.source, '') || ' '
+              || COALESCE((SELECT tl.aliases FROM tools tl WHERE tl.id = c.tool_id), '')) AS notes
   FROM circuits c JOIN codes co ON co.id = c.code_id`;
 
 const indexed = db
   .prepare(
-    `INSERT INTO circuit_search (circuit_id, name, code_name, tags, notes)
-     SELECT circuit_id, name, code_name, tags, notes FROM (${SEARCH_TEXT})`,
+    `INSERT INTO circuit_search (circuit_id, name, code_name, aliases, related, tags, code_tags, paper, notes)
+     SELECT circuit_id, name, code_name, aliases, related, tags, code_tags, paper, notes
+     FROM (${SEARCH_TEXT})`,
   )
   .run();
 
@@ -331,19 +444,54 @@ const TAGS_OF = (type) => `
             FROM taggings tg JOIN tags t ON t.id = tg.tag_id
             WHERE tg.taggable_id = e.id AND tg.taggable_type = '${type}'), '')`;
 
+// Aliases are indexed here too, so the dictionary learns their vocabulary and
+// "bivarient bicycle" or "laflame" correct like any other term. This also stops
+// an alias being "corrected" into something else: correctTokens only rewrites a
+// token that matches NOTHING, so a known alias is now left alone -- which is
+// what fixes `msd` silently becoming `msb`.
 db.prepare(
   `INSERT INTO search_terms (text)
-   SELECT name || ' ' || code_name || ' ' || tags || ' ' || notes FROM (${SEARCH_TEXT})`,
+   SELECT name || ' ' || code_name || ' ' || aliases || ' ' || related || ' '
+          || tags || ' ' || code_tags || ' ' || paper || ' ' || notes
+   FROM (${SEARCH_TEXT})`,
 ).run();
 db.prepare(
-  `INSERT INTO search_terms (text) SELECT e.name || ' ' || ${TAGS_OF("code")} FROM codes e`,
+  `INSERT INTO search_terms (text)
+   SELECT e.name || ' ' || COALESCE(e.aliases, '') || ' ' || COALESCE(e.related, '')
+          || ' ' || ${TAGS_OF("code")} FROM codes e`,
 ).run();
 db.prepare(
-  `INSERT INTO search_terms (text) SELECT e.name || ' ' || ${TAGS_OF("tool")} FROM tools e`,
+  `INSERT INTO search_terms (text)
+   SELECT e.name || ' ' || COALESCE(e.aliases, '') || ' ' || ${TAGS_OF("tool")} FROM tools e`,
+).run();
+// Papers get their own rows for the same reason tools do: a paper whose circuits
+// are not yet in the library appears in no circuit text, so a dictionary built
+// from circuits alone could never offer "Colmenarez" as a correction for
+// "Colmenraez". Title and authors only -- ids and years are digit tokens, which
+// correctTokens refuses to correct anyway (see queries/spelling.ts).
+db.prepare(
+  `INSERT INTO search_terms (text)
+   SELECT p.title || ' ' ||
+          COALESCE((SELECT group_concat(a.value, ' ') FROM json_each(p.authors) a), '')
+   FROM papers p`,
 ).run();
 
 const vocabSize = db.prepare("SELECT COUNT(*) AS n FROM search_vocab").get().n;
+const linked = db.prepare("SELECT COUNT(*) AS n FROM circuits WHERE paper_id IS NOT NULL").get().n;
+const paperCount = db.prepare("SELECT COUNT(*) AS n FROM papers").get().n;
 
 db.close();
 console.log(`\nSearch index: ${indexed.changes} circuits, ${vocabSize} dictionary terms.`);
+console.log(`Papers: ${paperCount}, linked to ${linked} circuits.`);
+
+// A link-shaped source with no paper behind it is the one way this feature
+// quietly under-delivers: the circuit still renders and still searches, it just
+// has no title or authors to find it by. Say so rather than let it pass.
+if (unmatchedSources.size > 0) {
+  console.log(`\nSources with no paper in data_yaml/papers/ (searchable by URL only):`);
+  for (const [source, count] of [...unmatchedSources].sort((a, b) => b[1] - a[1])) {
+    console.log(`  - ${source} (${count} circuit${count === 1 ? "" : "s"})`);
+  }
+}
+
 console.log("\nDatabase created successfully.");

--- a/scripts/paper-links.mjs
+++ b/scripts/paper-links.mjs
@@ -1,0 +1,52 @@
+/**
+ * Matching a circuit's `source` to a paper in data_yaml/papers/.
+ *
+ * Shared by scripts/db/create_database.mjs (which does the linking) and
+ * scripts/validate-yaml.mjs (which reports sources that will not link). The two
+ * MUST agree: if validation normalizes differently from the build, it would
+ * pass a source the build then silently fails to resolve — the exact failure
+ * this file exists to make impossible.
+ */
+
+/** Reduce a paper link to a comparison key.
+ *
+ * A circuit's `source` and a paper's declared `url` are written by different
+ * hands at different times, so the same paper arrives spelled several ways:
+ * http vs https, a trailing slash, `dx.doi.org` vs `doi.org`, a /pdf/ link
+ * instead of /abs/, or an arXiv version suffix (`2402.17761v2`). All of those
+ * are the same work and must collapse to one key.
+ *
+ * The version suffix is stripped for the same reason arXiv treats it as
+ * optional: v1 and v2 are the same paper, and a source pinned to v1 should
+ * still find it.
+ */
+export function paperKey(raw) {
+  return String(raw)
+    .trim()
+    .toLowerCase()
+    .replace(/^https?:\/\//, "")
+    .replace(/^www\./, "")
+    .replace(/^dx\.doi\.org\//, "doi.org/")
+    .replace(/^arxiv\.org\/pdf\//, "arxiv.org/abs/")
+    .replace(/\.pdf$/, "")
+    .replace(/\/+$/, "")
+    .replace(/^(arxiv\.org\/abs\/.+?)v\d+$/, "$1");
+}
+
+/** Every link a paper answers to: its canonical `url` plus the links implied by
+ *  its ids. A circuit may cite the arXiv abs page while the paper declares its
+ *  journal DOI as canonical (or vice versa), and both must resolve. */
+export function paperLinks(data) {
+  const links = [];
+  if (data.url) links.push(data.url);
+  if (data.arxiv_id) links.push(`https://arxiv.org/abs/${data.arxiv_id}`);
+  if (data.doi) links.push(`https://doi.org/${data.doi}`);
+  return links;
+}
+
+/** Whether a `source` is a candidate for paper linking at all. A source that is
+ *  not a link names a tool ("circuit-synth"), which is provenance but not a
+ *  paper. */
+export function isPaperSource(source) {
+  return /^https?:\/\//i.test(String(source ?? ""));
+}

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -63,6 +63,28 @@ fi
 # Advanced search: server-filtered, so results must appear in the HTML itself.
 check "/search?q=code" "<title"
 
+# Each of these reaches circuits through a DIFFERENT circuit_search column, so
+# together they assert the index still has all of them wired up. Any of them
+# returning nothing means a column stopped being populated or stopped being
+# matched -- both of which have shipped before, and neither of which shows up as
+# an error: /search just quietly answers "no circuits found".
+#
+# `search-schema.ts` throws on a column with no weight, so a broken deploy fails
+# these as HTTP 500 rather than a wrong ranking.
+search_finds() { # <query> <what it proves>
+  if ! body=$(curl -fsS "$BASE/search?q=$1" 2>&1); then
+    echo "FAIL /search?q=$1: HTTP error"; fail=1; return
+  fi
+  if grep -q "No circuits found" <<< "$body"; then
+    echo "FAIL /search?q=$1: no results ($2)"; fail=1; return
+  fi
+  echo "OK   /search?q=$1 ($2)"
+}
+search_finds "laflamme"      "aliases column"
+search_finds "topological"   "code_tags column"
+search_finds "forlivesi"     "paper column (authors)"
+search_finds "reinforcement" "paper column (title)"
+
 # Discover a code slug from the sitemap
 slug=$(curl -fsS "$BASE/sitemap.xml" \
        | grep -oE "/codes/[a-z0-9-]+" | head -1 | sed "s|/codes/||")

--- a/scripts/tests/test_add_paper.py
+++ b/scripts/tests/test_add_paper.py
@@ -1,0 +1,135 @@
+"""Tests for the paper fetcher's pure parts.
+
+Nothing here touches the network: the fetch itself is a thin wrapper over arXiv
+and Crossref, but what breaks in practice is the parsing around it -- which
+reference shapes are recognised, and how names survive becoming a filename.
+"""
+
+import pytest
+
+from scripts.add_paper import ascii_fold, extract_ref, slugify, surname
+
+
+class TestExtractRef:
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            # The shapes that actually appear in circuit `source` fields.
+            ("https://arxiv.org/abs/2402.17761", ("arxiv", "2402.17761")),
+            ("http://arxiv.org/abs/2402.17761", ("arxiv", "2402.17761")),
+            ("https://arxiv.org/abs/2402.17761/", ("arxiv", "2402.17761")),
+            ("https://doi.org/10.1098/rspa.1996.0136", ("doi", "10.1098/rspa.1996.0136")),
+            # Bare identifiers, as a maintainer would type them.
+            ("2402.17761", ("arxiv", "2402.17761")),
+            ("10.1098/rspa.1996.0136", ("doi", "10.1098/rspa.1996.0136")),
+            ("doi:10.1098/rspa.1996.0136", ("doi", "10.1098/rspa.1996.0136")),
+            # Old-style arXiv ids predate the numeric scheme; the 1996 Steane
+            # paper is one, so this is not hypothetical.
+            ("quant-ph/9601029", ("arxiv", "quant-ph/9601029")),
+            ("https://arxiv.org/abs/quant-ph/9601029", ("arxiv", "quant-ph/9601029")),
+            # A version suffix names the same work: v1 and v2 must not become two
+            # papers, and the stored id is the bare one.
+            ("2402.17761v2", ("arxiv", "2402.17761")),
+            ("https://arxiv.org/abs/2402.17761v3", ("arxiv", "2402.17761")),
+            # A /pdf/ link is the same paper as its /abs/ page.
+            ("https://arxiv.org/pdf/2402.17761", ("arxiv", "2402.17761")),
+            ("https://arxiv.org/pdf/2402.17761v2", ("arxiv", "2402.17761")),
+            ("https://arxiv.org/pdf/2402.17761.pdf", ("arxiv", "2402.17761")),
+        ],
+    )
+    def test_recognised(self, text, expected):
+        assert extract_ref(text) == expected
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            # A tool name, not a work: 109 circuits carry this and must not be
+            # mistaken for something fetchable.
+            "circuit-synth",
+            "",
+            "   ",
+            "Smith et al., some journal, 1998",  # free-form citation
+            "https://github.com/some/repo",  # a repo is not a paper
+            "https://example.com/paper.html",
+        ],
+    )
+    def test_unrecognised(self, text):
+        assert extract_ref(text) is None
+
+
+class TestAsciiFold:
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            # Dropping the accent instead of folding it would give "Brugire" and
+            # "Mller" -- both real authors in this catalogue.
+            ("Brugière", "Brugiere"),
+            ("Müller", "Muller"),
+            ("Zdeněk Kolář", "Zdenek Kolar"),
+            # NFKD does not decompose ß, so it is mapped by hand; without that
+            # "Heußen" folds to "Heuen".
+            ("Heußen", "Heussen"),
+            ("Sascha Heußen", "Sascha Heussen"),
+            ("Andrew Steane", "Andrew Steane"),
+            ("", ""),
+        ],
+    )
+    def test_fold(self, text, expected):
+        assert ascii_fold(text) == expected
+
+    def test_ascii_is_unchanged(self):
+        text = "Automated Synthesis of Fault-Tolerant State Preparation Circuits"
+        assert ascii_fold(text) == text
+
+
+class TestSurname:
+    @pytest.mark.parametrize(
+        "full,expected",
+        [
+            ("Remmy Zen", "Zen"),
+            ("Andrew Steane", "Steane"),
+            ("Markus Müller", "Müller"),
+            ("Timothée Goubault de Brugière", "Brugière"),
+            ("Cher", "Cher"),
+        ],
+    )
+    def test_surname(self, full, expected):
+        assert surname(full) == expected
+
+
+class TestSlugify:
+    def test_matches_the_hand_written_convention(self):
+        slug = slugify(
+            {
+                "authors": ["Tom Peham", "Ludwig Schmid"],
+                "title": "Automated Synthesis of Fault-Tolerant State Preparation Circuits",
+                "year": 2024,
+            }
+        )
+        # <surname>-<year>-<title words, stopwords dropped>
+        assert slug == "peham-2024-automated-synthesis-fault-tolerant"
+
+    def test_folds_accents_rather_than_dropping_them(self):
+        slug = slugify(
+            {
+                "authors": ["Timothée Goubault de Brugière"],
+                "title": "A graph-state based synthesis framework",
+                "year": 2022,
+            }
+        )
+        assert slug.startswith("brugiere-2022-")
+
+    def test_survives_a_missing_year(self):
+        slug = slugify({"authors": ["Andrew Steane"], "title": "Multiple Particle Interference"})
+        assert slug == "steane-multiple-particle-interference"
+
+    def test_is_filename_safe(self):
+        slug = slugify(
+            {
+                "authors": ["Chen Kang"],
+                "title": "QUITS: A modular Qldpc code circUIT Simulator",
+                "year": 2025,
+            }
+        )
+        # No colon, no space, no capital -- this becomes a path.
+        assert slug == "kang-2025-quits-modular-qldpc-code"

--- a/scripts/validate-yaml.mjs
+++ b/scripts/validate-yaml.mjs
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import * as yaml from "js-yaml";
+import { paperKey, paperLinks, isPaperSource } from "./paper-links.mjs";
 
 const DATA_DIR = path.join(process.cwd(), "data_yaml");
 
@@ -21,6 +22,8 @@ const SCHEMAS = {
       d: "number",
       canonical_hash: "string",
       zoo_url: "string",
+      aliases: "tags",
+      related: "tags",
       h: "matrix",
       logical: "matrix",
       tags: "tags",
@@ -49,7 +52,20 @@ const SCHEMAS = {
       homepage_url: "string",
       github_url: "string",
       paper_urls: "urls",
+      aliases: "tags",
       tags: "tags",
+    },
+  },
+  papers: {
+    required: { title: "string", authors: "names", url: "string" },
+    optional: {
+      year: "number",
+      // Typed `string` deliberately, and the reason is a real trap: unquoted,
+      // `arxiv_id: 2402.17761` is a YAML FLOAT, and 2601.05110 would silently
+      // lose its trailing zero. The type check is what forces the quotes.
+      arxiv_id: "string",
+      doi: "string",
+      journal_ref: "string",
     },
   },
 };
@@ -60,6 +76,12 @@ function checkType(value, type) {
   if (type === "string") return typeof value === "string";
   if (type === "number") return typeof value === "number" && Number.isFinite(value);
   if (type === "tags") return Array.isArray(value) && value.every((v) => typeof v === "string");
+  if (type === "names")
+    return (
+      Array.isArray(value) &&
+      value.length > 0 &&
+      value.every((v) => typeof v === "string" && v.trim() !== "")
+    );
   if (type === "urls")
     return (
       Array.isArray(value) && value.every((v) => typeof v === "string" && /^https?:\/\//.test(v))
@@ -177,6 +199,81 @@ for (const [dir, schema] of Object.entries(SCHEMAS)) {
         }
       }
     }
+
+    if (dir === "papers") {
+      if (typeof data?.url === "string" && !/^https?:\/\//.test(data.url)) {
+        allErrors.push(`${relPath}: url must be an http(s) link, got '${data.url}'`);
+      }
+      // The id is the match key, so its shape is load-bearing: "arXiv:2402.17761"
+      // or "2402.17761v2" would build a link no circuit source equals.
+      if (typeof data?.arxiv_id === "string") {
+        if (/^arxiv:/i.test(data.arxiv_id)) {
+          allErrors.push(`${relPath}: arxiv_id must not carry an 'arXiv:' prefix`);
+        }
+        if (/v\d+$/.test(data.arxiv_id)) {
+          allErrors.push(`${relPath}: arxiv_id must not carry a version suffix`);
+        }
+      }
+      if (typeof data?.doi === "string" && /^https?:\/\//.test(data.doi)) {
+        allErrors.push(`${relPath}: doi must be a bare DOI, not a link (use url for the link)`);
+      }
+    }
+  }
+}
+
+// --- Papers: link collisions, and circuit sources that will not resolve ---
+//
+// Both are warnings, not errors: a source with no paper still renders and still
+// searches by URL, it just cannot be found by title or author. Failing the build
+// over it would make adding a circuit depend on cataloguing its paper first.
+const warnings = [];
+{
+  const papersDir = path.join(DATA_DIR, "papers");
+  const circuitsDir = path.join(DATA_DIR, "circuits");
+  const claimed = new Map(); // paperKey -> paper file
+
+  if (fs.existsSync(papersDir)) {
+    for (const file of fs.readdirSync(papersDir).filter((f) => f.endsWith(".yaml"))) {
+      let data;
+      try {
+        data = yaml.load(fs.readFileSync(path.join(papersDir, file), "utf8"));
+      } catch {
+        continue; // parse error already reported above
+      }
+      if (!data) continue;
+      for (const link of paperLinks(data)) {
+        const key = paperKey(link);
+        if (claimed.has(key) && claimed.get(key) !== file) {
+          allErrors.push(
+            `papers/${file}: link '${link}' is also claimed by papers/${claimed.get(key)}`,
+          );
+        } else {
+          claimed.set(key, file);
+        }
+      }
+    }
+  }
+
+  if (fs.existsSync(circuitsDir)) {
+    const unmatched = new Map(); // source -> circuit count
+    for (const file of fs.readdirSync(circuitsDir).filter((f) => f.endsWith(".yaml"))) {
+      let data;
+      try {
+        data = yaml.load(fs.readFileSync(path.join(circuitsDir, file), "utf8"));
+      } catch {
+        continue;
+      }
+      if (!data || !isPaperSource(data.source)) continue;
+      if (!claimed.has(paperKey(data.source))) {
+        unmatched.set(data.source, (unmatched.get(data.source) ?? 0) + 1);
+      }
+    }
+    for (const [source, count] of [...unmatched].sort((a, b) => b[1] - a[1])) {
+      warnings.push(
+        `${count} circuit${count === 1 ? "" : "s"} cite '${source}', which has no file in ` +
+          `data_yaml/papers/ — they are searchable by URL but not by title or author`,
+      );
+    }
   }
 }
 
@@ -203,6 +300,14 @@ for (const [dir, schema] of Object.entries(SCHEMAS)) {
       }
     }
   }
+}
+
+if (warnings.length > 0) {
+  console.warn("Warnings:\n");
+  for (const w of warnings) {
+    console.warn(`  ! ${w}`);
+  }
+  console.warn("");
 }
 
 if (allErrors.length > 0) {

--- a/src/components/CircuitRow.astro
+++ b/src/components/CircuitRow.astro
@@ -1,13 +1,16 @@
 ---
-import type { Circuit, Tool } from "../types";
-import { formatCircuitId } from "../lib/queries";
+import type { Circuit, Paper, Tool } from "../types";
+import { formatCircuitId, formatCitation } from "../lib/queries";
 import { buildStimFilename } from "../lib/filename";
 import HeartIcon from "./HeartIcon.astro";
 import MetricBadge from "./MetricBadge.astro";
+import SourceLine from "./SourceLine.astro";
 
 interface Props {
   circuit: Circuit & { tags: string[] };
   tool?: Tool;
+  /** The paper this circuit is taken from, when it has one. */
+  paper?: Paper;
   codeSlug: string;
   /** Shown next to the name on cross-code lists (/search), where the row would
    *  otherwise not say which code it belongs to. Omitted on code pages, where
@@ -22,11 +25,13 @@ interface Props {
   permalinkPath?: string;
 }
 
-const { circuit, tool, codeSlug, codeLabel, tagHrefFor, permalinkPath } = Astro.props;
+const { circuit, tool, paper, codeSlug, codeLabel, tagHrefFor, permalinkPath } = Astro.props;
 
 const basePath = `/codes/${codeSlug}`;
 const tagHref = tagHrefFor ?? ((tag: string) => `${basePath}?tag=${encodeURIComponent(tag)}`);
 const displayId = formatCircuitId(circuit.qec_id);
+// Handed to the cite toast when a body is copied/downloaded from this row.
+const citationLabel = paper ? `${formatCitation(paper)}, ${paper.title}` : undefined;
 
 // Row data consumed by list-filter-client.ts (client-side filtering/sorting).
 const rowMetrics = JSON.stringify({
@@ -171,16 +176,7 @@ const stimFilename = buildStimFilename({
             </svg>
           </button>
         </div>
-        <div>
-          <span class="text-gray-500 dark:text-gray-400">Source:</span>{" "}
-          {circuit.source.startsWith("http") ? (
-            <a href={circuit.source} class="underline hover:text-gray-900 dark:hover:text-gray-100" target="_blank" rel="noopener">
-              {circuit.source}
-            </a>
-          ) : (
-            <span>{circuit.source}</span>
-          )}
-        </div>
+        <SourceLine source={circuit.source} paper={paper} />
         {tool && (
           <div>
             <span class="text-gray-500 dark:text-gray-400">Tool:</span>{" "}
@@ -234,6 +230,7 @@ const stimFilename = buildStimFilename({
         data-qec-id={anchorId}
         data-stim-filename={stimFilename}
         data-source={circuit.source}
+        data-citation={citationLabel}
       >
         <p class="circuit-bodies-status text-sm text-gray-500 dark:text-gray-400">Loading circuit&hellip;</p>
       </div>

--- a/src/components/CiteToast.astro
+++ b/src/components/CiteToast.astro
@@ -32,7 +32,11 @@
       toast.classList.remove("translate-y-0", "opacity-100", "pointer-events-auto");
     }
 
-    function show(text, sourceUrl) {
+    // `linkLabel` is what the link reads as; the URL is the fallback. Set to a
+    // citation ("Zen et al. (2024), <title>") where the source resolved to a
+    // paper — a reader can act on that, where a bare arxiv.org/abs/2402.17761
+    // only tells them to go look.
+    function show(text, sourceUrl, linkLabel) {
       clearTimeout(timer);
       msg.textContent = "";
       msg.appendChild(document.createTextNode(text));
@@ -43,7 +47,7 @@
         link.target = "_blank";
         link.rel = "noopener";
         link.className = "underline hover:text-gray-900 dark:hover:text-gray-100";
-        link.textContent = sourceUrl;
+        link.textContent = linkLabel || sourceUrl;
         msg.appendChild(link);
       }
       toast.classList.remove("translate-y-4", "opacity-0", "pointer-events-none");

--- a/src/components/CodeBlock.astro
+++ b/src/components/CodeBlock.astro
@@ -7,6 +7,9 @@ interface Props {
   label?: string;
   downloadName?: string;
   source?: string;
+  /** Human-readable citation for `source`, when it resolved to a paper. Used as
+   *  the cite-toast link label in place of the raw URL. */
+  citation?: string;
   /** The detector-annotated variant of `code`, when the circuit has one. It
    *  supersedes `code` for display: it is the same circuit with the |0...0>
    *  input stated explicitly, plus a readout the Detectors switch subtracts. */
@@ -19,7 +22,7 @@ interface Props {
 // KEEP THE CODE-BLOCK MARKUP IN SYNC with CircuitBodiesTemplate.astro, which
 // is cloned client-side on code pages (this component renders only on
 // circuit detail pages).
-const { code, label, downloadName, source, annotated, coordsToggle = true } = Astro.props;
+const { code, label, downloadName, source, citation, annotated, coordsToggle = true } = Astro.props;
 
 // The switches subtract from the fullest form the circuit has, so that is what
 // the block carries and what gets rendered down to the default view.
@@ -44,6 +47,7 @@ const needsRaw = hasCoords || hasDetectors(raw);
     class="rounded border border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-900 overflow-hidden"
     data-code-block
     data-source={source ?? ""}
+    data-citation={citation || undefined}
     data-raw-code={needsRaw ? raw : undefined}
   >
     <div class="border-b border-gray-200 dark:border-gray-800 px-4 py-2 text-xs text-gray-500 dark:text-gray-400 flex items-center justify-between">
@@ -88,6 +92,7 @@ const needsRaw = hasCoords || hasDetectors(raw);
 <script>
   import { copyToClipboard } from "../lib/dom-helpers";
   import { initBodyViews } from "../lib/body-view-client";
+  import { citeNotice as showCiteNotice } from "../lib/cite-client";
 
   initBodyViews();
 
@@ -95,17 +100,10 @@ const needsRaw = hasCoords || hasDetectors(raw);
     block.setAttribute("data-initialized", "");
 
     const source = block.dataset.source || "";
+    const citation = block.dataset.citation || undefined;
 
     function citeNotice() {
-      if (typeof window.showCiteToast === "function") {
-        if (source && source.startsWith("http")) {
-          window.showCiteToast("Please cite the source when using this circuit:", source);
-        } else if (source) {
-          window.showCiteToast("Please cite the source when using this circuit: " + source);
-        } else {
-          window.showCiteToast("Please check and cite the corresponding source when using this circuit.");
-        }
-      }
+      showCiteNotice(source, citation);
     }
 
     block.querySelectorAll(".copy-btn").forEach(function (btn) {

--- a/src/components/FormatSwitcher.astro
+++ b/src/components/FormatSwitcher.astro
@@ -14,9 +14,11 @@ interface Props {
   bodies: CircuitBody[];
   stimFilename?: string;
   source?: string;
+  /** Human-readable citation for `source`; forwarded to the cite toast. */
+  citation?: string;
 }
 
-const { bodies, stimFilename, source } = Astro.props;
+const { bodies, stimFilename, source, citation } = Astro.props;
 
 // The annotated body is a view of the STIM body, not a format of its own, so it
 // gets no tab. It supersedes the plain STIM body for display; the switches
@@ -82,6 +84,7 @@ const TAB_BASE_CLASS =
           label={`${b.format.toUpperCase()} Circuit`}
           downloadName={downloadNameFor(b.format)}
           source={source}
+          citation={citation}
           coordsToggle={false}
         />
       </div>
@@ -94,6 +97,7 @@ const TAB_BASE_CLASS =
     label={`${tabs[0].format.toUpperCase()} Circuit`}
     downloadName={downloadNameFor(tabs[0].format)}
     source={source}
+    citation={citation}
   />
 ) : (
   <p class="text-sm text-gray-500 dark:text-gray-400">No circuit body available.</p>

--- a/src/components/SourceLine.astro
+++ b/src/components/SourceLine.astro
@@ -1,0 +1,48 @@
+---
+import type { Paper } from "../types";
+import { formatCitation, formatPaperId } from "../lib/queries";
+
+interface Props {
+  /** The circuit's raw provenance string. Rendered as-is when no paper resolved
+   *  from it — as a link if it looks like one, plain text otherwise (a tool
+   *  name such as "circuit-synth"). */
+  source: string;
+  /** The paper `source` resolved to, when the library holds one. */
+  paper?: Paper;
+  /** Detail pages have a column to themselves and show the full title; list
+   *  rows sit in a dense flex line and keep it to the citation, with the title
+   *  on hover. */
+  detailed?: boolean;
+}
+
+const { source, paper, detailed = false } = Astro.props;
+
+const linkClass = "underline hover:text-gray-900 dark:hover:text-gray-100";
+const paperId = paper ? formatPaperId(paper) : null;
+// The row link's tooltip carries what the visible label omits, so a search hit
+// that matched on title text can still be explained by hovering it.
+const hoverTitle = paper ? [paper.title, paperId].filter(Boolean).join(" — ") : undefined;
+---
+
+<div>
+  <span class="text-gray-500 dark:text-gray-400">Source:</span>{" "}
+  {
+    paper ? (
+      <span>
+        <a href={paper.url} class={linkClass} title={hoverTitle} target="_blank" rel="noopener">
+          {formatCitation(paper)}
+        </a>
+        {detailed && <span>, {paper.title}</span>}
+        {paperId && (
+          <span class="text-gray-500 dark:text-gray-400"> &middot; {paperId}</span>
+        )}
+      </span>
+    ) : source.startsWith("http") ? (
+      <a href={source} class={linkClass} target="_blank" rel="noopener">
+        {source}
+      </a>
+    ) : (
+      <span>{source}</span>
+    )
+  }
+</div>

--- a/src/lib/circuit-bodies-client.ts
+++ b/src/lib/circuit-bodies-client.ts
@@ -8,6 +8,7 @@
 import { copyToClipboard, syncDetailHeight } from "./dom-helpers";
 import { initFormatSwitchers } from "./format-switcher-client";
 import { initBodyView } from "./body-view-client";
+import { citeNotice } from "./cite-client";
 import {
   ANNOTATED_OF,
   bodyForDisplay,
@@ -28,18 +29,6 @@ const TAB_BASE_CLASS =
 
 const loaded = new WeakSet<HTMLElement>();
 
-/** Same cite-toast behavior as CodeBlock.astro's copy/download handlers. */
-function citeNotice(source: string): void {
-  if (typeof window.showCiteToast !== "function") return;
-  if (source && source.startsWith("http")) {
-    window.showCiteToast("Please cite the source when using this circuit:", source);
-  } else if (source) {
-    window.showCiteToast("Please cite the source when using this circuit: " + source);
-  } else {
-    window.showCiteToast("Please check and cite the corresponding source when using this circuit.");
-  }
-}
-
 function buildSwitcher(
   container: HTMLElement,
   template: HTMLTemplateElement,
@@ -56,6 +45,7 @@ function buildSwitcher(
 
   const stimFilename = container.dataset.stimFilename ?? "";
   const source = container.dataset.source ?? "";
+  const citation = container.dataset.citation || undefined;
 
   // The annotated body is a view of the STIM body, not a format of its own, so
   // it gets no tab; it supersedes the plain STIM body for display. Mirrors
@@ -135,7 +125,7 @@ function buildSwitcher(
           a.download = downloadName;
           a.click();
           URL.revokeObjectURL(url);
-          citeNotice(source);
+          citeNotice(source, citation);
         });
       } else {
         downloadBtn.remove();
@@ -154,7 +144,7 @@ function buildSwitcher(
             label.textContent = original;
           }, 1500);
         }
-        citeNotice(source);
+        citeNotice(source, citation);
       });
     }
 

--- a/src/lib/cite-client.ts
+++ b/src/lib/cite-client.ts
@@ -1,0 +1,23 @@
+/** The "please cite" toast raised after copying or downloading a circuit body.
+ *
+ * Shared by CodeBlock.astro (circuit detail pages) and circuit-bodies-client.ts
+ * (the switchers built client-side on code pages). It lived in both before,
+ * which is exactly the kind of pair that drifts.
+ *
+ * `citation` is the human-readable label for the link — "Zen et al. (2024),
+ * <title>" — set wherever the circuit's source resolved to a paper. Without one
+ * the URL is its own label, which is all a bare source can offer.
+ */
+export function citeNotice(source: string, citation?: string): void {
+  if (typeof window.showCiteToast !== "function") return;
+
+  const msg = "Please cite the source when using this circuit:";
+  if (source && source.startsWith("http")) {
+    window.showCiteToast(msg, source, citation);
+  } else if (source) {
+    // A non-link source names a tool, so there is nothing to link to.
+    window.showCiteToast(`${msg} ${citation || source}`);
+  } else {
+    window.showCiteToast("Please check and cite the corresponding source when using this circuit.");
+  }
+}

--- a/src/lib/queries/circuits.ts
+++ b/src/lib/queries/circuits.ts
@@ -57,34 +57,6 @@ export function countAllCircuits(): number {
   return row.count;
 }
 
-/** Distinct papers to cite when using these circuits.
- *
- * `circuits.source` is the work a circuit should be credited to — normally a
- * paper link. It is free-form, though, and some rows instead hold the tool that
- * generated the circuit: a bare name ("circuit-synth"), or a repo URL that is
- * literally a tool's own `github_url`. Those belong to the tool, which carries
- * its own homepage/github/paper links, so they are not counted here.
- *
- * Hence the rule: a source is a paper if it is a link and is not a tool's link.
- * Testing for arxiv.org/doi.org instead would be narrower AND wronger — it
- * would miss a paper published anywhere else (a journal, quantum-journal.org).
- *
- * Counts the circuits' own sources only: `tools.paper_urls` cites the tool, not
- * the circuit.
- */
-export function countCircuitPapers(): number {
-  const db = getDb();
-  const row = db
-    .prepare(
-      `SELECT COUNT(DISTINCT source) AS count FROM circuits
-       WHERE source LIKE 'http%'
-         AND source NOT IN (SELECT homepage_url FROM tools WHERE homepage_url IS NOT NULL)
-         AND source NOT IN (SELECT github_url FROM tools WHERE github_url IS NOT NULL)`,
-    )
-    .get() as { count: number };
-  return row.count;
-}
-
 /** Most recently added circuits, for the landing page.
  *
  * Ordered by `qec_id DESC`, NOT `created_at`: create_database.mjs rebuilds the

--- a/src/lib/queries/index.ts
+++ b/src/lib/queries/index.ts
@@ -6,7 +6,6 @@ export {
   countCircuitsForCode,
   codeHasWeightedCircuits,
   countAllCircuits,
-  countCircuitPapers,
   getLatestCircuits,
   getCircuitTagsForCode,
   filterCircuitsForCode,
@@ -19,6 +18,13 @@ export {
   getOriginalForCircuit,
 } from "./circuits";
 export { getAllTools, countAllTools, filterTools, getToolsForCircuits } from "./tools";
+export {
+  getPapersForCircuits,
+  countCircuitPapers,
+  formatCitation,
+  formatAuthors,
+  formatPaperId,
+} from "./papers";
 export { correctTokens } from "./spelling";
 export {
   searchCodes,

--- a/src/lib/queries/papers.ts
+++ b/src/lib/queries/papers.ts
@@ -1,0 +1,84 @@
+import { getDb } from "../db";
+import type { Paper } from "../../types";
+
+export type PaperRow = Omit<Paper, "authors"> & { authors: string };
+
+export function parsePaperRow(row: PaperRow): Paper {
+  return { ...row, authors: JSON.parse(row.authors) as string[] };
+}
+
+/** Surname for the citation line.
+ *
+ * Last whitespace-separated word of the full name. This is a heuristic and it
+ * would get "Ludwig van Beethoven" wrong (-> "Beethoven" is right, but "Vincent
+ * van Gogh" -> "Gogh" is not), so it is confined to the citation label: every
+ * search index gets the FULL name, and the link always carries the real
+ * identifier. A wrong surname here mislabels a link; it cannot lose a paper.
+ */
+function surname(fullName: string): string {
+  const parts = fullName.trim().split(/\s+/);
+  return parts[parts.length - 1] ?? fullName;
+}
+
+/** Author credit in the usual convention: one name, two joined by "&", or the
+ *  first followed by "et al." */
+export function formatAuthors(authors: string[]): string {
+  if (authors.length === 0) return "";
+  if (authors.length === 1) return surname(authors[0]);
+  if (authors.length === 2) return `${surname(authors[0])} & ${surname(authors[1])}`;
+  return `${surname(authors[0])} et al.`;
+}
+
+/** The one-line citation shown wherever a circuit's source is displayed, e.g.
+ *  "Zen et al. (2024)". Year omitted rather than faked when unknown. */
+export function formatCitation(paper: Paper): string {
+  const authors = formatAuthors(paper.authors);
+  return paper.year == null ? authors : `${authors} (${paper.year})`;
+}
+
+/** How the paper prefers to be referred to in short form: "arXiv:2402.17761",
+ *  else the DOI, else nothing. Distinct from the citation — this is the id a
+ *  reader would search for, not the credit. */
+export function formatPaperId(paper: Paper): string | null {
+  if (paper.arxiv_id) return `arXiv:${paper.arxiv_id}`;
+  if (paper.doi) return `doi:${paper.doi}`;
+  return null;
+}
+
+/** Papers for a batch of circuits, keyed by circuit id. Mirrors
+ *  getToolsForCircuits: one query per page, not one per row. */
+export function getPapersForCircuits(circuitIds: number[]): Map<number, Paper> {
+  const result = new Map<number, Paper>();
+  if (circuitIds.length === 0) return result;
+
+  const placeholders = circuitIds.map(() => "?").join(",");
+  const rows = getDb()
+    .prepare(
+      `SELECT c.id AS circuit_id, p.* FROM circuits c
+       JOIN papers p ON p.id = c.paper_id
+       WHERE c.id IN (${placeholders}) AND c.paper_id IS NOT NULL`,
+    )
+    .all(...circuitIds) as (PaperRow & { circuit_id: number })[];
+
+  for (const row of rows) {
+    const { circuit_id, ...paper } = row;
+    result.set(circuit_id, parsePaperRow(paper));
+  }
+  return result;
+}
+
+/** Distinct papers at least one circuit is taken from, for the landing page
+ *  stat. Counts papers with circuits rather than every row in `papers`: the
+ *  stat claims "circuits drawn from N papers", and a paper catalogued ahead of
+ *  its circuits has contributed none yet. (`tools` counts differently and on
+ *  purpose — /tools lists tools with no circuits, so countAllTools includes
+ *  them.) */
+export function countCircuitPapers(): number {
+  const row = getDb()
+    .prepare(
+      `SELECT COUNT(DISTINCT p.id) AS count FROM papers p
+       JOIN circuits c ON c.paper_id = p.id`,
+    )
+    .get() as { count: number };
+  return row.count;
+}

--- a/src/lib/queries/search-schema.ts
+++ b/src/lib/queries/search-schema.ts
@@ -1,0 +1,128 @@
+// The two facts about `circuit_search` that must track its column list, derived
+// from the table itself rather than restated by hand.
+//
+// Both were hand-maintained before, and both drifted -- in the same week, in two
+// different branches, despite the comment on each shouting about it:
+//
+//   * BM25_WEIGHTS was left at 7 entries when an 8th column was added. FTS5
+//     silently defaults the rest to 1.0 rather than erroring, so `paper` quietly
+//     took the weight meant for `notes`. It only escaped notice because the two
+//     happened to want the same number.
+//   * STRICT_COLUMNS was missing `paper`, so an exact author match ("forlivesi")
+//     failed the strict rung and got reported to the user as a loose `related`
+//     fallback -- "no code goes by that name here" for a name that was right.
+//
+// A comment that is ignored twice is not a control. `PRAGMA table_info` returns
+// the real columns in declaration order, which is exactly what BM25 wants, so
+// the array is built from the table and a missing weight is a loud error naming
+// the column instead of a silent mis-ranking.
+
+import { getDb } from "../db";
+
+/** Weight per column, BY NAME. Order here is irrelevant -- position comes from
+ *  the table. Every column of circuit_search must appear, or building the array
+ *  throws.
+ *
+ * `circuit_id` is UNINDEXED and scores nothing; it takes 0.0 because FTS5 still
+ * counts it as a column.
+ *
+ * `name` dominates: a circuit's own name is the sharpest thing about it.
+ * `tags` (6.0) beat `code_name`/`aliases`/`code_tags` (4.0): a circuit's own tag
+ * distinguishes it from its siblings, while facts about its code are shared by
+ * every circuit under that code. An alias IS a code name, so it matches
+ * code_name exactly -- "laflamme" should rank a five-qubit circuit as
+ * "five-qubit" does.
+ *
+ * `related` (0.5) sits lowest: it only ever decides a query nothing else
+ * answered, and when it does every hit comes through it, so its weight orders
+ * nothing. Low means a circuit matching real text still outranks a loose match.
+ *
+ * `paper` (1.0) is deliberately as low as `notes`, which is counter-intuitive --
+ * a title looks like a stronger signal than boilerplate. It is not:
+ *   1. the text is identical across every circuit from that paper (370 for the
+ *      largest), so it never distinguishes between them; and
+ *   2. it is a SHORT field (~25 tokens), and BM25 already normalizes term
+ *      frequency by field length, so a hit there outscores the same hit in long
+ *      `notes` before any weight applies. Weighting it up double-counts that.
+ * Measured at 3.0: all 20 of the top 20 for "fault tolerant" were circuits
+ * tagged `non-ft` -- baselines from papers whose TITLES say fault-tolerant,
+ * beating the genuinely FT circuits whose notes say so. At 1.0: none. Weights
+ * reorder, they never filter, so no title query loses a hit. Re-check that query
+ * if you raise this.
+ */
+const COLUMN_WEIGHTS: Record<string, number> = {
+  circuit_id: 0.0,
+  name: 10.0,
+  code_name: 4.0,
+  aliases: 4.0,
+  related: 0.5,
+  tags: 6.0,
+  code_tags: 4.0,
+  paper: 1.0,
+  notes: 1.0,
+};
+
+/** Columns matched only as a last resort, which `/search` then owns up to.
+ *
+ * `related` names a DIFFERENT, adjacent code ("toric" for a planar surface
+ * code); treating a hit there as an exact answer would assert something untrue.
+ * Everything else indexed is strict. New columns are strict BY DEFAULT, which is
+ * the safe direction: the failure mode of wrongly-strict is a hit ranked
+ * normally, while wrongly-loose tells the user their exact query found nothing.
+ */
+const LOOSE_COLUMNS = new Set(["related"]);
+
+/** UNINDEXED, so FTS5 rejects it inside a column filter. */
+const UNINDEXED_COLUMNS = new Set(["circuit_id"]);
+
+let cache: { weights: number[]; strict: string } | null = null;
+
+/** Read the columns as declared, in order. The DB is baked at build time and
+ *  immutable for the life of the process, so this runs once. */
+function columns(): string[] {
+  return (getDb().prepare("PRAGMA table_info(circuit_search)").all() as { name: string }[]).map(
+    (r) => r.name,
+  );
+}
+
+function build(): { weights: number[]; strict: string } {
+  const cols = columns();
+
+  const missing = cols.filter((c) => !(c in COLUMN_WEIGHTS));
+  if (missing.length > 0) {
+    throw new Error(
+      `circuit_search has column(s) with no BM25 weight: ${missing.join(", ")}. ` +
+        `Add them to COLUMN_WEIGHTS in queries/search-schema.ts. (Left unset, FTS5 ` +
+        `would silently score them 1.0 and mis-rank every result.)`,
+    );
+  }
+  const stale = Object.keys(COLUMN_WEIGHTS).filter((c) => !cols.includes(c));
+  if (stale.length > 0) {
+    throw new Error(
+      `COLUMN_WEIGHTS names column(s) that circuit_search does not have: ${stale.join(", ")}. ` +
+        `Drop them, or fix the CREATE in the latest migration.`,
+    );
+  }
+
+  // Positional, in declaration order -- which is what bm25() expects.
+  const weights = cols.map((c) => COLUMN_WEIGHTS[c]);
+
+  const strictCols = cols.filter((c) => !LOOSE_COLUMNS.has(c) && !UNINDEXED_COLUMNS.has(c));
+  return { weights, strict: `{${strictCols.join(" ")}}` };
+}
+
+function schema(): { weights: number[]; strict: string } {
+  if (cache === null) cache = build();
+  return cache;
+}
+
+/** BM25 weights, one per column, in the table's own order. */
+export function bm25Weights(): number[] {
+  return schema().weights;
+}
+
+/** FTS5 column-filter for the strict rungs of resolveQuery, e.g.
+ *  `{name code_name aliases tags code_tags paper notes}`. */
+export function strictColumns(): string {
+  return schema().strict;
+}

--- a/src/lib/queries/search.ts
+++ b/src/lib/queries/search.ts
@@ -2,6 +2,7 @@ import { getDb } from "../db";
 import type { Circuit, CodeListItem, TagWithCount, Tool } from "../../types";
 import { withTags, addTagConditions } from "./shared";
 import { correctTokens } from "./spelling";
+import { bm25Weights, strictColumns } from "./search-schema";
 import { parseToolRow, type ToolRow } from "./tools";
 
 /** Shortest query we will run. Below this, LIKE/FTS scans match near-everything
@@ -29,9 +30,16 @@ export function tokenizeQuery(raw: string): string[] {
 }
 
 /** Quote each token as a literal phrase and join them. The final token gets a
- *  `*` so partial words still match ("encod" -> "encoding"). */
-function buildFtsExpr(tokens: string[], op: "AND" | "OR"): string {
-  return tokens.map((t, i) => `"${t}"${i === tokens.length - 1 ? "*" : ""}`).join(` ${op} `);
+ *  `*` so partial words still match ("encod" -> "encoding").
+ *
+ * `scope` restricts the whole expression to a column set. Applied around the
+ * group rather than per token so that AND/OR still range over the expression:
+ * `{a b} : (x AND y)` means "x and y, each in a or b", whereas repeating the
+ * filter per token would nest filters and change what the operators bind to.
+ */
+function buildFtsExpr(tokens: string[], op: "AND" | "OR", scope?: string): string {
+  const expr = tokens.map((t, i) => `"${t}"${i === tokens.length - 1 ? "*" : ""}`).join(` ${op} `);
+  return scope ? `${scope} : (${expr})` : expr;
 }
 
 function countMatches(expr: string): number {
@@ -55,6 +63,11 @@ export interface ResolvedQuery {
   corrected: boolean;
   /** No circuit had every term, so we matched any term instead. */
   partial: boolean;
+  /** Nothing matched by name/alias, so we fell back to `related` -- these
+   *  circuits are a DIFFERENT code to the one asked for (a planar surface code
+   *  for "toric"). The page must say so; silently equating them would assert
+   *  something untrue. */
+  relatedOnly: boolean;
 }
 
 /** Returns null when nothing searchable remains (e.g. input was all
@@ -68,23 +81,40 @@ export function resolveQuery(raw: string, opts: { literal?: boolean } = {}): Res
     ? { tokens, changed: false }
     : correctTokens(tokens);
 
-  // Falling back to "any term" is a last resort, taken only when every term
-  // together finds nothing -- otherwise a query like "steane encoding" would
-  // dilute its own precise hits with everything merely mentioning "encoding".
+  // Widening is a last resort, and the order below is the whole design: each
+  // step gives up less than the one after it.
+  //
+  //   1. every term, by name/alias        -- what was asked for
+  //   2. every term, allowing `related`   -- a neighbouring code, flagged
+  //   3. any term, by name/alias          -- a weaker answer to the question
+  //   4. any term, allowing `related`
+  //
+  // (2) precedes (3) because dropping to "any term" is the bigger concession:
+  // "toric code" widened to ANY term matches every circuit with "code" in it
+  // (824 of 833), while allowing `related` returns surface codes -- which is
+  // what the user meant. Ranking (3) first would answer a precise query with the
+  // catalogue.
+  //
   // Decided on the query alone, before code/tag filters, so that narrowing a
   // filter to zero cannot silently widen the query underneath it.
-  const and = buildFtsExpr(fixed, "AND");
-  let match = and;
-  let partial = false;
-  if (fixed.length > 1 && countMatches(and) === 0) {
-    const or = buildFtsExpr(fixed, "OR");
-    if (countMatches(or) > 0) {
-      match = or;
-      partial = true;
-    }
+  const attempts: { match: string; partial: boolean; relatedOnly: boolean }[] = [
+    { match: buildFtsExpr(fixed, "AND", strictColumns()), partial: false, relatedOnly: false },
+    { match: buildFtsExpr(fixed, "AND"), partial: false, relatedOnly: true },
+  ];
+  if (fixed.length > 1) {
+    attempts.push(
+      { match: buildFtsExpr(fixed, "OR", strictColumns()), partial: true, relatedOnly: false },
+      { match: buildFtsExpr(fixed, "OR"), partial: true, relatedOnly: true },
+    );
   }
 
-  return { raw, display: fixed.join(" "), match, corrected: changed, partial };
+  const base = { raw, display: fixed.join(" "), corrected: changed };
+  for (const attempt of attempts) {
+    if (countMatches(attempt.match) > 0) return { ...base, ...attempt };
+  }
+  // Nothing matched anywhere. Return the strictest expression so the page
+  // reports "no results" for what was actually asked, not for a widened query.
+  return { ...base, ...attempts[0] };
 }
 
 function rawTokenize(query: string): string[] {
@@ -108,16 +138,20 @@ function searchByType<T extends { id: number }>(
   const patterns = tokenize(query);
   if (patterns.length === 0) return [];
 
+  // `aliases` is matched here but `related` deliberately is not: the quick-search
+  // is a jump-to-a-known-thing list with no room to explain itself, and offering
+  // "Rotated Surface Code" under the heading of a `toric` search would read as a
+  // claim that they are the same code. /search has the space to say otherwise.
   const db = getDb();
   const tokenClauses = patterns.map(
     () =>
-      `(c.name LIKE ? ESCAPE '\\' OR EXISTS (
+      `(c.name LIKE ? ESCAPE '\\' OR c.aliases LIKE ? ESCAPE '\\' OR EXISTS (
         SELECT 1 FROM taggings tg JOIN tags t ON t.id = tg.tag_id
         WHERE tg.taggable_id = c.id AND tg.taggable_type = ? AND t.name LIKE ? ESCAPE '\\'
       ))`,
   );
   const params: string[] = [];
-  for (const p of patterns) params.push(p, taggableType, p);
+  for (const p of patterns) params.push(p, p, taggableType, p);
 
   const rows = db
     .prepare(
@@ -153,30 +187,35 @@ export function searchCircuits(
     const stripped = raw.replace(/^#/, "");
     const asInt = /^\d+$/.test(stripped) ? parseInt(stripped, 10) : null;
 
+    // As in searchByType: code aliases match, code `related` names do not.
     if (asInt !== null) {
       tokenClauses.push(
         `(ci.qec_id = ? OR ci.name LIKE ? ESCAPE '\\' OR co.name LIKE ? ESCAPE '\\'
+          OR co.aliases LIKE ? ESCAPE '\\'
           OR EXISTS (
             SELECT 1 FROM taggings tg JOIN tags t ON t.id = tg.tag_id
             WHERE tg.taggable_id = ci.id AND tg.taggable_type = 'circuit' AND t.name LIKE ? ESCAPE '\\'
           )
           OR EXISTS (
-            SELECT 1 FROM tools tl WHERE tl.id = ci.tool_id AND tl.name LIKE ? ESCAPE '\\'
+            SELECT 1 FROM tools tl WHERE tl.id = ci.tool_id
+              AND (tl.name LIKE ? ESCAPE '\\' OR tl.aliases LIKE ? ESCAPE '\\')
           ))`,
       );
-      params.push(asInt, p, p, p, p);
+      params.push(asInt, p, p, p, p, p, p);
     } else {
       tokenClauses.push(
         `(ci.name LIKE ? ESCAPE '\\' OR co.name LIKE ? ESCAPE '\\'
+          OR co.aliases LIKE ? ESCAPE '\\'
           OR EXISTS (
             SELECT 1 FROM taggings tg JOIN tags t ON t.id = tg.tag_id
             WHERE tg.taggable_id = ci.id AND tg.taggable_type = 'circuit' AND t.name LIKE ? ESCAPE '\\'
           )
           OR EXISTS (
-            SELECT 1 FROM tools tl WHERE tl.id = ci.tool_id AND tl.name LIKE ? ESCAPE '\\'
+            SELECT 1 FROM tools tl WHERE tl.id = ci.tool_id
+              AND (tl.name LIKE ? ESCAPE '\\' OR tl.aliases LIKE ? ESCAPE '\\')
           ))`,
       );
-      params.push(p, p, p, p);
+      params.push(p, p, p, p, p, p);
     }
   }
 
@@ -286,13 +325,6 @@ export function searchCircuitFacets(query: ResolvedQuery): SearchFacets {
   return { codes, tags };
 }
 
-// BM25 column weights. ONE PER COLUMN OF circuit_search, INCLUDING THE
-// UNINDEXED circuit_id -- FTS5 counts it as a column, and passing too few
-// weights is silently accepted (the rest default to 1.0) rather than erroring,
-// so a missing leading 0.0 would quietly mis-rank every result.
-//   circuit_id, name, code_name, tags, notes
-const BM25_WEIGHTS = [0.0, 10.0, 4.0, 6.0, 1.0];
-
 /** Circuit search for /search: full-text over name/code name/tags/notes,
  *  ranked by relevance, optionally restricted to one code.
  *
@@ -330,7 +362,7 @@ export function searchCircuitsRanked(
        JOIN circuits c ON c.id = circuit_search.circuit_id
        JOIN codes co ON co.id = c.code_id
        WHERE ${conditions.join(" AND ")}
-       ORDER BY bm25(circuit_search, ${BM25_WEIGHTS.join(", ")}), c.name
+       ORDER BY bm25(circuit_search, ${bm25Weights().join(", ")}), c.name
        LIMIT ?`,
     )
     .all(...params, limit) as Omit<RankedCircuit, "tags">[];

--- a/src/pages/circuits/[qec_id].astro
+++ b/src/pages/circuits/[qec_id].astro
@@ -8,12 +8,15 @@ import CollapsibleSection from "../../components/CollapsibleSection.astro";
 import FormatSwitcher from "../../components/FormatSwitcher.astro";
 import HeartIcon from "../../components/HeartIcon.astro";
 import MetricBadge from "../../components/MetricBadge.astro";
+import SourceLine from "../../components/SourceLine.astro";
 import {
   getCircuitByQecId,
   getOriginalForCircuit,
   getBodiesForCircuits,
   getToolsForCircuits,
+  getPapersForCircuits,
   formatCircuitId,
+  formatCitation,
 } from "../../lib/queries";
 import { buildStimFilename } from "../../lib/filename";
 import { notFound } from "../../lib/not-found";
@@ -32,9 +35,11 @@ const bodiesMap = getBodiesForCircuits([circuit.id]);
 const bodies = bodiesMap.get(circuit.id) ?? [];
 const toolsMap = getToolsForCircuits([circuit.id]);
 const tool = toolsMap.get(circuit.id);
+const paper = getPapersForCircuits([circuit.id]).get(circuit.id);
 const original = getOriginalForCircuit(circuit.id);
 
 const displayId = formatCircuitId(circuit.qec_id);
+const citationLabel = paper ? `${formatCitation(paper)}, ${paper.title}` : undefined;
 
 const stimFilename = buildStimFilename({
   codeSlug: circuit.code_slug,
@@ -68,7 +73,22 @@ const jsonLd = [
     },
     license: "https://creativecommons.org/licenses/by-sa/4.0/",
     ...(circuit.tags.length ? { keywords: circuit.tags.join(", ") } : {}),
-    ...(circuit.source.startsWith("http") ? { citation: circuit.source } : {}),
+    // A resolved paper cites as a ScholarlyArticle with its real authors; a bare
+    // URL is all schema.org can be told about an unresolved source.
+    ...(paper
+      ? {
+          citation: {
+            "@type": "ScholarlyArticle",
+            name: paper.title,
+            author: paper.authors.map((name) => ({ "@type": "Person", name })),
+            url: paper.url,
+            ...(paper.year != null ? { datePublished: String(paper.year) } : {}),
+            ...(paper.doi ? { identifier: `https://doi.org/${paper.doi}` } : {}),
+          },
+        }
+      : circuit.source.startsWith("http")
+        ? { citation: circuit.source }
+        : {}),
   },
   {
     "@context": "https://schema.org",
@@ -124,16 +144,7 @@ const jsonLd = [
   </div>
 
   <div class="flex flex-wrap items-center gap-x-6 gap-y-1 text-sm mb-4">
-    <div>
-      <span class="text-gray-500 dark:text-gray-400">Source:</span>{" "}
-      {circuit.source.startsWith("http") ? (
-        <a href={circuit.source} class="underline hover:text-gray-900 dark:hover:text-gray-100" target="_blank" rel="noopener">
-          {circuit.source}
-        </a>
-      ) : (
-        <span>{circuit.source}</span>
-      )}
-    </div>
+    <SourceLine source={circuit.source} paper={paper} detailed />
     {tool && (
       <div>
         <span class="text-gray-500 dark:text-gray-400">Tool:</span>{" "}
@@ -189,7 +200,7 @@ const jsonLd = [
 
   <h2 class="text-lg font-semibold mb-2">Circuit</h2>
   <div class="mb-6">
-    <FormatSwitcher bodies={bodies} stimFilename={stimFilename} source={circuit.source} />
+    <FormatSwitcher bodies={bodies} stimFilename={stimFilename} source={circuit.source} citation={citationLabel} />
   </div>
 
   {original && (
@@ -197,7 +208,7 @@ const jsonLd = [
       <CollapsibleSection id="originals" label="Original submission (before canonicalization)">
         <div class="space-y-4">
           {original?.original_stim && (
-            <CodeBlock code={original.original_stim} label="Original STIM Circuit" source={circuit.source} />
+            <CodeBlock code={original.original_stim} label="Original STIM Circuit" source={circuit.source} citation={citationLabel} />
           )}
           {hasOriginalMatrices && (
             <CodeMatrices

--- a/src/pages/codes/[code].astro
+++ b/src/pages/codes/[code].astro
@@ -17,6 +17,7 @@ import {
   getCircuitTagsForCode,
   getCircuitsForCode,
   getToolsForCircuits,
+  getPapersForCircuits,
 } from "../../lib/queries";
 import type { CircuitSort, CircuitSortField } from "../../types";
 import { notFound } from "../../lib/not-found";
@@ -46,6 +47,7 @@ const circuits = getCircuitsForCode(code.id, DEFAULT_SORT);
 const totalCount = circuits.length;
 const allCircuitTags = getCircuitTagsForCode(code.id);
 const toolsMap = getToolsForCircuits(circuits.map((c) => c.id));
+const papersMap = getPapersForCircuits(circuits.map((c) => c.id));
 
 const countLabel = `${totalCount} circuit${totalCount !== 1 ? "s" : ""}`;
 
@@ -216,7 +218,7 @@ const jsonLd = [
       </div>
       <div class="space-y-2" data-list-container>
         {circuits.map((circuit) => (
-          <CircuitRow circuit={circuit} tool={toolsMap.get(circuit.id)} codeSlug={codeSlug!} />
+          <CircuitRow circuit={circuit} tool={toolsMap.get(circuit.id)} paper={papersMap.get(circuit.id)} codeSlug={codeSlug!} />
         ))}
       </div>
     </div>

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -11,6 +11,7 @@ import {
   searchCircuitFacets,
   resolveQuery,
   getToolsForCircuits,
+  getPapersForCircuits,
   formatCodeParams,
   MIN_QUERY_LENGTH,
 } from "../lib/queries";
@@ -54,6 +55,7 @@ const results = resolved
   : [];
 const truncated = results.length === RESULT_LIMIT;
 const toolsMap = getToolsForCircuits(results.map((c) => c.id));
+const papersMap = getPapersForCircuits(results.map((c) => c.id));
 
 // Grouped the same way as a code page's circuit tags (CircuitFilter.astro).
 const tagGroups = TAG_CATEGORIES.map((c) => ({
@@ -81,8 +83,9 @@ Astro.response.headers.set("Cache-Control", "public, max-age=0, s-maxage=600");
 >
   <h1 class="text-2xl font-bold mb-2">Search circuits</h1>
   <p class="text-sm text-gray-500 dark:text-gray-400 mb-6">
-    Searches circuit names, notes, tags and code names. For codes and tools, use the
-    quick search in the header.
+    Searches circuit names, notes, tags, code names, and the title, authors and arXiv
+    id of the paper a circuit is taken from. For codes and tools, use the quick search
+    in the header.
   </p>
 
   <form method="GET" action="/search" class="mb-6">
@@ -212,6 +215,13 @@ Astro.response.headers.set("Cache-Control", "public, max-age=0, s-maxage=600");
         </p>
       )}
 
+      {resolved?.relatedOnly && (
+        <p class="text-sm text-gray-500 dark:text-gray-400 mb-3">
+          No code goes by that name here. These are closely related codes that people
+          often mean by it &mdash; check the code on each result before relying on it.
+        </p>
+      )}
+
       {resolved?.partial && (
         <p class="text-sm text-gray-500 dark:text-gray-400 mb-3">
           No circuit matches every term, so these match at least one.
@@ -253,6 +263,7 @@ Astro.response.headers.set("Cache-Control", "public, max-age=0, s-maxage=600");
               <CircuitRow
                 circuit={circuit}
                 tool={toolsMap.get(circuit.id)}
+                paper={papersMap.get(circuit.id)}
                 codeSlug={circuit.code_slug}
                 codeLabel={codeLabel({
                   name: circuit.code_name,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,6 +30,10 @@ export interface Circuit {
   crumble_url_annotated: string | null;
   quirk_url: string | null;
   tool_id: number | null;
+  /** The paper this circuit is taken from, resolved from `source` at build time
+   *  (scripts/db/create_database.mjs). Null when the source names a tool rather
+   *  than a paper, or cites a work data_yaml/papers/ has no record of. */
+  paper_id: number | null;
 }
 
 export interface CircuitBody {
@@ -41,6 +45,22 @@ export interface CircuitOriginal {
   original_stim: string;
   original_h: string | null;
   original_logical: string | null;
+}
+
+/** A published work a circuit is taken from. Its text is what makes a circuit
+ *  findable by title, author or arXiv id — `circuits.source` holds only a link. */
+export interface Paper {
+  id: number;
+  slug: string;
+  title: string;
+  /** In author order — the citation renders "<first author> et al." */
+  authors: string[];
+  year: number | null;
+  /** Bare id, no "arXiv:" prefix or version suffix. */
+  arxiv_id: string | null;
+  doi: string | null;
+  journal_ref: string | null;
+  url: string;
 }
 
 export interface Tool {

--- a/src/types/window.d.ts
+++ b/src/types/window.d.ts
@@ -1,6 +1,6 @@
 declare global {
   interface Window {
-    showCiteToast?: (msg: string, url?: string) => void;
+    showCiteToast?: (msg: string, url?: string, linkLabel?: string) => void;
   }
 }
 

--- a/uv.lock
+++ b/uv.lock
@@ -829,7 +829,7 @@ wheels = [
 
 [[package]]
 name = "qecirc-website"
-version = "0.5.4"
+version = "0.5.5"
 source = { virtual = "." }
 dependencies = [
     { name = "mqt-qecc" },


### PR DESCRIPTION
## What & why

Three ways `/search` could not find a circuit that was sitting right there. They all rewrite `circuit_search`, so they land together — separate PRs would each leave `BM25_WEIGHTS` out of step with the table.

| query | before | after | why it was broken |
| --- | ---: | ---: | --- |
| `reinforcement learning` | 0 | **207** | `source` was a bare URL — no title or author text existed anywhere |
| `forlivesi` | 0 | **370** | same |
| `laflamme` | 0 | **54** | the catalogue stores one name per code |
| `bb codes` | 824 | **28** | `bb` matched nothing, so the OR fallback fired on `codes` |
| `LDPC` | 0 | **28** | `circuit_search.tags` only ever held `taggable_type='circuit'` |
| `topological` | 0 | **98** | same — a code tag, invisible to the index |

### Papers (migration 018)

`data_yaml/papers/` holds title, authors, year and identifiers for the 7 works this library draws from. **Circuits don't declare their paper** — `db:create` matches `source` against each paper's `url`/`arxiv_id`/`doi`, tolerating http/https, trailing slashes, `dx.doi.org`, `/pdf/` vs `/abs/` and version suffixes. Adding a paper file enriches every circuit citing it, with no churn across 833 circuit YAMLs. 724 link; the other 109 are `source: circuit-synth` — a tool, not a work, and not an error. The build and `validate:yaml` both report any link-shaped source with no paper.

A source now renders as `Zen et al. (2024) · arXiv:2402.17761` instead of a raw URL, in rows, detail pages and the cite toast; detail pages emit the paper as a schema.org `ScholarlyArticle` with real authors.

`scripts/add_paper.py` fetches the metadata (`npm run papers:add -- <id|doi|link>`, or `npm run papers:missing` after a bulk import). Author lists are facts about real people that render in JSON-LD, and papers are routinely newer than a model's training data — so this is fetched, never recalled. It refuses to write a record with no authors rather than emit a half-citation.

> **This is the only part of the repo that touches the network**, and it's a maintainer tool whose output is committed — same shape as `annotate_circuits.py`. `db:create` and the site read committed YAML only and build offline. That boundary is now stated next to the "no third-party APIs" principle in CLAUDE.md.

### Aliases (migration 017)

Hand-written `aliases:` on codes and tools, plus `related:` on codes. `related` names a *different, adjacent* code (`toric` → planar surface codes) and `/search` says so rather than silently equating them. `resolveQuery` gains a ladder preferring a flagged `related` match over widening to "any term" — widening `toric code` matches every circuit containing "code" (824/833). Design notes: [`docs/superpowers/plans/2026-07-15-search-aliases.md`](docs/superpowers/plans/2026-07-15-search-aliases.md).

### Code tags (migration 019)

Own `code_tags` column, kept separate from `tags` so a name used at both levels can't double-count its term frequency. This failed *silently*: `search_terms` already indexed code tags, so spelling correction saw `topological` as a real word and left the dead query alone — a typo would have been rescued, a correct word wasn't.

## Ranking — one thing worth reviewing

`paper` is weighted **1.0**, as low as `notes`, which looks wrong. BM25 normalizes term frequency by field length, so a hit in a ~25-token field already outscores the same hit in long `notes` before any weight applies. At 3.0, **all 20 of the top 20 for `fault tolerant` were circuits tagged `non-ft`** — baselines from papers whose *titles* say fault-tolerant — outranking the genuinely FT circuits whose notes say so. At 1.0: none, and no title query loses a hit (weights reorder, they never filter).

`BM25_WEIGHTS` and `STRICT_COLUMNS` were hand-maintained and **both drifted from the table while this branch was being built** — a 7-entry array for 8 columns (silently scoring `paper` as `notes`), and a strict set missing `paper` (reporting an exact author match as a loose `related` fallback). `search-schema.ts` now derives both from `PRAGMA table_info`; a column with no weight throws and names itself. Adding a column is: put it in the migration, give it a named weight. That's the checklist.

## Verification

479/479 `validate:circuits` · 286 pytest · lint · ruff · format · validate:yaml · build · 23/23 smoke — which now asserts a query reaching each of `aliases`, `code_tags` and `paper` still returns circuits, and the `non-ft` ranking guard.

Version bumped 0.5.4 → **0.5.5**, with `pyproject.toml`, `uv.lock`, `package-lock.json` synced. Patch rather than minor: the YAML changes are purely additive (new optional keys, a new directory — existing files still parse), and the migrations drop only the derived `circuit_search` index, not real data.

## Notes for the reviewer

- **`npm run lint` was broken on `main`** before this branch — a nested `.claude/worktrees/feat+search-aliases` gave typescript-eslint two tsconfig roots, failing 168 files. That worktree held the uncommitted aliases work; it's merged here, and the worktree is removed so lint runs again. Its original state is archived on branch `worktree-feat+search-aliases` (commit `1ace6f1`) — safe to delete once this merges.
- Migrations 017→019 each drop and recreate `circuit_search`. FTS5 has no `ADD COLUMN`, and the index is derived data rebuilt on every build, so this is free.

## Checklist

- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `npm run format` and `npm run lint` pass
- [x] `npm run validate:yaml && npm run validate:circuits` pass
- [x] Version bumped — 0.5.4 → 0.5.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
