### PR TITLE
feat(about): link to the repo from the about page and footer

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,7 @@ data/
 .mypy_cache/
 uv.lock
 *.db
+# Local agent worktrees and generated caches. Note this is deliberately not a
+# blanket `.claude/` — the tracked agents/ and commands/ markdown stays formatted.
+.claude/worktrees/
+**/.cache/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qecirc-website",
-  "version": "0.6.0",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qecirc-website",
-      "version": "0.6.0",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
         "@astrojs/node": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qecirc-website",
   "type": "module",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "license": "MIT",
   "scripts": {
     "dev": "astro dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qecirc-website"
-version = "0.6.0"
+version = "0.6.2"
 description = "QECirc — quantum error correction circuit library"
 license = "MIT"
 requires-python = ">=3.13"

--- a/src/components/Layout.astro
+++ b/src/components/Layout.astro
@@ -215,7 +215,7 @@ const sunIconSvg = `<svg class="w-4 h-4 hidden dark:block" viewBox="0 0 24 24" f
           </div>
         </div>
         <div class="mt-2 flex justify-end font-mono text-[11px] text-gray-500 dark:text-gray-400">
-          v{version} · {totalCircuitsLabel} circuits
+          <span>v{version} · {totalCircuitsLabel} circuits · <a href="https://github.com/qecirc/qecirc-website" target="_blank" rel="noopener noreferrer" class="hover:text-gray-600 dark:hover:text-gray-300">Star on GitHub</a></span>
         </div>
       </div>
     </footer>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -68,6 +68,9 @@ const kbdCls =
         height="28"
       />
     </a>
+    <p class="text-gray-600 dark:text-gray-400 mb-6">
+      QECirc is open source. If you find it useful, <a href="https://github.com/qecirc/qecirc-website" class="prose-link" target="_blank" rel="noopener">star the repository on GitHub</a> — it helps others discover the project.
+    </p>
 
     {/* Maintained by hand — the repository's human contributors, excluding bots
         (Claude, Renovate) and the `qecirc` service account, PLUS people who
@@ -90,12 +93,10 @@ const kbdCls =
 
     <h2 class="text-xl font-semibold mb-3">License</h2>
     <p class="text-gray-600 dark:text-gray-400 mb-2">
-      The source code is licensed under the
-      <a href="https://opensource.org/licenses/MIT" class="prose-link" target="_blank" rel="noopener">MIT License</a>.
+      The source code is licensed under the <a href="https://opensource.org/licenses/MIT" class="prose-link" target="_blank" rel="noopener">MIT License</a>.
     </p>
     <p class="text-gray-600 dark:text-gray-400">
-      The circuit data is licensed under
-      <a href="https://creativecommons.org/licenses/by-sa/4.0/" class="prose-link" target="_blank" rel="noopener">CC BY-SA 4.0</a>.
+      The circuit data is licensed under <a href="https://creativecommons.org/licenses/by-sa/4.0/" class="prose-link" target="_blank" rel="noopener">CC BY-SA 4.0</a>.
     </p>
   </div>
 </Layout>

--- a/uv.lock
+++ b/uv.lock
@@ -829,7 +829,7 @@ wheels = [
 
 [[package]]
 name = "qecirc-website"
-version = "0.6.0"
+version = "0.6.2"
 source = { virtual = "." }
 dependencies = [
     { name = "mqt-qecc" },


### PR DESCRIPTION
The header GitHub icon is navigation — it says where the source is, but it can't make an ask. This adds the ask, in two places, without duplicating the icon:

- **About page** — a one-line note at the end of the Development section, after the Unitary Foundation badge.
- **Footer** — a `Star on GitHub` link appended to the version/circuit-count strip, so it's reachable from every page.

### No star count

Showing one means a GitHub API call at build or request time, which the "no external services" rule in `CLAUDE.md` rules out. The repo is also at 9 stars right now, where a number is weaker social proof than no number. If it grows, the better move is to enrich the existing header icon into an icon+count pill rather than add a second element.

### Also in here

- **Two missing spaces on the About page** — `licensed under theMIT License` and `licensed under CC BY-SA 4.0` ran together. Those two were the only spots in the file where the `<a>` began on its own source line, and Astro drops that newline. A scan of every `.astro` file found no other instance.
- **Prettier ignores `.claude/worktrees/` and `**/.cache/`** — a local agent worktree was failing `npm run format:check` on two generated JSON cache files. Deliberately not a blanket `.claude/`, so the tracked `agents/` and `commands/` markdown stays formatted.
- **Version bump to 0.6.2.** `pyproject.toml` goes `0.6.0` → `0.6.2`: #141 bumped `package.json` without it, so the two had drifted. This resyncs them.

### Implementation note

The footer meta line is `flex justify-end`. The link had to be wrapped together with the surrounding text in a single `<span>` — as two separate flex items the whitespace between them collapses and it renders `833 circuits ·Star on GitHub`.

### Verified

Both pages rendered locally against a freshly built DB: light and dark, desktop and 375px mobile (single line, no horizontal overflow), no console errors. `prettier --check .` passes. ESLint is clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)