### PR TITLE
fix(add-circuit): file a non-CSS circuit under the matched code's slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ the source-of-truth `package.json` version.
 
 ## Unreleased
 
+### Fixed
+
+- **A non-CSS circuit for an existing code is filed under that code's slug.** On a dedup
+  match the CSS path has always used the stored slug; the non-CSS path only used it when
+  nothing else had set one, so `code_slug` — or a slug derived from `code_name` — won
+  instead. A five-qubit-code circuit submitted with
+  `code_name="Five-Qubit Perfect Code"` was written as
+  `five-qubit-perfect-code--<circuit>.yaml` while the code itself lives at
+  `five-qubit-code`; no code YAML was written under that name, because there was no new
+  code, so the circuit referenced an entry that does not exist —
+  `annotate_circuits.py` reported `code '...' not found` and `db:create` rejected it.
+  `code_slug` is documented as naming a _new_ code, and on a match there is no new code
+  to name.
+
 ### Added
 
 - **Search aliases** (`data/migrations/017`). Codes and tools gain optional

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qecirc-website",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qecirc-website",
-      "version": "0.5.6",
+      "version": "0.5.7",
       "license": "MIT",
       "dependencies": {
         "@astrojs/node": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qecirc-website",
   "type": "module",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "license": "MIT",
   "scripts": {
     "dev": "astro dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qecirc-website"
-version = "0.5.6"
+version = "0.5.7"
 description = "QECirc — quantum error correction circuit library"
 license = "MIT"
 requires-python = ">=3.13"

--- a/scripts/add_circuit/compute.py
+++ b/scripts/add_circuit/compute.py
@@ -258,8 +258,17 @@ def compute_code_data_h(
         if dedup.status == "match":
             code_status = "existing"
             existing_perm = dedup.qubit_permutation
-            if not slug:
-                slug = dedup.slug
+            # The stored slug is authoritative, exactly as on the CSS path above.
+            # This used to be `if not slug`, which let `code_slug` — or a slug
+            # derived from `code_name` — win over the code the submission
+            # actually matched: a five-qubit-code circuit passed
+            # `code_name="Five-Qubit Perfect Code"` was written as
+            # `five-qubit-perfect-code--<circuit>.yaml` while the code itself
+            # lives at `five-qubit-code`, so the circuit referenced a code entry
+            # that is never written and `db:create` rejected it. `code_slug` is
+            # documented as naming a *new* code, and on a match there is no new
+            # code to name.
+            slug = dedup.slug
 
     if code_status == "existing":
         # Use the perm from _check_yaml_dedup_h (already normalized to None for

--- a/scripts/tests/test_non_css_ingestion.py
+++ b/scripts/tests/test_non_css_ingestion.py
@@ -354,3 +354,61 @@ class TestAddCircuitH:
         assert any(p.endswith(".yaml") and "five-qubit" in p for p in paths)
         assert any(p.endswith(".stim") for p in paths)
         assert any(p.endswith(".original.yaml") for p in paths)
+
+
+class TestExistingNonCssCodeSlug:
+    """A non-CSS submission that matches a stored code must file under the
+    stored slug.
+
+    It used not to: `code_slug` — or a slug derived from `code_name` — won over
+    the code the submission actually matched, so the circuit was written as
+    `five-qubit-perfect-code--<circuit>.yaml` while the code lives at
+    `five-qubit-code`. No code YAML was written under that name (there was no
+    new code), leaving circuit files that reference an entry which does not
+    exist; `annotate_circuits.py` reported `code '...' not found` and
+    `db:create` rejected them. The CSS path never had this — these tests pin the
+    two paths to the same behaviour.
+    """
+
+    @staticmethod
+    def _five_qubit_h():
+        Hx, Hz = _five_qubit_matrices()
+        return np.hstack([Hx, Hz])
+
+    def _add(self, tmp_path, **kwargs):
+        from scripts.add_circuit import add_circuit
+
+        return add_circuit(
+            circuit="I 0 1 2 3 4",
+            circuit_name="Slug Probe",
+            d=3,
+            H=self._five_qubit_h(),
+            n=5,
+            source="test://example",
+            data_dir="data_yaml",
+            dry_run=True,
+            **kwargs,
+        )
+
+    def test_code_name_does_not_override_the_matched_slug(self, tmp_path):
+        result = self._add(tmp_path, code_name="Five-Qubit Perfect Code")
+        assert result.code_status == "existing"
+        assert result.code_slug == "five-qubit-code"
+
+    def test_code_slug_does_not_override_the_matched_slug(self, tmp_path):
+        """`code_slug` is documented as naming a *new* code, and on a match
+        there is no new code to name."""
+        result = self._add(tmp_path, code_name="Anything", code_slug="5-1-3")
+        assert result.code_status == "existing"
+        assert result.code_slug == "five-qubit-code"
+
+    def test_the_circuit_files_are_named_after_the_code_that_exists(self, tmp_path):
+        from pathlib import Path
+
+        result = self._add(tmp_path, code_name="Five-Qubit Perfect Code")
+        stems = {Path(p).name.split("--")[0] for p in result.files_written if "--" in p}
+        assert stems == {"five-qubit-code"}
+        # and nothing is written for a code that does not exist
+        assert not any(
+            Path(p).name.startswith("five-qubit-perfect-code") for p in result.files_written
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -829,7 +829,7 @@ wheels = [
 
 [[package]]
 name = "qecirc-website"
-version = "0.5.6"
+version = "0.5.7"
 source = { virtual = "." }
 dependencies = [
     { name = "mqt-qecc" },


### PR DESCRIPTION
A non-CSS submission that dedups to an existing code was filed under the wrong slug, producing circuit files that reference a code entry which is never written.

## The bug

Both dedup paths end with the same decision — which slug does this circuit file under? The CSS path takes the stored one unconditionally:

```python
# compute_code_data, CSS path
if dedup.status == "match":
    ...
    # The existing code's stored slug is authoritative. [...]
    slug = dedup.slug
```

The non-CSS path guarded it:

```python
# compute_code_data_h, non-CSS path
if dedup.status == "match":
    ...
    if not slug:            # <-- only when nothing else set one
        slug = dedup.slug
```

`slug` is set earlier from `code_slug or slugify(code_name)`, so it is almost always truthy — and the matched code's slug was discarded.

## What that looked like

Importing a five-qubit-code circuit with `code_name="Five-Qubit Perfect Code"`:

- the code correctly deduped to the stored `five-qubit-code`, so **no code YAML was written** — there was no new code;
- but the circuit was written as `five-qubit-perfect-code--<circuit>.yaml/.stim/…`;
- so the circuit referenced a code entry that does not exist. `annotate_circuits.py` reported `code 'five-qubit-perfect-code' not found` and `db:create` rejected it.

Passing `code_slug` explicitly reproduced the same class of failure — it was used verbatim even when the code matched a different, existing slug.

## The fix

Make the non-CSS path match the CSS path. This restores the **documented** behaviour rather than changing it — `add_circuit`'s own docstring already says:

> `code_slug`: Explicit slug for a *new* code […] **Ignored for existing codes (the stored slug is authoritative).**

On a match there is no new code to name.

## Tests

Three regression tests in `scripts/tests/test_non_css_ingestion.py::TestExistingNonCssCodeSlug`, pinning the two paths to the same behaviour: `code_name` does not override the matched slug, `code_slug` does not either, and the written files are named after the code that actually exists.

**Each was verified to fail without the fix** — reverting the one-line change fails all three, and they pass with it.

## Verification

289 tests, `npm run lint`, `npm run format:check`, `npm run validate:yaml`.

## Related

Found while importing qLDPC circuits (#136), which carries a local workaround — resolving the stored slug with `find_existing_code_h()` before calling `add_circuit`. That workaround can be removed once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)