### PR TITLE
fix(circuit-page): download button producing empty files on detail pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qecirc-website",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qecirc-website",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "license": "MIT",
       "dependencies": {
         "@astrojs/node": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qecirc-website",
   "type": "module",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "license": "MIT",
   "scripts": {
     "dev": "astro dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qecirc-website"
-version = "0.5.5"
+version = "0.5.6"
 description = "QECirc — quantum error correction circuit library"
 license = "MIT"
 requires-python = ">=3.13"

--- a/src/components/CodeBlock.astro
+++ b/src/components/CodeBlock.astro
@@ -124,7 +124,10 @@ const needsRaw = hasCoords || hasDetectors(raw);
     block.querySelectorAll(".download-btn").forEach(function (btn) {
       btn.addEventListener("click", function () {
         const el = btn as HTMLElement;
-        const copyBtn = el.closest(".flex")?.querySelector(".copy-btn") as HTMLElement | null;
+        // Query within the block, not via closest(".flex"): the download button's
+        // own class list contains "flex", so closest() would match the button
+        // itself and find no copy button inside it.
+        const copyBtn = block.querySelector(".copy-btn") as HTMLElement | null;
         const body = copyBtn?.dataset.code || "";
         const name = el.dataset.downloadName || "circuit.stim";
         const blob = new Blob([body], { type: "text/plain" });

--- a/src/components/Layout.astro
+++ b/src/components/Layout.astro
@@ -84,6 +84,8 @@ const sunIconSvg = `<svg class="w-4 h-4 hidden dark:block" viewBox="0 0 24 24" f
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" sizes="any" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <meta name="description" content={description} />
+    {/* Bing Webmaster Tools site verification — keep even after verification succeeds. */}
+    <meta name="msvalidate.01" content="39DDB139B2FACB05C7FB9F807989250F" />
     <link rel="canonical" href={canonicalUrl} />
     <meta property="og:title" content={fullTitle} />
     <meta property="og:description" content={description} />

--- a/uv.lock
+++ b/uv.lock
@@ -829,7 +829,7 @@ wheels = [
 
 [[package]]
 name = "qecirc-website"
-version = "0.5.5"
+version = "0.5.6"
 source = { virtual = "." }
 dependencies = [
     { name = "mqt-qecc" },


### PR DESCRIPTION
## Problem

Downloading a circuit from its **detail page** (`/circuits/[qec_id]`) produced a 0-byte file. Downloading the same circuit from a **code page's** circuit listing worked fine.

## Root cause

The download handler in `CodeBlock.astro` located the circuit body via:

```js
const copyBtn = el.closest(".flex")?.querySelector(".copy-btn");
```

`Element.closest()` starts matching **at the element itself**, and the download button's own class list contains `flex` (`class="download-btn flex items-center gap-1 …"`). So `closest(".flex")` returned the download button itself instead of the shared toolbar container, `.querySelector(".copy-btn")` inside the button found nothing, and the body fell back to `""` — an empty download.

Code-page listings were unaffected because `circuit-bodies-client.ts` holds a direct reference to the copy button when cloning the row template — no DOM traversal.

## Fix

Query the copy button from the enclosing `[data-code-block]` element (already in scope as `block`, contains exactly one copy button) instead of traversing via `closest(".flex")`.

Also bumps the version to 0.5.6 (patch, per the versioning convention).

## Also included

- `feat(seo)`: Bing Webmaster Tools site verification meta tag (`msvalidate.01`), added site-wide via the shared `Layout` head — Bing reads it from the home page. Must stay in place even after verification succeeds.

## Testing

- `npm run lint` and `npm run format:check` pass
- Verified in dev server by instrumenting `URL.createObjectURL`:
  - Detail page `/circuits/163`: blob is now **3809 bytes** with correct filename `108-8-10_circuit-synth-encoding-depth-optimized_G618_2Q568_D35_Q108.stim` (was 0 bytes)
  - Code page `/codes/108-8-10` (regression check): row download still works (2041-byte blob, correct filename)
  - No console errors on either page
- Bing tag verified rendering in `<head>` of `/` in the dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)