### PR TITLE
feat(codes): store subsystem codes with their gauge group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ the source-of-truth `package.json` version.
 
 ## Unreleased
 
+### Added
+
+- **Subsystem codes can be stored** (`data/migrations/020`). A subsystem code is described
+  by two groups, not one: the **gauge** group a decoder may measure, and the **stabilizer**
+  group — its centre — whose outcomes are deterministic. The difference between them is
+  real qubits, `(rank(G) − rank(S)) / 2` of them, which carry no information and are not
+  corrected.
+
+  The library read k off a single check matrix as `n − rank(h)`, which counts those gauge
+  qubits as logical ones: Bacon-Shor [[9,1,3]] would have been stored as **[[9,5,3]]** and
+  SHYPS [[49,9,4]] as **[[49,25,4]]**, so both were excluded rather than recorded wrongly.
+  Codes now carry an optional `gauge` matrix and `gauge_qubits` count, and
+
+      k = n − rank(S) − (rank(G) − rank(S)) / 2
+
+  which for a stabilizer code has a zero gauge term and is the formula already in use — one
+  implementation, not two.
+  - **`h` still means the stabilizer group**, for every code. Validators, dedup, the CSS
+    split and the matrices view are untouched: a circuit is checked against the operators
+    that are actually deterministic, which is what those checks want. Stabilizer codes gain
+    no fields at all.
+  - **Logicals are the bare ones.** `_compute_symplectic_logicals` takes the kernel of the
+    gauge group rather than of `h` when there is one, so they commute with everything a
+    decoder may measure, while still quotienting by the stabilizers.
+  - **Identity is the gauge group's.** Two subsystem codes can share a stabilizer group and
+    differ in gauge group, so `canonical_hash` is computed over the gauge group when there
+    is one — it determines the stabilizer group as its centre, so it is the more
+    informative of the two.
+  - Tagged `subsystem`, so a reader who sees [[9,1,3]] over a rank-4 `h` is told why rather
+    than left to think it a bug.
+
+  Verified against qLDPC's own `get_code_params()` on Bacon-Shor(3), Bacon-Shor(4),
+  SHYPS(3) and Steane. Importing the codes themselves is a follow-up.
+
 ### Changed
 
 - **Submitted check matrices are stored once instead of once per circuit.** They are a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ URL alone. Both the build and `validate:yaml` report such sources.
 ```
 codes
   id, name, slug, n, k, d, zoo_url, aliases, related,
-  h, logical, canonical_hash, created_at
+  h, logical, gauge, gauge_qubits, canonical_hash, created_at
   -- n, k, d: code parameters [[n,k,d]] for direct querying/sorting
   -- zoo_url: optional link to QEC Zoo
   -- aliases: other names for THIS code, space-joined (e.g. "Laflamme code")
@@ -52,7 +52,14 @@ codes
   -- h: symplectic stabilizer matrix, shape (n−k) × 2n, JSON-encoded
   -- logical: symplectic logical operators, shape 2k × 2n, JSON-encoded
   -- For CSS codes, the Hx/Hz/Lx/Lz view is derived in the UI via splitHToCss
-  -- canonical_hash: SHA256 of canonical form for dedup (indexed)
+  -- gauge: subsystem codes only — the gauge group a decoder may measure,
+  --   symplectic, JSON-encoded. NULL when it coincides with `h`.
+  -- gauge_qubits: (rank(gauge) - rank(h)) / 2. Qubits that carry no
+  --   information and are not corrected, so k = n - rank(h) - gauge_qubits.
+  --   Reading k off `h` alone stored Bacon-Shor [[9,1,3]] as [[9,5,3]].
+  -- canonical_hash: SHA256 of canonical form for dedup (indexed) — of the
+  --   gauge group when there is one, since two subsystem codes can share a
+  --   stabilizer group and differ in what a decoder may measure
 
 tools
   id, name, slug, description, homepage_url, github_url, paper_urls, aliases, created_at

--- a/data/migrations/020_code_gauge.sql
+++ b/data/migrations/020_code_gauge.sql
@@ -1,0 +1,15 @@
+-- Subsystem codes: the gauge group, and the qubit count it implies.
+--
+-- `codes.h` keeps meaning the *stabilizer* group for every code, so validators,
+-- dedup, the CSS split and the matrices view are untouched. A subsystem code
+-- additionally has a gauge group — the operators a decoder may measure, whose
+-- outcomes are not all deterministic — and the difference between the two is
+-- `gauge_qubits` real qubits that carry no information and are not corrected.
+--
+-- Without this the library read k off the stabilizer group alone, as
+-- n - rank(h), which counts gauge qubits as logical ones: Bacon-Shor [[9,1,3]]
+-- came out [[9,5,3]] and SHYPS [[49,9,4]] came out [[49,25,4]]. Both columns are
+-- NULL for a stabilizer code, where the two groups coincide.
+
+ALTER TABLE codes ADD COLUMN gauge TEXT;
+ALTER TABLE codes ADD COLUMN gauge_qubits INTEGER;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qecirc-website",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qecirc-website",
-      "version": "0.6.2",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@astrojs/node": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qecirc-website",
   "type": "module",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "license": "MIT",
   "scripts": {
     "dev": "astro dev",
@@ -42,5 +42,8 @@
   },
   "engines": {
     "node": ">=24.0.0"
+  },
+  "allowScripts": {
+    "better-sqlite3@12.11.1": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,8 +42,5 @@
   },
   "engines": {
     "node": ">=24.0.0"
-  },
-  "allowScripts": {
-    "better-sqlite3@12.11.1": true
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qecirc-website"
-version = "0.6.2"
+version = "0.7.0"
 description = "QECirc — quantum error correction circuit library"
 license = "MIT"
 requires-python = ">=3.13"

--- a/scripts/add_circuit/compute.py
+++ b/scripts/add_circuit/compute.py
@@ -272,7 +272,12 @@ def compute_code_data_h(
     logical = _compute_symplectic_logicals(canon_H, n, k, gauge=gauge_canon)
     orig_logical = _compute_symplectic_logicals(H, n, k, gauge=gauge_to_store)
 
-    params_with_d = CodeParams(n=n, k=k, is_css=False, d=d)
+    # CSS-ness is a property of the stabilizer group, and a subsystem code can
+    # have a CSS one — Bacon-Shor does. It only reaches this path because k
+    # cannot be derived the CSS way, so the tag would otherwise be lost and the
+    # code would not be findable as CSS while the page rendered its X/Z split.
+    is_css = gauge_to_store is not None and split_h_to_css(H, n) is not None
+    params_with_d = CodeParams(n=n, k=k, is_css=is_css, d=d)
     tags = suggest_code_tags(params_with_d)
     if gauge_to_store is not None:
         # Worth surfacing: a reader who sees [[9,1,3]] over a rank-4 `h` should
@@ -336,7 +341,7 @@ def compute_code_data_h(
             "zoo_url": zoo_url or None,
             "h": canon_H.tolist(),
             "logical": logical.tolist(),
-            "is_css": False,
+            "is_css": is_css,
             "gauge": None if gauge_canon is None else gauge_canon.tolist(),
             "gauge_qubits": gauge_qubit_count or None,
             "canonical_hash": c_hash,

--- a/scripts/add_circuit/compute.py
+++ b/scripts/add_circuit/compute.py
@@ -8,6 +8,7 @@ from typing import Literal, NamedTuple, Optional
 
 import numpy as np
 
+from . import subsystem
 from .code_identify import (
     build_symplectic_h,
     build_symplectic_logical,
@@ -204,6 +205,7 @@ def compute_code_data_h(
     data_dir: Optional[str] = None,
     code_slug: str = "",
     code_tags: Optional[list[str]] = None,
+    gauge: Optional[np.ndarray] = None,
 ) -> dict:
     """
     Compute all code-level data from a single symplectic stabilizer matrix H.
@@ -219,10 +221,12 @@ def compute_code_data_h(
     if H.shape[1] != 2 * n:
         raise ValueError(f"Expected H with 2n={2 * n} columns, got {H.shape[1]}")
 
-    # Try CSS detection first; if the row space is CSS-decomposable, route
-    # through the CSS path so we get the CSS tag and the canonical-form h.
-    css_split = split_h_to_css(H, n)
-    if css_split is not None:
+    # A subsystem code takes the symplectic path whatever its stabilizer group
+    # looks like. The CSS route below re-derives k as n - rank, which is the
+    # very thing the gauge group is here to correct — Bacon-Shor's stabilizer
+    # group *is* CSS, so it would take that route and store [[9,5,3]].
+    gauge_k, gauge_qubit_count, gauge_to_store = subsystem.describe(gauge, H, n)
+    if css_split := (None if gauge_to_store is not None else split_h_to_css(H, n)):
         Hx, Hz = css_split
         result = compute_code_data(
             Hx,
@@ -245,16 +249,35 @@ def compute_code_data_h(
         result["original_matrices"]["h"] = H.tolist()
         return result
 
-    # Non-CSS path
-    k = n - gf2_rank(H)
+    # Non-CSS path — and the subsystem path, which is the same one.
+    k = gauge_k
     canon_H, qubit_perm = canonical_form_h(H, n)
-    c_hash = canonical_hash_h(H, n)
+    # Identity is the *gauge* group's when there is one: two subsystem codes can
+    # share a stabilizer group and differ in what a decoder may measure, and
+    # hashing only the centre would merge them. The gauge group determines the
+    # stabilizer group as its centre, so it is the more informative of the two.
+    c_hash = canonical_hash_h(gauge_to_store if gauge_to_store is not None else H, n)
 
-    logical = _compute_symplectic_logicals(canon_H, n, k)
-    orig_logical = _compute_symplectic_logicals(H, n, k)
+    # The canonical form permutes qubits, so the gauge group has to follow it —
+    # logicals that commute with the gauge group in one labelling do not in
+    # another. `qubit_perm` maps canonical column -> original column, which is
+    # exactly the gather these two halves need.
+    gauge_canon = (
+        None
+        if gauge_to_store is None
+        else np.hstack(
+            [gauge_to_store[:, list(qubit_perm)], gauge_to_store[:, [q + n for q in qubit_perm]]]
+        )
+    )
+    logical = _compute_symplectic_logicals(canon_H, n, k, gauge=gauge_canon)
+    orig_logical = _compute_symplectic_logicals(H, n, k, gauge=gauge_to_store)
 
     params_with_d = CodeParams(n=n, k=k, is_css=False, d=d)
     tags = suggest_code_tags(params_with_d)
+    if gauge_to_store is not None:
+        # Worth surfacing: a reader who sees [[9,1,3]] over a rank-4 `h` should
+        # be told why the two do not line up, not left to think it a bug.
+        tags.append(TagEntry(name="subsystem", status="derived"))
     # Caller-supplied family tags (only CSS/self-dual are auto-derived).
     tags += [TagEntry(name=name, status="provided") for name in code_tags or []]
     seen = set()
@@ -314,6 +337,8 @@ def compute_code_data_h(
             "h": canon_H.tolist(),
             "logical": logical.tolist(),
             "is_css": False,
+            "gauge": None if gauge_canon is None else gauge_canon.tolist(),
+            "gauge_qubits": gauge_qubit_count or None,
             "canonical_hash": c_hash,
             "tags": [{"name": t.name, "status": t.status} for t in tags],
         },
@@ -401,7 +426,11 @@ def _reduce_logical_weight(L: np.ndarray, H: np.ndarray, n: int) -> np.ndarray:
 
 
 def _compute_symplectic_logicals(
-    H: np.ndarray, n: int, k: int, minimize: bool = True
+    H: np.ndarray,
+    n: int,
+    k: int,
+    minimize: bool = True,
+    gauge: Optional[np.ndarray] = None,
 ) -> np.ndarray:
     """Compute logical operators for any stabilizer code in symplectic form.
 
@@ -419,6 +448,12 @@ def _compute_symplectic_logicals(
     representative — a brute-force over ``2^m`` stabilizer combinations that is
     purely cosmetic. Pass ``minimize=False`` when any valid logical suffices
     (adding a circuit to an existing code, or a logical expectation) to skip it.
+
+    ``gauge`` makes these the **bare** logicals of a subsystem code: step 1 takes
+    the kernel of the *gauge* group rather than of ``H``, so the result commutes
+    with everything a decoder may measure, while step 2 still quotients by the
+    stabilizers. For a stabilizer code the two groups coincide and passing it
+    changes nothing, which is why there is one implementation and not two.
     """
     if k == 0:
         return np.zeros((0, 2 * n), dtype=int)
@@ -426,9 +461,11 @@ def _compute_symplectic_logicals(
     if H.shape[1] != 2 * n:
         raise ValueError(f"Expected H with 2n={2 * n} columns, got {H.shape[1]}")
 
-    # H @ Lambda swaps the X and Z halves of each row.
-    H_swap = np.hstack([H[:, n:], H[:, :n]])
-    ker = gf2_nullspace(H_swap)
+    # H @ Lambda swaps the X and Z halves of each row. For a subsystem code the
+    # operators that must be commuted with are the gauge group's, not H's.
+    centralize = H if gauge is None else np.asarray(gauge, dtype=int) % 2
+    swapped = np.hstack([centralize[:, n:], centralize[:, :n]])
+    ker = gf2_nullspace(swapped)
     im = gf2_row_basis(H)
 
     stacked = np.vstack([im, ker]).astype(int) % 2

--- a/scripts/add_circuit/subsystem.py
+++ b/scripts/add_circuit/subsystem.py
@@ -1,0 +1,108 @@
+"""Subsystem codes: the gauge group, and the k it implies.
+
+A stabilizer code is described by one group. A **subsystem code** is described by
+two: the *gauge* group `G` a decoder may measure, and the *stabilizer* group
+`S` — the centre of `G` — whose outcomes are actually deterministic. The
+difference between them is real qubits: `(rank(G) - rank(S)) / 2` **gauge
+qubits**, which carry no information and are not corrected.
+
+That is the whole reason this file exists. The library stores one check matrix
+per code and read `k` off it as `n - rank(h)`, which is right only when the two
+groups coincide. Storing Bacon-Shor [[9,1,3]] that way gives [[9,5,3]] — the four
+gauge qubits counted as logical ones — so the codes were excluded rather than
+recorded wrongly. With the gauge group in hand:
+
+    k = n - rank(S) - (rank(G) - rank(S)) / 2
+
+and for a stabilizer code `G == S`, the gauge term is zero and the formula is the
+one the library already used. There is no separate code path.
+
+**What is stored where.** `h` keeps meaning the stabilizer group, for every code,
+so validators, dedup, the CSS split and the matrices view are untouched — a
+circuit is checked against the operators that are deterministic, which is what
+those checks want. The gauge group goes in its own field, present only when it
+differs from `h`.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+
+from .code_identify import gf2_rank
+
+
+def symplectic_product(a: np.ndarray, b: np.ndarray, n: int) -> np.ndarray:
+    """`a_i` against `b_j`: 0 where they commute, 1 where they anticommute."""
+    a = np.asarray(a, dtype=int) % 2
+    b = np.asarray(b, dtype=int) % 2
+    return (a[:, :n] @ b[:, n:].T + a[:, n:] @ b[:, :n].T) % 2
+
+
+def gauge_qubits(gauge: np.ndarray, stabilizers: np.ndarray, n: int) -> int:
+    """How many gauge qubits `G` carries over `S`.
+
+    Raises when the difference is odd, which no valid pair can produce: gauge
+    qubits come in anticommuting pairs, so `rank(G) - rank(S)` is always even.
+    An odd value means the two matrices do not describe the same code, and
+    guessing a `k` from them would be worse than refusing.
+    """
+    gap = gf2_rank(gauge) - gf2_rank(stabilizers)
+    if gap < 0:
+        raise ValueError("the stabilizer group cannot outrank the gauge group")
+    if gap % 2:
+        raise ValueError(
+            f"rank(gauge) - rank(stabilizers) = {gap} is odd; gauge qubits come in "
+            "anticommuting pairs, so these two matrices are not one code"
+        )
+    del n  # signature kept uniform with the rest of this module
+    return gap // 2
+
+
+def logical_qubits(gauge: np.ndarray, stabilizers: np.ndarray, n: int) -> int:
+    """`k` for a code given both groups. Reduces to `n - rank(h)` when equal."""
+    return n - gf2_rank(stabilizers) - gauge_qubits(gauge, stabilizers, n)
+
+
+def check_stabilizers_are_central(gauge: np.ndarray, stabilizers: np.ndarray, n: int) -> None:
+    """Refuse a pair where `S` is not inside the centre of `G`.
+
+    The centre is what makes `S`'s outcomes deterministic; a "stabilizer" that
+    anticommutes with a gauge operator is not one, and every number derived here
+    would be meaningless. Cheap to check and worth checking, because the two
+    matrices arrive from a caller that could have paired them up wrongly.
+    """
+    stabilizers = np.atleast_2d(np.asarray(stabilizers, dtype=int) % 2)
+    if not stabilizers.size:
+        return
+    if symplectic_product(stabilizers, np.asarray(gauge, dtype=int) % 2, n).any():
+        raise ValueError(
+            "a stabilizer anticommutes with a gauge operator, so the stabilizer "
+            "group is not central in the gauge group"
+        )
+
+
+def describe(
+    gauge: Optional[np.ndarray], stabilizers: np.ndarray, n: int
+) -> tuple[int, int, Optional[np.ndarray]]:
+    """`(k, gauge_qubit_count, gauge_to_store)` for a code.
+
+    `gauge` may be None, or equal to the stabilizer group; either way this is a
+    stabilizer code, the count is zero and nothing extra is stored.
+    """
+    stabilizers = np.asarray(stabilizers, dtype=int) % 2
+    if gauge is None:
+        return n - gf2_rank(stabilizers), 0, None
+
+    gauge = np.asarray(gauge, dtype=int) % 2
+    if gauge.shape[1] != stabilizers.shape[1]:
+        raise ValueError(
+            f"gauge group is {gauge.shape[1]} columns and the stabilizer group "
+            f"{stabilizers.shape[1]}; both must be 2n = {2 * n}"
+        )
+    check_stabilizers_are_central(gauge, stabilizers, n)
+    count = gauge_qubits(gauge, stabilizers, n)
+    if count == 0:
+        return n - gf2_rank(stabilizers), 0, None
+    return n - gf2_rank(stabilizers) - count, count, gauge

--- a/scripts/add_circuit/yaml_helpers.py
+++ b/scripts/add_circuit/yaml_helpers.py
@@ -39,7 +39,10 @@ def build_code_yaml(code):
     if code.get("canonical_hash"):
         data["canonical_hash"] = code["canonical_hash"]
 
-    for field in ("h", "logical"):
+    if code.get("gauge_qubits"):
+        data["gauge_qubits"] = code["gauge_qubits"]
+
+    for field in ("h", "logical", "gauge"):
         if code.get(field) is not None:
             data[field] = _encoded(code[field])
 
@@ -153,14 +156,14 @@ def _convert_matrices(data):
     """Convert matrix fields (lists of lists) to flow-style representation."""
     result = {}
     for key, value in data.items():
-        if key in ("h", "logical") and isinstance(value, dict):
+        if key in ("h", "logical", "gauge") and isinstance(value, dict):
             # Sparse form: one flow-style list of column indices per row.
             result[key] = {
                 "rows": value["rows"],
                 "cols": value["cols"],
                 "nonzero": [_FlowList(indices) for indices in value["nonzero"]],
             }
-        elif key in ("h", "logical", "tags") and isinstance(value, list):
+        elif key in ("h", "logical", "gauge", "tags") and isinstance(value, list):
             if key == "tags":
                 result[key] = _FlowList(value)
             else:

--- a/scripts/db/create_database.mjs
+++ b/scripts/db/create_database.mjs
@@ -40,8 +40,8 @@ const stmts = {
     INSERT INTO papers (slug, title, authors, year, arxiv_id, doi, journal_ref, url)
     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`),
   insertCode: db.prepare(`
-    INSERT INTO codes (name, slug, n, k, d, zoo_url, aliases, related, h, logical, canonical_hash)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`),
+    INSERT INTO codes (name, slug, n, k, d, zoo_url, aliases, related, h, logical, gauge, gauge_qubits, canonical_hash)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`),
   insertCircuit: db.prepare(`
     INSERT INTO circuits (qec_id, code_id, name, slug, notes, source, gate_count, two_qubit_gate_count, depth, qubit_count, weight, crumble_url, crumble_url_annotated, quirk_url, tool_id, paper_id)
     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`),
@@ -227,6 +227,10 @@ try {
         joinAliases(data.related),
         data.h == null ? null : JSON.stringify(decodeMatrix(data.h)),
         data.logical == null ? null : JSON.stringify(decodeMatrix(data.logical)),
+        // Present only for a subsystem code, where the gauge group is bigger
+        // than the stabilizer group in `h` and is what makes its k make sense.
+        data.gauge == null ? null : JSON.stringify(decodeMatrix(data.gauge)),
+        data.gauge_qubits ?? null,
         data.canonical_hash || null,
       );
       codeSlugToId.set(slug, Number(lastInsertRowid));

--- a/scripts/tests/test_subsystem.py
+++ b/scripts/tests/test_subsystem.py
@@ -1,0 +1,181 @@
+"""Tests for the gauge-group arithmetic behind subsystem codes."""
+
+import numpy as np
+import pytest
+
+from scripts.add_circuit.code_identify import gf2_rank
+from scripts.add_circuit.subsystem import (
+    check_stabilizers_are_central,
+    describe,
+    gauge_qubits,
+    logical_qubits,
+)
+
+# Bacon-Shor [[9,1,3]] on a 3x3 grid, built here rather than imported so the test
+# does not need qLDPC. The gauge group is the weight-2 XX pairs in each row and
+# ZZ pairs in each column; the stabilizer group is the pairs of adjacent full
+# rows/columns. Four gauge qubits sit between them, which is exactly what made
+# this code unstorable: n - rank(S) = 5, not 1.
+#
+# It spans different groups from `qldpc.codes.BaconShorCode(3)` — a different
+# qubit convention — but `describe` gives (k=1, 4 gauge qubits) for both, which
+# is what is under test.
+_ROWS = [[0, 1, 2], [3, 4, 5], [6, 7, 8]]
+_COLS = [[0, 3, 6], [1, 4, 7], [2, 5, 8]]
+
+
+def _op(x_support, z_support, n=9):
+    row = np.zeros(2 * n, dtype=int)
+    for q in x_support:
+        row[q] = 1
+    for q in z_support:
+        row[n + q] = 1
+    return row
+
+
+def _bacon_shor():
+    gauge = []
+    for row in _ROWS:  # XX on horizontally adjacent pairs
+        for a, b in zip(row, row[1:]):
+            gauge.append(_op([a, b], []))
+    for col in _COLS:  # ZZ on vertically adjacent pairs
+        for a, b in zip(col, col[1:]):
+            gauge.append(_op([], [a, b]))
+    stabilizers = []
+    # The X gauge operators run along rows, so their products that commute with
+    # everything span two adjacent *columns* — and the Z ones the other way.
+    # Getting this pair the wrong way round gives a set that anticommutes with
+    # the gauge group, which `check_stabilizers_are_central` catches.
+    for a, b in zip(_COLS, _COLS[1:]):  # X on two adjacent columns
+        stabilizers.append(_op(a + b, []))
+    for a, b in zip(_ROWS, _ROWS[1:]):  # Z on two adjacent rows
+        stabilizers.append(_op([], a + b))
+    return np.array(gauge), np.array(stabilizers)
+
+
+STEANE_H = np.array(
+    [
+        [0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0],
+        [0, 1, 1, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0],
+        [1, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1],
+        [0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 1, 1],
+        [0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 1],
+    ]
+)
+
+
+class TestBaconShor:
+    def test_k_is_one_not_five(self):
+        """The bug this exists to fix: counting gauge qubits as logical ones
+        stored [[9,1,3]] as [[9,5,3]]."""
+        gauge, stabilizers = _bacon_shor()
+        assert logical_qubits(gauge, stabilizers, 9) == 1
+        assert 9 - gf2_rank(stabilizers) == 5  # what the old formula gave
+
+    def test_four_gauge_qubits(self):
+        gauge, stabilizers = _bacon_shor()
+        assert gauge_qubits(gauge, stabilizers, 9) == 4
+
+    def test_the_stabilizers_are_central(self):
+        gauge, stabilizers = _bacon_shor()
+        check_stabilizers_are_central(gauge, stabilizers, 9)  # does not raise
+
+    def test_describe_reports_the_gauge_group_for_storage(self):
+        gauge, stabilizers = _bacon_shor()
+        k, count, to_store = describe(gauge, stabilizers, 9)
+        assert (k, count) == (1, 4)
+        assert to_store is not None and to_store.shape == gauge.shape
+
+
+class TestStabilizerCodesAreUnaffected:
+    """`G == S` must give exactly the number the library computed before, by the
+    same formula rather than a special case."""
+
+    def test_no_gauge_group_at_all(self):
+        k, count, to_store = describe(None, STEANE_H, 7)
+        assert (k, count, to_store) == (1, 0, None)
+
+    def test_a_gauge_group_equal_to_the_stabilizers(self):
+        k, count, to_store = describe(STEANE_H, STEANE_H, 7)
+        assert (k, count) == (1, 0)
+        assert to_store is None, "nothing extra to store when the groups coincide"
+
+    def test_a_redundant_generating_set_is_still_the_same_code(self):
+        """Rank, not row count — a repeated generator adds no gauge qubit."""
+        redundant = np.vstack([STEANE_H, STEANE_H[0]])
+        assert describe(redundant, STEANE_H, 7)[:2] == (1, 0)
+
+
+class TestRefusals:
+    def test_a_non_central_stabilizer_is_refused(self):
+        """X0 and Z0 anticommute, so calling Z0 a stabilizer of a gauge group
+        containing X0 is incoherent — better to refuse than to derive a k."""
+        gauge = np.array([_op([0], [])])
+        stabilizers = np.array([_op([], [0])])
+        with pytest.raises(ValueError, match="not central"):
+            check_stabilizers_are_central(gauge, stabilizers, 9)
+
+    def test_an_odd_rank_gap_is_refused(self):
+        """Gauge qubits come in anticommuting pairs, so the gap is always even.
+        An odd one means the two matrices are not one code."""
+        gauge = np.array([_op([0], [])])  # rank 1 over an empty stabilizer group
+        stabilizers = np.zeros((0, 18), dtype=int)
+        with pytest.raises(ValueError, match="odd"):
+            gauge_qubits(gauge, stabilizers, 9)
+
+    def test_a_stabilizer_group_outranking_the_gauge_group_is_refused(self):
+        with pytest.raises(ValueError, match="cannot outrank"):
+            gauge_qubits(np.array([_op([0, 1], [])]), _bacon_shor()[1], 9)
+
+    def test_mismatched_widths_are_refused(self):
+        with pytest.raises(ValueError, match="columns"):
+            describe(np.zeros((2, 10), dtype=int), STEANE_H, 7)
+
+
+class TestItReachesStorage:
+    """The arithmetic is only useful if it survives into the stored YAML."""
+
+    def _computed(self):
+        from scripts.add_circuit.compute import compute_code_data_h
+
+        gauge, stabilizers = _bacon_shor()
+        return compute_code_data_h(stabilizers, 9, 3, code_name="Bacon-Shor", gauge=gauge)
+
+    def test_the_stored_parameters_are_the_code_s_own(self):
+        code = self._computed()["code"]
+        assert (code["n"], code["k"], code["d"]) == (9, 1, 3)
+        assert code["gauge_qubits"] == 4
+
+    def test_the_gauge_group_is_stored_and_the_stabilizers_stay_in_h(self):
+        code = self._computed()["code"]
+        assert code["gauge"] is not None
+        assert gf2_rank(np.array(code["h"])) == 4, "h is still the stabilizer group"
+        assert gf2_rank(np.array(code["gauge"])) == 12
+
+    def test_it_is_tagged_so_the_page_can_explain_itself(self):
+        code = self._computed()["code"]
+        assert "subsystem" in [t["name"] for t in code["tags"]]
+
+    def test_the_yaml_carries_both_matrices(self):
+        from scripts.add_circuit.yaml_helpers import build_code_yaml, dump_yaml, load_yaml
+
+        doc = load_yaml(dump_yaml(build_code_yaml(self._computed()["code"])))
+        assert doc["k"] == 1 and doc["gauge_qubits"] == 4
+        assert doc["h"] and doc["gauge"]
+
+    def test_a_stabilizer_code_gains_no_new_fields(self):
+        """The change has to be invisible to the 38 codes already stored."""
+        from scripts.add_circuit.compute import compute_code_data_h
+        from scripts.add_circuit.yaml_helpers import build_code_yaml
+
+        five_qubit = np.array(
+            [
+                [1, 0, 0, 1, 0, 0, 1, 1, 0, 0],
+                [0, 1, 0, 0, 1, 0, 0, 1, 1, 0],
+                [1, 0, 1, 0, 0, 0, 0, 0, 1, 1],
+                [0, 1, 0, 1, 0, 1, 0, 0, 0, 1],
+            ]
+        )
+        doc = build_code_yaml(compute_code_data_h(five_qubit, 5, 3)["code"])
+        assert "gauge" not in doc and "gauge_qubits" not in doc

--- a/scripts/tests/test_subsystem.py
+++ b/scripts/tests/test_subsystem.py
@@ -179,3 +179,15 @@ class TestItReachesStorage:
         )
         doc = build_code_yaml(compute_code_data_h(five_qubit, 5, 3)["code"])
         assert "gauge" not in doc and "gauge_qubits" not in doc
+
+    def test_a_css_subsystem_code_is_still_tagged_css(self):
+        """Bacon-Shor's stabilizer group is CSS; it takes the symplectic path
+        only because k cannot be derived the CSS way. Losing the tag would hide
+        it from a CSS search while its page rendered an X/Z split anyway."""
+        from scripts.add_circuit.code_identify import split_h_to_css
+
+        _, stabilizers = _bacon_shor()
+        assert split_h_to_css(stabilizers, 9) is not None, "fixture must be CSS"
+        code = self._computed()["code"]
+        assert code["is_css"] is True
+        assert "CSS" in [t["name"] for t in code["tags"]]

--- a/scripts/validate-yaml.mjs
+++ b/scripts/validate-yaml.mjs
@@ -27,6 +27,8 @@ const SCHEMAS = {
       related: "tags",
       h: "matrix",
       logical: "matrix",
+      gauge: "matrix",
+      gauge_qubits: "number",
       tags: "tags",
     },
   },

--- a/uv.lock
+++ b/uv.lock
@@ -829,7 +829,7 @@ wheels = [
 
 [[package]]
 name = "qecirc-website"
-version = "0.6.2"
+version = "0.7.0"
 source = { virtual = "." }
 dependencies = [
     { name = "mqt-qecc" },


### PR DESCRIPTION
A subsystem code is described by **two** groups, not one: the **gauge** group a decoder may measure, and the **stabilizer** group — its centre — whose outcomes are actually deterministic. Between them sit real qubits: `(rank(G) − rank(S)) / 2` of them, which carry no information and are not corrected.

The library read `k` off a single check matrix as `n − rank(h)`, which counts those as logical qubits. Bacon-Shor [[9,1,3]] would have stored as **[[9,5,3]]** and SHYPS [[49,9,4]] as **[[49,25,4]]** — so #136 excluded both rather than record them wrongly. This is what that exclusion was waiting on.

```
k = n − rank(S) − (rank(G) − rank(S)) / 2
```

For a stabilizer code the gauge term is zero and this *is* the formula already in use, so there is one implementation and not a second path.

## What is stored where

`h` keeps meaning the **stabilizer group**, for every code. That is the load-bearing decision: validators, dedup, the CSS split and the matrices view are untouched, because a circuit is checked against the operators that are deterministic — which is what those checks want. A stabilizer code gains no fields at all.

The gauge group goes in a new optional `gauge` matrix alongside a `gauge_qubits` count (`data/migrations/020`), present only when the two groups differ.

## Three things a reviewer should look at

**Logicals are the bare ones.** `_compute_symplectic_logicals` now takes the kernel of the *gauge* group rather than of `h` when one is given, so the result commutes with everything a decoder may measure, while step 2 still quotients by the stabilizers. Same routine, one branch — for a stabilizer code the two groups coincide and nothing changes. Checked directly: the logicals commute with the gauge group and pair up symplectically for both codes.

**Identity is the gauge group's.** Two subsystem codes can share a stabilizer group and differ in what a decoder may measure, so hashing only the centre would merge them. `canonical_hash` is computed over the gauge group when there is one; it determines the stabilizer group as its centre, so it is the more informative of the two.

**The canonical form permutes qubits, so the gauge group follows it.** Logicals that commute with the gauge group in one labelling do not in another, so the gauge matrix is gathered through the same `qubit_perm` before the canonical logicals are derived.

## It refuses rather than guesses

Given a pair it cannot make sense of, this raises instead of deriving a number: a "stabilizer" that anticommutes with a gauge operator (then it is not central, and every number here is meaningless), an odd `rank(G) − rank(S)` (gauge qubits come in anticommuting pairs, so the gap is always even — an odd one means the two matrices are not one code), or mismatched widths.

## Verification

16 new tests in `scripts/tests/test_subsystem.py`, plus the arithmetic checked against qLDPC's own `get_code_params()`:

| code | qLDPC | this branch | before |
| --- | --- | --- | --- |
| Bacon-Shor(3) | (9, 1, 3) | **[[9,1,3]]** | [[9,5,3]] |
| Bacon-Shor(4) | (16, 1, 4) | **[[16,1,4]]** | — |
| SHYPS(3) | (49, 9, 4) | **[[49,9,4]]** | [[49,25,4]] |
| Steane | (7, 1, 3) | [[7,1,3]] | [[7,1,3]] — unchanged |

337 tests, `npm run lint`, `npm run format:check`, `npm run validate:yaml`, `npm run db:migrate`, `npm run db:create`. The 38 stored codes are byte-identical: no existing code writes either new field.

## Not in this PR

Importing Bacon-Shor and SHYPS themselves — that belongs on the qLDPC branch (#136), which can drop its exclusion once this lands. Rendering the gauge group on the code page is a follow-up too; for now the `subsystem` tag is what tells a reader why [[9,1,3]] sits over a rank-4 `h`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
