### PR TITLE
feat(circuits): support syndrome-extraction circuits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ the source-of-truth `package.json` version.
 
 ### Added
 
+- **Syndrome-extraction circuits are a supported kind.** The pipeline could describe an
+  encoder and a state prep; a round of syndrome extraction fitted neither, and there was
+  nothing to check one against.
+  - **`validate_syndrome_extraction_h`** (`scripts/add_circuit/circuit_validate.py`) — a
+    round must measure exactly the stabilizer group and leave the encoded state, logicals
+    included, alone. It cannot be a codespace test the way the prep and encoder checks
+    are: a round acts on an already-encoded state, so there is nothing to simulate it on.
+    It is a **stabilizer-flow** check instead, and the ancilla-to-check correspondence is
+    derived rather than assumed.
+  - **`build_se_round`** (`scripts/add_circuit/syndrome_extraction.py`) — ticks of
+    (data, ancilla, basis) into one canonical round, refusing a tick that reuses a qubit
+    or an ancilla asked to carry both bases.
+  - **`round_check_matrix`** — which operator each measurement reads, which is what
+    placing detectors needs. Deliberately narrow: no map is better than a wrong one, and
+    nothing in validation depends on it.
+  - **A round's `stim-annotated` body is the memory experiment it belongs to** — reset the
+    data, `REPEAT d` of the round, terminal readout, detectors, observable. Unlike a prep
+    or an encoder, a round is not reset-free and has no tableau, so none of the derive/fit
+    machinery may be pointed at it.
+  - `schedule:` and `decoder:` join the `method` tag category. They pair up: a schedule
+    found by search is co-designed with the decoder it was scored against, so two rounds
+    for one code can differ only by `decoder:`.
+  - **`scripts/add_circuit/find_sigma.py`** — the codeword-based permutation matcher,
+    for codes that match a stored one on every cheap invariant but defeat
+    `find_code_permutation`'s budget. Written for the asyndrome import; three importers
+    need it, so it lives in the shared package rather than in one of them.
+
+### Added
+
 - **Subsystem codes can be stored** (`data/migrations/020`). A subsystem code is described
   by two groups, not one: the **gauge** group a decoder may measure, and the **stabilizer**
   group — its centre — whose outcomes are deterministic. The difference between them is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,10 +20,10 @@ is represented as a tag, not a separate entity.
 
 Both levels support **tags** to aid discovery and filtering:
 
-| Level   | Example tags                               |
-| ------- | ------------------------------------------ |
-| Code    | `CSS`, `topological`, `bosonic`            |
-| Circuit | `encoding`, `fault-tolerant`, `distance:3` |
+| Level   | Example tags                                                      |
+| ------- | ----------------------------------------------------------------- |
+| Code    | `CSS`, `topological`, `bosonic`                                   |
+| Circuit | `encoding`, `syndrome-extraction`, `fault-tolerant`, `distance:3` |
 
 Tags can be either **structured** (`key:value`, e.g. `distance:3`) or **free-form strings**.
 
@@ -130,12 +130,21 @@ the code's density. Submitted matrices are shared: they live once in
 `data_yaml/matrices/<digest>.yaml` and circuits reference them by digest. Readers call
 `matrix_format.decode` / `decodeMatrix` and never need to know which encoding was used.
 
-The canonical STIM body is **reset-free** — `to_tableau()` and the derive/fit
-machinery need a circuit with no resets — so it leaves the `|0…0⟩` input implied.
-State-prep and encoding circuits therefore also carry a `stim-annotated` body
-that states it explicitly, plus a terminal readout and detectors where a readout
-basis exists. Generate it with `uv run python scripts/annotate_circuits.py`
-(idempotent); the canonical body must stay reset-free.
+The canonical STIM body of a **prep or encoding** circuit is **reset-free** —
+`to_tableau()` and the derive/fit machinery need a circuit with no resets — so it
+leaves the `|0…0⟩` input implied. Those circuits therefore also carry a
+`stim-annotated` body that states it explicitly, plus a terminal readout and
+detectors where a readout basis exists.
+
+**Syndrome extraction is the exception, and has to be.** A round _is_ reset,
+gates, measure — the resets and measurements are the circuit, not an annotation
+of it. So those bodies are not reset-free and have no tableau, and none of the
+derive/fit machinery may be pointed at them. They are checked by stabilizer flows
+instead (`validate_syndrome_extraction_h`), and their `stim-annotated` body is the
+memory experiment the round belongs to: reset the data, `REPEAT d` of the round,
+terminal readout, detectors, observable.
+
+Generate both with `uv run python scripts/annotate_circuits.py` (idempotent).
 
 ---
 

--- a/docs/adding-circuits-agent.md
+++ b/docs/adding-circuits-agent.md
@@ -30,14 +30,14 @@ Before writing any files, the agent:
 - Detects qubit ordering differences between your matrices and the stored code, and reports the permutation that will be applied to the circuit
 - Shows circuit metrics (qubit count, gate count, depth) and a Crumble link
 - Can extract Hx/Hz directly from the circuit via Pauli propagation (`extract_code`) if matrices aren't provided
-- Runs validation if you tell it the circuit type (encoding or state-prep)
+- Runs validation if you tell it the circuit type (encoding, state-prep or syndrome extraction)
 - Shows a dry-run preview of what files would be generated
 
 You confirm before anything is written.
 
 ### Phase 3: Generate YAML files
 
-The agent calls the Python API to write the code YAML, circuit YAML, and body files (`.stim`, `.qasm`, `.cirq`) to `data_yaml/`. For state-prep and encoding circuits, run `uv run python scripts/annotate_circuits.py` afterwards to add the `.stim-annotated` body. Each circuit is automatically assigned a unique `qec_id` (displayed as `#N` in the UI). This ID is permanent and must never be reused.
+The agent calls the Python API to write the code YAML, circuit YAML, and body files (`.stim`, `.qasm`, `.cirq`) to `data_yaml/`. Run `uv run python scripts/annotate_circuits.py` afterwards to add the `.stim-annotated` body. Each circuit is automatically assigned a unique `qec_id` (displayed as `#N` in the UI). This ID is permanent and must never be reused.
 
 ### Phase 4: Zoo lookup, paper lookup, and tagging
 
@@ -81,9 +81,9 @@ The pipeline also preserves the original (pre-canonicalization) STIM circuit and
 
 The agent only uses tags that already exist in the library. Current tags:
 
-| Level   | Tags                                                                                                                                                                                              |
-| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Code    | `CSS`, `stabilizer`, `self-dual`, `color-code`, `surface-code`, `concatenated`                                                                                                                    |
-| Circuit | `encoding`, `state-preparation`, `syndrome-extraction`, `ft`, `non-ft`, `flag`, `deterministic`, plus structured tags `logical-state:*`, `connectivity:*`, `device:*`, `prep:*`, `verification:*` |
+| Level   | Tags                                                                                                                                                                                                                         |
+| ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Code    | `CSS`, `stabilizer`, `self-dual`, `color-code`, `surface-code`, `concatenated`                                                                                                                                               |
+| Circuit | `encoding`, `state-preparation`, `syndrome-extraction`, `ft`, `non-ft`, `flag`, `deterministic`, plus structured tags `logical-state:*`, `connectivity:*`, `device:*`, `prep:*`, `verification:*`, `schedule:*`, `decoder:*` |
 
 `tool:*` tags are **not** set by hand — they are derived from a circuit's `tool` field when the database is built. If the Zoo or user suggests any other tag not already in the library, the agent will ask before adding it.

--- a/docs/adding-circuits.md
+++ b/docs/adding-circuits.md
@@ -23,12 +23,13 @@ uv sync                # install Python dependencies
 
 Pick the path that matches what you have — they all end at the same YAML files and the same `npm run db:create`.
 
-| You have…                                                   | Use                   | Section                                                           |
-| ----------------------------------------------------------- | --------------------- | ----------------------------------------------------------------- |
-| An **encoding** circuit + check matrices (`Hx/Hz` or `H`)   | `add_circuit()`       | [Steps 1–4](#step-1-inspect)                                      |
-| A **state-preparation** circuit (matrices optional)         | `import_state_prep()` | [State-preparation circuits](#adding-a-state-preparation-circuit) |
-| A circuit whose qubit labeling differs from the stored code | either, with a _fit_  | [Fitting to an existing code](#fitting-to-an-existing-code)       |
-| **Many** circuits from one source/paper                     | a dataset importer    | [Bulk / dataset imports](#bulk--dataset-imports)                  |
+| You have…                                                   | Use                                  | Section                                                               |
+| ----------------------------------------------------------- | ------------------------------------ | --------------------------------------------------------------------- |
+| An **encoding** circuit + check matrices (`Hx/Hz` or `H`)   | `add_circuit()`                      | [Steps 1–4](#step-1-inspect)                                          |
+| A **state-preparation** circuit (matrices optional)         | `import_state_prep()`                | [State-preparation circuits](#adding-a-state-preparation-circuit)     |
+| A **syndrome-extraction** round, or a check schedule        | `build_se_round()` + `add_circuit()` | [Syndrome-extraction circuits](#adding-a-syndrome-extraction-circuit) |
+| A circuit whose qubit labeling differs from the stored code | either, with a _fit_                 | [Fitting to an existing code](#fitting-to-an-existing-code)           |
+| **Many** circuits from one source/paper                     | a dataset importer                   | [Bulk / dataset imports](#bulk--dataset-imports)                      |
 
 Only have a circuit? That's fine: [`extract_code`](#extract-code-from-circuit-optional) recovers `Hx/Hz` from an encoding circuit, and the [state-prep helpers](#get-the-check-matrices-from-the-circuit) derive them from a prep circuit. New here? See the [FAQ](#faq).
 
@@ -81,13 +82,18 @@ print(summarize_circuit(circuit_text))
 ### Validate (optional)
 
 ```python
-from scripts.add_circuit import validate_encoding, validate_state_prep
+from scripts.add_circuit import (
+    validate_encoding, validate_state_prep, validate_syndrome_extraction,
+)
 
 # For encoding circuits:
 print(validate_encoding(circuit, Hx, Hz))   # 'passed' or 'failed: ...'
 
 # For state-preparation circuits:
 print(validate_state_prep(circuit, Hx, Hz)) # 'passed' or 'failed: ...'
+
+# For syndrome-extraction circuits (one round):
+print(validate_syndrome_extraction(circuit, Hx, Hz))  # 'passed' or 'failed: ...'
 ```
 
 Validation uses your provided Hx/Hz (same source as the circuit). If the code already exists in the library with a different qubit ordering, `add_circuit()` handles the relabeling separately.
@@ -96,16 +102,29 @@ For a **non-CSS** code there is no Hx/Hz split; pass the symplectic `h` (shape
 `(m, 2n)`, X-half then Z-half — the form stored in `codes.h`) instead:
 
 ```python
-from scripts.add_circuit import validate_encoding_h, validate_state_prep_h
+from scripts.add_circuit import (
+    validate_encoding_h, validate_state_prep_h, validate_syndrome_extraction_h,
+)
 
 print(validate_encoding_h(circuit, h, n))    # 'passed' or 'failed: ...'
 print(validate_state_prep_h(circuit, h, n))  # 'passed' or 'failed: ...'
+print(validate_syndrome_extraction_h(circuit, h, n, logical=logical))
 ```
 
 These are the general implementations — the Hx/Hz pair above is a thin wrapper —
 so CSS codes may use either. Both check each stabilizer up to **sign** (`|⟨S⟩| = 1`,
 not `⟨S⟩ = +1`): a sign-free binary `h` names a stabilizer group only up to a Pauli
 frame, so a circuit preparing a codeword in a different frame is still valid.
+
+**Syndrome extraction is checked differently**, because it acts on an
+already-encoded state: there is no fixed input to simulate it on, and its resets
+and measurements leave it with no tableau. `validate_syndrome_extraction_h` uses
+stim's _stabilizer flows_ instead, and asks three things of one round: the group
+it measures is exactly the code's stabilizer group, every stabilizer survives
+(`S -> S`), and — when `logical` is passed — every logical does too (`L -> L`).
+Which ancilla reads which stabilizer is **derived** from the circuit, never
+assumed from the measurement order, since nothing in the stored data records it.
+Data qubits are `0..n-1`; anything above is treated as an ancilla.
 
 ### Extract code from circuit (optional)
 
@@ -320,6 +339,65 @@ print(result.summary())
 
 The full circuit (flags included) is what gets stored; the pipeline dedups it to the canonical code, applies any qubit permutation, and preserves the original in `originals/`. Provenance you pass (`source_file`, `logical_state`, `connectivity`, `gate_set`, `device`, `qubit_placement`) is folded into the circuit notes, and the categorical ones also become `key:value` tags — nothing is dropped.
 
+## Adding a syndrome-extraction circuit
+
+A syndrome-extraction round is the odd one out, and in a way worth understanding before you
+add one: it acts on an **already-encoded** state. There is no `|0…0⟩` input to simulate it on,
+and its resets and measurements are the circuit rather than an annotation of it, so it has no
+tableau. Nothing in the derive/fit machinery applies.
+
+### From a check schedule
+
+The reusable description of a round is a **schedule**: ticks of `(data, ancilla, pauli)` checks
+that run in parallel. `build_se_round` turns one into STIM.
+
+```python
+from scripts.add_circuit import build_se_round, validate_syndrome_extraction_h
+
+ticks = [
+    [(0, 7, "X"), (1, 10, "Z")],   # tick 0: two checks, in parallel
+    [(2, 7, "X"), (3, 10, "Z")],   # tick 1
+]
+circuit = build_se_round(ticks, n=7)          # hadamards="basis" | "per-check"
+```
+
+Data qubits are `0..n-1`; every ancilla must be `>= n`. The ticks are emitted **verbatim** — a
+scheduling result _is_ its tick assignment, so nothing is re-packed — and the ancillas are
+measured in ascending index order. A tick that uses the same qubit twice is rejected rather
+than silently serialised.
+
+### Validate
+
+```python
+print(validate_syndrome_extraction_h(circuit, h, n, logical=logical))  # 'passed' | 'failed: ...'
+```
+
+Three checks, on stabilizer flows: the group the round **measures** is exactly the code's, every
+stabilizer is **preserved** (`S -> S`), and every logical is too (`L -> L`, when `logical` is
+given). Which ancilla reads which check is _derived_ from the circuit, never assumed from the
+measurement order.
+
+Run it. The interesting failure is invisible to inspection: when an X-check and a Z-check share
+two data qubits and their CNOTs are ordered inconsistently, the two ancillas come out entangled
+and each outcome is random — with every check applied exactly once, on the right qubits, in a
+conflict-free schedule. `measured_stabilizers` reports what the round actually measures, and
+`round_check_matrix` the per-ancilla map, if you need to see why.
+
+### Store
+
+`add_circuit()` takes it from there unchanged — pass the symplectic `h`, tag it
+`syndrome-extraction`, and run `scripts/annotate_circuits.py` afterwards to get the
+`stim-annotated` memory experiment (reset the data, `REPEAT d` of the round, terminal readout,
+detectors, observable).
+
+```python
+add_circuit(circuit=circuit, circuit_name="Depth-optimal schedule", d=3,
+            H=h, n=n, source="https://arxiv.org/abs/...",
+            tags=["syndrome-extraction", "schedule:depth-optimal"])
+```
+
+The importers under `data-imports/` are the worked examples.
+
 ## Fitting to an existing code
 
 Published circuits rarely use the same qubit labeling as the stored code, so the circuit must be **fitted** by a qubit permutation (convention `σ[new] = old`). Both `add_circuit()` and `import_state_prep()` resolve this for you, trying in order:
@@ -420,14 +498,18 @@ The `qec_id` is a **permanent, globally unique** integer identifier for the circ
 
 Body files (`.stim`, `.qasm`, `.cirq`) share the same stem as the circuit YAML.
 
-State-prep and encoding circuits get one more, `.stim-annotated`, written by
+Circuits get one more, `.stim-annotated`, written by
 `uv run python scripts/annotate_circuits.py` (idempotent — run it after adding
-such a circuit). It restates the `|0…0⟩` input that the canonical `.stim` body
-leaves implied, and adds a terminal readout with detectors where a readout basis
-exists. It is a view of the STIM body rather than a display format, so it gets no
-format tab; the Detectors toggle derives both views from it. The canonical
-`.stim` body must stay reset-free — `to_tableau()` and the derive/fit machinery
-depend on that.
+one). For a prep or encoder it restates the `|0…0⟩` input that the canonical
+`.stim` body leaves implied and adds a terminal readout with detectors; for a
+syndrome-extraction round it is the memory experiment (reset the data, `REPEAT d`,
+readout, detectors, observable). Either way it is a view of the STIM body rather
+than a display format, so it gets no format tab; the Detectors toggle derives both
+views from it.
+
+A prep or encoder's canonical `.stim` body must stay **reset-free** —
+`to_tableau()` and the derive/fit machinery depend on that. A syndrome-extraction
+body cannot be: its resets and measurements are the circuit.
 
 ### Original submission
 
@@ -575,8 +657,8 @@ quote it and save yourself the round trip.
 **I only have a circuit, no check matrices. Can I still add it?**
 Yes. For an encoding circuit use [`extract_code`](#extract-code-from-circuit-optional); for a state-prep circuit use the [derive-matrices helpers](#get-the-check-matrices-from-the-circuit). Both recover the code from the circuit.
 
-**Encoding vs state-preparation — which is my circuit?**
-An _encoding_ circuit maps `k` data qubits (plus ancillas) into the codespace; the first `k` qubits carry the logical input. A _state-preparation_ circuit starts from `|0…0⟩` and outputs a fixed logical state (`|0⟩_L`, `|+⟩_L`, …). Most library circuits are state-prep. The choice sets the `encoding` / `state-preparation` tag, which routes `validate:circuits`.
+**Encoding vs state-preparation vs syndrome extraction — which is my circuit?**
+An _encoding_ circuit maps `k` data qubits (plus ancillas) into the codespace; the first `k` qubits carry the logical input. A _state-preparation_ circuit starts from `|0…0⟩` and outputs a fixed logical state (`|0⟩_L`, `|+⟩_L`, …). A _syndrome-extraction_ round acts on a state that is **already** encoded, and reads the checks into ancillas. Most library circuits are state-prep. The choice sets the `encoding` / `state-preparation` / `syndrome-extraction` tag, which routes `validate:circuits` — and the three are validated by genuinely different means, so tagging it wrong means checking the wrong property.
 
 **My circuit uses different qubit indices than the stored code.**
 Expected — see [Fitting to an existing code](#fitting-to-an-existing-code). You rarely need to work out the permutation by hand.

--- a/docs/database.md
+++ b/docs/database.md
@@ -65,7 +65,7 @@ The build prints how many circuits linked, and lists any link-shaped `source` wi
 behind it:
 
 ```
-Papers: 7, linked to 724 circuits.
+Papers: 8, linked to 780 circuits.
 ```
 
 Those unlinked circuits still render and still search by URL; they just cannot be found by

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qecirc-website",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qecirc-website",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "@astrojs/node": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qecirc-website",
   "type": "module",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "MIT",
   "scripts": {
     "dev": "astro dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qecirc-website"
-version = "0.7.0"
+version = "0.7.1"
 description = "QECirc — quantum error correction circuit library"
 license = "MIT"
 requires-python = ">=3.13"

--- a/scripts/add_circuit/__init__.py
+++ b/scripts/add_circuit/__init__.py
@@ -28,11 +28,13 @@ import stim
 
 from .circuit_validate import (  # noqa: F401
     extract_code,
+    measured_stabilizers,
     validate_encoding,
     validate_encoding_h,
     validate_state_prep,
     validate_state_prep_h,
     validate_syndrome_extraction,
+    validate_syndrome_extraction_h,
 )
 from .code_identify import gf2_row_basis
 from .compute import compute_code_data, compute_code_data_h
@@ -50,6 +52,7 @@ from .helpers import (  # noqa: F401
 from .ids import next_qec_id
 from .matrix_format import decode as decode_matrix
 from .models import ExtractedCode  # noqa: F401
+from .syndrome_extraction import build_se_round  # noqa: F401
 from .yaml_helpers import (
     build_circuit_yaml,
     build_code_yaml,
@@ -475,6 +478,8 @@ __all__ = [  # noqa: F822  (names defined above / re-exported)
     "validate_state_prep",
     "validate_state_prep_h",
     "validate_syndrome_extraction",
+    "validate_syndrome_extraction_h",
+    "measured_stabilizers",
     "extract_code",
     "ExtractedCode",
     "ExistingCodeMatch",
@@ -493,4 +498,5 @@ __all__ = [  # noqa: F822  (names defined above / re-exported)
     "import_state_prep",
     # perm_find re-exports
     "find_code_permutation",
+    "build_se_round",
 ]

--- a/scripts/add_circuit/annotate.py
+++ b/scripts/add_circuit/annotate.py
@@ -344,6 +344,105 @@ def build_annotated(
     return out
 
 
+def build_annotated_se(
+    body: str,
+    stored_h: np.ndarray,
+    logical: np.ndarray,
+    n: int,
+    rounds: int,
+) -> Optional[stim.Circuit]:
+    """Build the ``stim-annotated`` body for a syndrome-extraction round.
+
+    The stored body is *one* round, which is the reusable unit. What a reader
+    actually runs is a memory experiment, and that is what this returns: the data
+    reset to ``|0...0>``, the round repeated ``rounds`` times, a terminal readout,
+    and the detectors that make the whole thing decodable.
+
+    So this is the same idea as :func:`build_annotated` — state what the stored
+    body leaves out — but nothing about the construction is shared. A prep gets a
+    prologue because it starts from ``|0...0>``; a round does not, because it acts
+    on whatever it is given. The round count is the thing that has to be supplied
+    from outside, and ``d`` is the standard choice.
+
+    Which measurement reads which check comes from
+    :func:`~.circuit_validate.round_check_matrix`; ``None`` from there means no
+    annotated body, since without the map no detector can be placed.
+
+    Three families of detector, and the split is just about what is deterministic
+    when:
+
+    * **first round** — only the checks with no X component. The data starts in a
+      Z-basis product state, so those read ``+1`` and everything else is random.
+    * **later rounds** — every check, against the same check in the round before.
+      Nothing needs to be known about the code for these.
+    * **terminal** — each no-X check again, this time against the transversal Z
+      readout that recomputes it from the data.
+
+    A code with **no** pure-Z check — a non-CSS code, whose stabilizers all mix X
+    and Z on the same qubit — gets no body at all, and returns ``None``. Only the
+    middle family would survive, and inter-round detectors with no readout and no
+    observable describe an experiment with no outcome. That is the same narrowing
+    :func:`_readout_basis` applies to preps and for the same reason; it just costs
+    more here, because for a prep the prologue alone is still worth showing.
+
+    The result is *not* validated here; run :func:`validate_annotated` on it.
+    """
+    from .circuit_validate import round_check_matrix
+
+    if rounds < 1:
+        return None
+    checks = round_check_matrix(body, n)
+    if checks is None or not checks.size:
+        return None
+
+    source = stim.Circuit(body)
+    per_round = checks.shape[0]
+    z_checks = [j for j in range(per_round) if not checks[j, :n].any()]
+    z_logicals = (
+        [row for row in np.atleast_2d(logical) if not row[:n].any()] if logical.size else []
+    )
+    if not z_checks:
+        return None
+
+    gates = stim.Circuit()
+    for op in source:
+        if isinstance(op, stim.CircuitRepeatBlock):
+            return None
+        if op.name == "QUBIT_COORDS":
+            continue
+        gates.append(op.name, op.targets_copy(), op.gate_args_copy())
+
+    out = stim.Circuit()
+    for qubit, coord in sorted(source.get_final_qubit_coordinates().items()):
+        if coord:
+            out.append("QUBIT_COORDS", [qubit], coord)
+    out.append("R", list(range(n)))
+    out.append("TICK")
+
+    out += gates
+    for j in z_checks:
+        out.append("DETECTOR", [stim.target_rec(j - per_round)])
+
+    if rounds > 1:
+        repeat = gates.copy()
+        for j in range(per_round):
+            repeat.append(
+                "DETECTOR",
+                [stim.target_rec(j - per_round), stim.target_rec(j - 2 * per_round)],
+            )
+        out.append(stim.CircuitRepeatBlock(rounds - 1, repeat))
+
+    out.append("TICK")
+    out.append("M", list(range(n)))
+    for j in z_checks:
+        support = [stim.target_rec(q - n) for q in range(n) if checks[j, n + q]]
+        out.append("DETECTOR", [*support, stim.target_rec(j - per_round - n)])
+    for index, row in enumerate(z_logicals):
+        support = [stim.target_rec(q - n) for q in range(n) if row[n + q]]
+        out.append("OBSERVABLE_INCLUDE", support, index)
+    return out
+
+
 def strip_readout(circ: stim.Circuit) -> stim.Circuit:
     """Drop the readout epilogue, keeping the reset prologue and the body.
 
@@ -358,6 +457,11 @@ def strip_readout(circ: stim.Circuit) -> stim.Circuit:
     instruction, last, so after the annotations are dropped it is the final
     instruction — anything earlier belongs to the body.
 
+    Annotations inside a ``REPEAT`` block go too — a syndrome-extraction round is
+    annotated as a repeated memory experiment, so that is where most of its
+    detectors live. The browser's mirror strips lines and so has always reached
+    them; this one had to be taught to recurse.
+
     Mirrors ``stripReadout`` in src/lib/stim-format.ts, which does the same for
     the browser. Keep the two in step.
     """
@@ -370,7 +474,7 @@ def strip_readout(circ: stim.Circuit) -> stim.Circuit:
     out = stim.Circuit()
     for op in ops:
         if isinstance(op, stim.CircuitRepeatBlock):
-            out.append(op)
+            out.append(stim.CircuitRepeatBlock(op.repeat_count, strip_readout(op.body_copy())))
             continue
         out.append(op.name, op.targets_copy(), op.gate_args_copy())
     return out

--- a/scripts/add_circuit/circuit_validate.py
+++ b/scripts/add_circuit/circuit_validate.py
@@ -5,12 +5,12 @@ Uses stim.Circuit built-ins and stim.gate_data() for accurate metrics.
 """
 
 from collections.abc import Sequence
-from typing import Union
+from typing import Optional, Union
 
 import numpy as np
 import stim
 
-from .code_identify import gf2_rank, gf2_rref
+from .code_identify import gf2_rank, gf2_row_basis, gf2_rref, gf2_rref_pivots
 from .models import CircuitProperties, ExtractedCode
 
 # Gate data for classification (computed once at module level)
@@ -357,14 +357,253 @@ def validate_state_prep(circuit: Union[stim.Circuit, str], Hx: np.ndarray, Hz: n
     return validate_state_prep_h(circuit, h, n)
 
 
+# ---------------------------------------------------------------------------
+# Syndrome extraction
+# ---------------------------------------------------------------------------
+#
+# A syndrome-extraction round is validated by *stabilizer flows*, not by
+# simulation on |0...0>: it acts on an already-encoded state, so there is no
+# fixed input to simulate, and it contains resets and measurements, so it has no
+# tableau. Two independent things must hold, and neither implies the other:
+#
+#   measured   for every stabilizer S there is a flow  1 -> S xor rec[...]
+#              — the ancillas are reset, so their input is trivial, and the
+#              measurement record carries S's eigenvalue out of the round
+#   preserved  for every stabilizer S there is a flow  S -> S
+#              — the round leaves the code state where it found it
+#
+# The measured set is *derived* from the circuit rather than assumed from the
+# measurement order: see :func:`measured_stabilizers`. That matters because
+# nothing in the stored data records which ancilla measures which stabilizer,
+# and because deriving it is what catches the interesting failure — an X- and a
+# Z-check sharing two data qubits whose CNOTs are ordered inconsistently leave
+# their two ancillas entangled, so the outcome is individually random and the
+# round measures nothing, even though every check was applied exactly once.
+
+
+def measured_stabilizers(circuit: Union[stim.Circuit, str], n: int) -> np.ndarray:
+    """The data-qubit Paulis a round measures deterministically.
+
+    Returns a symplectic matrix of shape ``(r, 2n)`` (X-half then Z-half) whose
+    row space is the group of operators on qubits ``0..n-1`` whose eigenvalue the
+    round writes into its measurement record. Qubits ``>= n`` are the ancillas.
+
+    Derived from :meth:`stim.Circuit.flow_generators`, which returns a complete
+    basis for the circuit's flows. The ones that count are those with a **trivial
+    input** (the ancillas are reset, so nothing has to be supplied) and **no
+    residual support on the ancillas** (an ancilla term means the outcome is
+    entangled with another ancilla rather than determined — exactly the
+    interleaving failure described above). Gaussian elimination over the ancilla
+    columns extracts that subspace; whatever remains, restricted to the data
+    qubits, is what the round actually measures.
+
+    A flow with no measurement record is excluded: ``1 -> P`` with no ``rec``
+    says the round *prepares* a P eigenstate, which is a state-prep property,
+    not a measurement.
+    """
+    circ = _widen(_to_stim_circuit(circuit), n)
+    width = circ.num_qubits
+    n_anc = max(width - n, 0)
+    n_meas = circ.num_measurements
+
+    # Column layout: ancilla halves first, so RREF pivots on them and the rows
+    # left without an ancilla pivot are precisely the ancilla-free subspace.
+    anc_cols = 2 * n_anc
+    rows: list[np.ndarray] = []
+    for flow in circ.flow_generators():
+        if flow.input_copy().weight:
+            continue
+        out = flow.output_copy()
+        vec = np.zeros(anc_cols + 2 * n + n_meas, dtype=int)
+        # stim trims a flow's Pauli strings to their support, so `out` may be
+        # narrower than the circuit (and empty for a measurement-only flow).
+        for q in range(min(width, len(out))):
+            p = out[q]
+            if not p:
+                continue
+            x, z = (p in (1, 2)), (p in (2, 3))
+            if q < n:
+                vec[anc_cols + q] = x
+                vec[anc_cols + n + q] = z
+            else:
+                vec[q - n] = x
+                vec[n_anc + q - n] = z
+        for m in flow.measurements_copy():
+            vec[anc_cols + 2 * n + (m % n_meas)] = 1
+        rows.append(vec)
+
+    if not rows:
+        return np.zeros((0, 2 * n), dtype=int)
+
+    reduced, pivots = gf2_rref_pivots(np.array(rows, dtype=int))
+    n_anc_pivots = sum(1 for c in pivots if c < anc_cols)
+    ancilla_free = reduced[n_anc_pivots:]
+    if not ancilla_free.size:
+        return np.zeros((0, 2 * n), dtype=int)
+
+    # Keep only rows that carry a measurement record and touch a data qubit.
+    data = ancilla_free[:, anc_cols : anc_cols + 2 * n]
+    meas = ancilla_free[:, anc_cols + 2 * n :]
+    keep = np.any(data, axis=1) & np.any(meas, axis=1)
+    return data[keep]
+
+
+def round_check_matrix(circuit: Union[stim.Circuit, str], n: int) -> Optional[np.ndarray]:
+    """Which operator *each measurement* of a round reads, or ``None``.
+
+    Returns a symplectic matrix with one row per measurement, in measurement
+    order. Where :func:`measured_stabilizers` answers "what does this round
+    measure" as a group — the question validation asks — this answers "and which
+    ancilla reads which", which is what building detectors needs.
+
+    That extra precision costs generality, so this one is deliberately narrow: it
+    only handles a round shaped ``reset → unitary → measure``, with each ancilla
+    reset once at the start, untouched by anything but gates, and measured once
+    at the end. Anything else — mid-round measurement, ``MR``, a flag qubit
+    re-used — returns ``None``, and the caller falls back to whatever it can do
+    without the map. Validation never depends on this function, so a ``None``
+    here can cost an annotation but never a verdict.
+
+    The operator is obtained by pulling ``Z_ancilla`` back through the unitary
+    part: whatever it becomes at the start of the round is what the measurement
+    reports, given the reset fixes ``Z_ancilla = +1``. Residual support on
+    *another* ancilla means the two are entangled and the outcome is not
+    determined by the data at all — that also returns ``None``.
+    """
+    circ = _widen(_to_stim_circuit(circuit), n)
+    width = circ.num_qubits
+
+    unitary = stim.Circuit()
+    measured: list[int] = []
+    reset: set[int] = set()
+    for op in circ:
+        if isinstance(op, stim.CircuitRepeatBlock):
+            return None
+        if op.name in ("R", "RZ"):
+            if measured:
+                return None  # a reset after a measurement: not a single simple round
+            reset.update(t.value for t in op.targets_copy())
+        elif op.name in ("M", "MZ"):
+            measured.extend(t.value for t in op.targets_copy())
+        elif op.name == "TICK" or op.name == "QUBIT_COORDS":
+            continue
+        elif _ALL_GATES.get(op.name) is not None and _ALL_GATES[op.name].is_unitary:
+            unitary.append(op.name, op.targets_copy(), op.gate_args_copy())
+        else:
+            return None  # some other non-unitary op; out of scope
+
+    if not measured or not set(measured) <= reset:
+        return None
+    if len(set(measured)) != len(measured) or any(q < n for q in measured):
+        return None
+
+    try:
+        inverse = _widen(unitary, width).to_tableau().inverse()
+    except ValueError:
+        return None
+
+    rows = np.zeros((len(measured), 2 * n), dtype=int)
+    for row, anc in enumerate(measured):
+        ps = stim.PauliString(width)
+        ps[anc] = 3  # Z
+        pulled = inverse(ps)
+        for q in range(width):
+            p = pulled[q]
+            if not p:
+                continue
+            if q >= n:
+                if q != anc or p != 3:
+                    return None  # entangled with another ancilla, or not a Z
+                continue
+            rows[row, q] = p in (1, 2)
+            rows[row, n + q] = p in (2, 3)
+    return rows
+
+
+def validate_syndrome_extraction_h(
+    circuit: Union[stim.Circuit, str],
+    h: np.ndarray,
+    n: int,
+    logical: Optional[np.ndarray] = None,
+) -> str:
+    """Verify one syndrome-extraction round for the code with stabilizers ``h``.
+
+    ``h`` is the symplectic stabilizer matrix (shape ``(m, 2n)``, X-half then
+    Z-half) — the form stored in ``codes.h``. Data qubits are ``0..n-1``;
+    everything above is an ancilla. ``logical`` is the optional ``codes.logical``
+    matrix (shape ``(2k, 2n)``).
+
+    Three checks, in the order they are reported:
+
+    1. **measured** — the group the round measures (:func:`measured_stabilizers`)
+       is exactly the stabilizer group of ``h``. Both inclusions matter: a round
+       that measures too little is not extracting the full syndrome, and one that
+       measures an operator outside the group is measuring something that does
+       not commute with the code, which destroys the logical state.
+    2. **preserved** — every stabilizer satisfies the flow ``S -> S``.
+    3. **logical** — every logical operator satisfies ``L -> L`` (skipped when
+       ``logical`` is not given).
+
+    All flows are checked with ``unsigned=True``, matching the sign-free ``h``
+    everywhere else in this module: a round that measures ``-S`` measures S in a
+    different Pauli frame, which is a labeling difference, not an error.
+
+    Note on (3): a round that mapped ``L -> L·S`` for some stabilizer ``S`` would
+    act identically on the codespace but be reported as failing. No such circuit
+    has come up; if one does, the check should be relaxed to equality modulo the
+    stabilizer group rather than dropped.
+
+    Returns 'passed' or 'failed: <reason>'.
+    """
+    h = np.atleast_2d(np.asarray(h, dtype=int)) % 2
+    if h.size and h.shape[1] != 2 * n:
+        raise ValueError(f"Expected h with 2n={2 * n} columns, got {h.shape[1]}")
+
+    circ = _widen(_to_stim_circuit(circuit), n)
+    if circ.num_measurements == 0:
+        return "failed: circuit has no measurements, so it extracts no syndrome"
+
+    measured = measured_stabilizers(circ, n)
+    stab_basis, meas_basis = gf2_row_basis(h), gf2_row_basis(measured)
+    if stab_basis.shape != meas_basis.shape or not np.array_equal(stab_basis, meas_basis):
+        extra = gf2_rank(np.vstack([h, measured])) - gf2_rank(h) if measured.size else 0
+        missing = gf2_rank(h) - (gf2_rank(measured) - extra) if measured.size else gf2_rank(h)
+        return (
+            f"failed: the round measures a group of rank {gf2_rank(measured)}, but the code "
+            f"has {gf2_rank(h)} independent stabilizers "
+            f"({missing} not measured, {extra} measured outside the stabilizer group)"
+        )
+
+    width = circ.num_qubits
+    for row in h:
+        ps = _row_to_pauli_string(row, n, width)
+        if not circ.has_flow(stim.Flow(input=ps, output=ps), unsigned=True):
+            return f"failed: stabilizer {ps} is not preserved by the round"
+
+    if logical is not None:
+        logical = np.atleast_2d(np.asarray(logical, dtype=int)) % 2
+        if logical.size and logical.shape[1] != 2 * n:
+            raise ValueError(f"Expected logical with 2n={2 * n} columns, got {logical.shape[1]}")
+        for row in logical:
+            ps = _row_to_pauli_string(row, n, width)
+            if not circ.has_flow(stim.Flow(input=ps, output=ps), unsigned=True):
+                return f"failed: logical operator {ps} is not preserved by the round"
+
+    return "passed"
+
+
 def validate_syndrome_extraction(
     circuit: Union[stim.Circuit, str], Hx: np.ndarray, Hz: np.ndarray
 ) -> str:
-    """Verify syndrome extraction circuit.
+    """Verify a syndrome-extraction round for a CSS code.
 
-    Not yet implemented.
+    Thin wrapper over :func:`validate_syndrome_extraction_h` for callers holding
+    CSS halves.
+
+    Returns 'passed' or 'failed: <reason>'.
     """
-    raise NotImplementedError("Syndrome extraction validation not yet implemented")
+    h, n = _css_to_h(Hx, Hz)
+    return validate_syndrome_extraction_h(circuit, h, n)
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/add_circuit/find_sigma.py
+++ b/scripts/add_circuit/find_sigma.py
@@ -1,0 +1,220 @@
+"""Find the qubit permutation that maps one CSS code onto another.
+
+Split out of the asyndrome import, which wrote it, because three importers now
+need it: a code can match a stored one on every cheap invariant and still defeat
+`find_code_permutation`'s search budget. That happens exactly where you would
+expect — topological codes with large automorphism groups, whose column
+invariants barely separate anything.
+
+This matcher uses the natural check structure of such a code instead: its
+low-weight checks pin a qubit's local geometry down hard. The catch is that *a*
+low-weight basis is not canonical — `sparsify_basis` returns weight-4 generators
+for two codes, but not the same ones, so the hypergraphs are incomparable. The
+set of all low-weight **codewords** is canonical, and cheap to enumerate
+exactly: in RREF each row owns a pivot column no other row touches, so a
+codeword of weight <= w is the sum of at most w rows. Enumerating subsets that
+small is nothing, and it is exhaustive rather than a heuristic.
+
+From there: colour refinement over that hypergraph, then backtracking with a
+pairwise co-occurrence test.
+
+Nothing here is trusted on its own. Every candidate is confirmed by row-space
+equality against the stored code, and `add_circuit` repeats that check on every
+import, so a wrong or stale sigma fails loudly rather than quietly mislabeling
+a code's qubits.
+"""
+
+from __future__ import annotations
+
+import itertools
+from collections import defaultdict
+
+import numpy as np
+
+from .code_identify import gf2_rank, gf2_row_basis, gf2_rref
+
+# Codeword weights to try, smallest first: the search widens until the words span
+# the whole space (see `_checks`). Enumerating up to weight w costs C(rank, w)
+# subsets, so the cap is where that stops being cheap.
+WEIGHTS = (2, 3, 4, 5, 6, 7, 8, 9, 10)
+
+
+def low_weight_codewords(H: np.ndarray, wmax: int) -> list[frozenset[int]]:
+    """Every codeword of weight <= ``wmax`` in the row space of ``H``.
+
+    Exhaustive, and canonical in a way no basis is. Reducing to RREF gives each
+    row a private pivot column, so a sum of ``s`` rows has exactly ``s`` ones
+    among the pivots — a codeword of weight <= wmax therefore uses at most
+    ``wmax`` rows, and enumerating subsets that small covers all of them.
+
+    Rows are packed into Python ints so a subset sum is one XOR and its weight
+    one ``bit_count``; at weight 8 over a rank-24 space that is 735k subsets, and
+    the packed form is what keeps it seconds rather than minutes.
+    """
+    basis = gf2_rref(np.asarray(H, dtype=int) % 2)
+    basis = basis[np.any(basis, axis=1)]
+    n = basis.shape[1]
+    packed = [int("".join(str(int(b)) for b in row), 2) for row in basis]
+
+    found: set[frozenset[int]] = set()
+    for size in range(1, min(wmax, len(packed)) + 1):
+        for subset in itertools.combinations(packed, size):
+            word = 0
+            for row in subset:
+                word ^= row
+            if 0 < word.bit_count() <= wmax:
+                bits = format(word, f"0{n}b")
+                found.add(frozenset(q for q in range(n) if bits[q] == "1"))
+    return sorted(found, key=lambda s: (len(s), sorted(s)))
+
+
+def _spanning_codewords(H: np.ndarray) -> list[frozenset[int]]:
+    """Low-weight codewords of ``H``, widened until they span its whole row space.
+
+    Spanning is the condition that makes the reduction to a graph **lossless**: if
+    the codewords generate the code, a relabeling preserving them preserves the
+    code, and an isomorphism of the incidence structure is a code equivalence. If
+    they only span a subspace, the graph describes that subspace and nothing else
+    — every complete map then fails the final row-space check, and the search
+    exhausts instead of answering.
+
+    That is not hypothetical. The 4.8.8 colour code's 36 weight-4 squares span
+    rank 18 of 24; its octagons carry the rest. Stopping at "enough words" instead
+    of "spanning" is what made `color-oct-9` look intractable.
+    """
+    target = len(gf2_row_basis(H))
+    n = H.shape[1]
+    for wmax in WEIGHTS:
+        words = low_weight_codewords(H, wmax)
+        if not words:
+            continue
+        matrix = np.zeros((len(words), n), dtype=int)
+        for i, support in enumerate(words):
+            for q in support:
+                matrix[i, q] = 1
+        if gf2_rank(matrix) == target:
+            return words
+    raise ValueError(f"low-weight codewords up to weight {WEIGHTS[-1]} do not span the code")
+
+
+def _checks(Hx: np.ndarray, Hz: np.ndarray) -> list[tuple[int, frozenset[int]]]:
+    """The canonical, spanning low-weight codeword hypergraph, as (type, support).
+
+    Weight classes are distinguished by the initial colouring (which includes each
+    check's size), so widening past the minimum weight adds structure rather than
+    blurring it.
+    """
+    return [(kind, s) for kind, H in ((0, Hx), (1, Hz)) for s in _spanning_codewords(H)]
+
+
+def _refine(n: int, incident, checks, colour: list) -> list:
+    """Weisfeiler-Leman refinement of a qubit colouring over the check hypergraph.
+
+    A qubit's new colour is its old one plus, for each check it sits in, that
+    check's type and the multiset of its members' colours. Iterated to a fixpoint.
+    Colours are canonicalised to small integers by sorted order, which is what
+    makes two codes' colourings comparable — the value depends only on structure,
+    never on qubit numbering.
+    """
+    while True:
+        refined = [
+            (
+                colour[q],
+                tuple(
+                    sorted(
+                        (checks[i][0], tuple(sorted(colour[p] for p in checks[i][1])))
+                        for i in incident[q]
+                    )
+                ),
+            )
+            for q in range(n)
+        ]
+        keys = {c: i for i, c in enumerate(sorted(set(refined)))}
+        new = [keys[c] for c in refined]
+        if new == colour:
+            return colour
+        colour = new
+
+
+def _incidence(n: int, checks):
+    incident = defaultdict(list)
+    for index, (_kind, support) in enumerate(checks):
+        for q in support:
+            incident[q].append(index)
+    return incident
+
+
+def _initial(n: int, incident, checks) -> list:
+    """The degree-and-weight colouring refinement starts from."""
+    seed = [tuple(sorted((checks[i][0], len(checks[i][1])) for i in incident[q])) for q in range(n)]
+    keys = {c: i for i, c in enumerate(sorted(set(seed)))}
+    return [keys[c] for c in seed]
+
+
+def find_sigma(Hx1, Hz1, Hx2, Hz2) -> list[int] | None:
+    """sigma with ``Hx1[:, sigma]`` spanning ``Hx2`` (convention sigma[new] = old).
+
+    Individualization-refinement, the technique canonical-labelling tools are
+    built on. Refinement alone stops at the code's automorphism orbits — for the
+    4.8.8 colour code that is four classes of a dozen qubits, and no invariant
+    will do better, because those qubits really are interchangeable. The move is
+    to stop asking: pick a qubit, *declare* it its own colour, and refine again.
+    The symmetry that made the class large is exactly what makes the choice free,
+    and one round of it usually shatters the rest of the classes.
+
+    Plain backtracking with a static order — refine once, then guess — is what
+    this replaces. It searched the 4.8.8 code for minutes without an answer;
+    re-refining after each choice settles it in well under a second.
+
+    Nothing here is trusted: the accepted sigma is checked by exact row-space
+    equality over GF(2), and `add_circuit` checks it again on every import.
+    """
+    n = Hx1.shape[1]
+    checks1, checks2 = _checks(Hx1, Hz1), _checks(Hx2, Hz2)
+    inc1, inc2 = _incidence(n, checks1), _incidence(n, checks2)
+    colour1 = _refine(n, inc1, checks1, _initial(n, inc1, checks1))
+    colour2 = _refine(n, inc2, checks2, _initial(n, inc2, checks2))
+
+    def verify(sigma) -> bool:
+        return np.array_equal(gf2_row_basis(Hx1[:, sigma]), gf2_row_basis(Hx2)) and np.array_equal(
+            gf2_row_basis(Hz1[:, sigma]), gf2_row_basis(Hz2)
+        )
+
+    def search(c1: list, c2: list, sigma: dict) -> list[int] | None:
+        # Comparable colourings are the invariant: a mismatch anywhere means this
+        # branch cannot extend to an isomorphism.
+        if sorted(c1) != sorted(c2):
+            return None
+        classes = defaultdict(list)
+        for q, c in enumerate(c2):
+            classes[c].append(q)
+
+        open_class = min(
+            (c for c, qs in classes.items() if len(qs) > 1),
+            key=lambda c: len(classes[c]),
+            default=None,
+        )
+        if open_class is None:
+            candidate = [0] * n
+            for new, c in enumerate(c2):
+                candidate[new] = c1.index(c)
+            return candidate if verify(candidate) else None
+
+        new = classes[open_class][0]
+        fresh = max(max(c1), max(c2)) + 1
+        for old in (q for q, c in enumerate(c1) if c == open_class):
+            if old in sigma.values():
+                continue
+            d1, d2 = list(c1), list(c2)
+            d1[old] = fresh
+            d2[new] = fresh
+            found = search(
+                _refine(n, inc1, checks1, d1),
+                _refine(n, inc2, checks2, d2),
+                {**sigma, new: old},
+            )
+            if found is not None:
+                return found
+        return None
+
+    return search(colour1, colour2, {})

--- a/scripts/add_circuit/syndrome_extraction.py
+++ b/scripts/add_circuit/syndrome_extraction.py
@@ -1,0 +1,122 @@
+"""Build a syndrome-extraction round from a check schedule.
+
+A syndrome-measurement *schedule* is the reusable description of one round: a
+sequence of ticks, each a set of ``(data, ancilla, pauli)`` checks that run in
+parallel. It says nothing about gates — turning it into a circuit is a fixed
+recipe — but the tick assignment is the whole content of a scheduling result,
+which is why this emitter never re-packs it.
+
+The recipe, per ancilla:
+
+* **X-check** — the ancilla is measured in the X basis: ``H`` before its first
+  check and after its last, then ``CX ancilla data`` per check.
+* **Z-check** — the ancilla stays in the Z basis: ``CX data ancilla`` per check.
+
+``hadamards="per-check"`` wraps every single X-check in its own ``H`` pair
+instead. The two are equivalent — between two checks on the same ancilla the
+inner pair cancels — but some sources emit circuits that way, and reproducing a
+published body verbatim is sometimes worth the extra gates. ``"basis"`` is the
+default because it is what the rest of the library's ``gate_count`` figures are
+comparable against.
+"""
+
+from collections.abc import Mapping, Sequence
+from typing import Optional, Union
+
+import stim
+
+# One check: measure ``pauli`` on ``data``, recorded by ``ancilla``.
+Check = tuple[int, int, str]
+
+HADAMARD_STYLES = ("basis", "per-check")
+
+
+def build_se_round(
+    checks_by_tick: Sequence[Sequence[Check]],
+    n: int,
+    *,
+    hadamards: str = "basis",
+    coords: Optional[Mapping[int, Sequence[Union[int, float]]]] = None,
+) -> stim.Circuit:
+    """One syndrome-extraction round as a STIM circuit.
+
+    ``checks_by_tick[t]`` holds the checks that run in tick ``t``; each is
+    ``(data, ancilla, pauli)`` with ``pauli`` in ``"XZ"``. Data qubits are
+    ``0..n-1`` and every ancilla must be ``>= n``. ``coords`` optionally supplies
+    ``QUBIT_COORDS`` per qubit index.
+
+    The circuit resets every ancilla, emits one ``TICK``-separated layer per
+    tick, and measures the ancillas in **ascending index order** — that order is
+    what a caller pairs with its stabilizers, and what
+    :func:`~.circuit_validate.round_check_matrix` reports.
+
+    Raises ``ValueError`` if an ancilla index collides with the data range, if a
+    Pauli is not X or Z, or if a tick uses the same qubit twice — a tick is a
+    parallel layer by definition, and a repeated qubit means the emitted order,
+    not the schedule, would decide what the round measures.
+    """
+    if hadamards not in HADAMARD_STYLES:
+        raise ValueError(f"hadamards must be one of {HADAMARD_STYLES}, got {hadamards!r}")
+
+    ancillas: set[int] = set()
+    first: dict[int, int] = {}
+    last: dict[int, int] = {}
+    for tick, checks in enumerate(checks_by_tick):
+        seen: set[int] = set()
+        for data, anc, pauli in checks:
+            if pauli not in ("X", "Z"):
+                raise ValueError(f"check pauli must be 'X' or 'Z', got {pauli!r}")
+            if anc < n:
+                raise ValueError(f"ancilla {anc} is inside the data range 0..{n - 1}")
+            if data >= n:
+                raise ValueError(f"data qubit {data} is outside the data range 0..{n - 1}")
+            for q in (data, anc):
+                if q in seen:
+                    raise ValueError(f"tick {tick} uses qubit {q} twice; a tick must be parallel")
+                seen.add(q)
+            ancillas.add(anc)
+            first.setdefault(anc, tick)
+            last[anc] = tick
+
+    order = sorted(ancillas)
+    # An X-ancilla is one that only ever takes X-checks; a mixed ancilla would
+    # need a basis change mid-round, which no schedule format expresses.
+    kinds: dict[int, set[str]] = {a: set() for a in order}
+    for checks in checks_by_tick:
+        for _data, anc, pauli in checks:
+            kinds[anc].add(pauli)
+    mixed = [a for a, ps in kinds.items() if len(ps) > 1]
+    if mixed:
+        raise ValueError(f"ancillas {mixed} take both X and Z checks; that is not a Pauli check")
+    x_ancillas = {a for a, ps in kinds.items() if ps == {"X"}}
+
+    circ = stim.Circuit()
+    for qubit, coord in sorted((coords or {}).items()):
+        circ.append("QUBIT_COORDS", [int(qubit)], list(coord))
+    if order:
+        circ.append("R", order)
+        circ.append("TICK")
+
+    for tick, checks in enumerate(checks_by_tick):
+        if hadamards == "basis":
+            opening = sorted({a for _d, a, _p in checks if a in x_ancillas and first[a] == tick})
+            if opening:
+                circ.append("H", opening)
+        for data, anc, pauli in sorted(checks, key=lambda c: c[1]):
+            if pauli == "X":
+                if hadamards == "per-check":
+                    circ.append("H", [anc])
+                circ.append("CX", [anc, data])
+                if hadamards == "per-check":
+                    circ.append("H", [anc])
+            else:
+                circ.append("CX", [data, anc])
+        if hadamards == "basis":
+            closing = sorted({a for _d, a, _p in checks if a in x_ancillas and last[a] == tick})
+            if closing:
+                circ.append("H", closing)
+        circ.append("TICK")
+
+    if order:
+        circ.append("M", order)
+    return circ

--- a/scripts/annotate_circuits.py
+++ b/scripts/annotate_circuits.py
@@ -38,6 +38,7 @@ import yaml  # noqa: E402
 
 from scripts.add_circuit.annotate import (  # noqa: E402
     build_annotated,
+    build_annotated_se,
     logical_input_qubits,
     strip_readout,
     validate_annotated,
@@ -68,6 +69,8 @@ def _kind_and_state(tags: list[str]) -> tuple[str, str]:
         kind = "state-preparation"
     elif "encoding" in tags:
         kind = "encoding"
+    elif "syndrome-extraction" in tags:
+        kind = "syndrome-extraction"
     state = next((t.split(":", 1)[1] for t in tags if t.startswith("logical-state:")), "")
     return kind, state
 
@@ -90,7 +93,7 @@ def annotate_all(data_dir: Path, only: str = "", dry_run: bool = False) -> list[
         tags = data.get("tags") or []
         kind, state = _kind_and_state(tags)
         if not kind:
-            continue  # gadgets, syndrome extraction: nothing deterministic to annotate
+            continue  # flag gadgets: no code of their own, nothing to annotate against
 
         slug = _code_slug(stem)
         code = codes.get(slug)
@@ -117,19 +120,32 @@ def annotate_all(data_dir: Path, only: str = "", dry_run: bool = False) -> list[
                 if original.get("h"):
                     original_h = decode_matrix(original["h"])
 
-        circ = build_annotated(
-            body=body_path.read_text(encoding="utf-8"),
-            stored_h=stored_h,
-            logical=logical,
-            n=n,
-            k=k,
-            kind=kind,
-            logical_state=state,
-            original_h=original_h,
-            notes=data.get("notes") or "",
-        )
+        if kind == "syndrome-extraction":
+            # A round is annotated as the memory experiment it belongs to, and
+            # the round count that makes one distance-preserving is d.
+            circ = build_annotated_se(
+                body=body_path.read_text(encoding="utf-8"),
+                stored_h=stored_h,
+                logical=logical,
+                n=n,
+                rounds=code.get("d") or 1,
+            )
+            skip_reason = "no per-measurement check map (see round_check_matrix)"
+        else:
+            circ = build_annotated(
+                body=body_path.read_text(encoding="utf-8"),
+                stored_h=stored_h,
+                logical=logical,
+                n=n,
+                k=k,
+                kind=kind,
+                logical_state=state,
+                original_h=original_h,
+                notes=data.get("notes") or "",
+            )
+            skip_reason = _why_skipped(body_path, stored_h, n, k, kind)
         if circ is None:
-            results.append(Result(stem, "skipped", _why_skipped(body_path, stored_h, n, k, kind)))
+            results.append(Result(stem, "skipped", skip_reason))
             continue
 
         error = validate_annotated(circ)

--- a/scripts/tests/test_syndrome_extraction.py
+++ b/scripts/tests/test_syndrome_extraction.py
@@ -1,0 +1,322 @@
+"""Syndrome-extraction validation.
+
+Every negative case here is a circuit that *looks* right — every check applied
+exactly once, on the right qubits, with the right ancillas — and is still not a
+syndrome extraction. That is the point: applying the checks is easy, and the
+things that go wrong (a lost stabilizer, an operator measured outside the group,
+two ancillas left entangled by a bad interleaving) are invisible to any test that
+only counts gates.
+
+Steane is the workhorse: self-dual CSS, so the same three rows serve as Hx and
+Hz, and its weight-4 stabilizers overlap enough for the interleaving case to be
+constructible by hand.
+"""
+
+import numpy as np
+import pytest
+import stim
+
+from scripts.add_circuit.annotate import build_annotated_se, strip_readout, validate_annotated
+from scripts.add_circuit.circuit_validate import (
+    circuit_properties,
+    measured_stabilizers,
+    round_check_matrix,
+    validate_syndrome_extraction,
+    validate_syndrome_extraction_h,
+)
+from scripts.add_circuit.syndrome_extraction import build_se_round
+
+N = 7
+STEANE_CHECKS = np.array(
+    [
+        [1, 0, 1, 0, 1, 0, 1],
+        [0, 1, 1, 0, 0, 1, 1],
+        [0, 0, 0, 1, 1, 1, 1],
+    ]
+)
+_Z = np.zeros_like(STEANE_CHECKS)
+STEANE_H = np.vstack([np.hstack([STEANE_CHECKS, _Z]), np.hstack([_Z, STEANE_CHECKS])])
+# X-bar and Z-bar: the all-ones operator in each basis.
+STEANE_LOGICAL = np.array([[1] * N + [0] * N, [0] * N + [1] * N])
+
+# Ancillas: 7,8,9 read the X-checks, 10,11,12 the Z-checks.
+_X_ANCILLAS = [7, 8, 9]
+_Z_ANCILLAS = [10, 11, 12]
+
+
+def steane_round(drop: int | None = None, spurious: bool = False) -> stim.Circuit:
+    """One Steane syndrome-extraction round, checks taken one ancilla at a time.
+
+    Sequential rather than scheduled, so it is correct by construction and the
+    negative cases below differ from it in exactly one respect.
+
+    ``drop`` omits one ancilla's checks entirely; ``spurious`` adds a seventh
+    ancilla that copies a bare ``Z0`` — an operator that is not in the stabilizer
+    group and anticommutes with the X-checks.
+    """
+    ancillas = _X_ANCILLAS + _Z_ANCILLAS + ([13] if spurious else [])
+    circ = stim.Circuit()
+    circ.append("R", ancillas)
+    for anc, row in zip(_X_ANCILLAS, STEANE_CHECKS):
+        if anc == drop:
+            continue
+        circ.append("H", [anc])
+        for q in np.flatnonzero(row):
+            circ.append("CX", [anc, int(q)])
+        circ.append("H", [anc])
+    for anc, row in zip(_Z_ANCILLAS, STEANE_CHECKS):
+        if anc == drop:
+            continue
+        for q in np.flatnonzero(row):
+            circ.append("CX", [int(q), anc])
+    if spurious:
+        circ.append("CX", [0, 13])
+    circ.append("M", ancillas)
+    return circ
+
+
+class TestValidRound:
+    def test_sequential_round_passes(self):
+        assert validate_syndrome_extraction_h(steane_round(), STEANE_H, N) == "passed"
+
+    def test_logicals_are_checked_and_preserved(self):
+        assert (
+            validate_syndrome_extraction_h(steane_round(), STEANE_H, N, logical=STEANE_LOGICAL)
+            == "passed"
+        )
+
+    def test_css_wrapper_agrees(self):
+        """The Hx/Hz entry point is the same check, not a parallel implementation."""
+        assert (
+            validate_syndrome_extraction(steane_round(), STEANE_CHECKS, STEANE_CHECKS) == "passed"
+        )
+
+    def test_accepts_circuit_as_text(self):
+        assert validate_syndrome_extraction_h(str(steane_round()), STEANE_H, N) == "passed"
+
+    def test_measured_group_is_the_stabilizer_group(self):
+        measured = measured_stabilizers(steane_round(), N)
+        assert measured.shape[1] == 2 * N
+        assert np.linalg.matrix_rank(measured) == 6
+
+
+class TestRejects:
+    def test_missing_stabilizer(self):
+        """Five of six checks read is not a syndrome extraction."""
+        outcome = validate_syndrome_extraction_h(steane_round(drop=8), STEANE_H, N)
+        assert outcome.startswith("failed:")
+        assert "rank 5" in outcome and "1 not measured" in outcome
+
+    def test_operator_outside_the_stabilizer_group(self):
+        """A bare Z0 anticommutes with the X-checks: it both measures something
+        the code does not stabilize and destroys an X-check's determinism."""
+        outcome = validate_syndrome_extraction_h(steane_round(spurious=True), STEANE_H, N)
+        assert outcome.startswith("failed:")
+        assert "1 measured outside the stabilizer group" in outcome
+
+    def test_no_measurements(self):
+        gates_only = stim.Circuit("H 7\nCX 7 0 7 2 7 4 7 6\nH 7")
+        outcome = validate_syndrome_extraction_h(gates_only, STEANE_H, N)
+        assert outcome == "failed: circuit has no measurements, so it extracts no syndrome"
+
+    def test_operator_not_preserved_is_reported_as_such(self):
+        """A single-qubit X is not a logical of the code, and the Z-checks do not
+        preserve it — so the logical branch fires rather than the measured one."""
+        not_a_logical = np.array([[1] + [0] * (2 * N - 1)])
+        outcome = validate_syndrome_extraction_h(steane_round(), STEANE_H, N, logical=not_a_logical)
+        assert "is not preserved by the round" in outcome
+
+    def test_wrong_width_raises(self):
+        try:
+            validate_syndrome_extraction_h(steane_round(), STEANE_H, 5)
+        except ValueError as e:
+            assert "columns" in str(e)
+        else:
+            raise AssertionError("expected ValueError for an h of the wrong width")
+
+
+class TestInterleaving:
+    """The failure a gate-counting check cannot see.
+
+    An X-check and a Z-check sharing data qubits commute as operators, but their
+    CNOTs do not: reverse the relative order on an odd number of the shared
+    qubits and the two ancillas come out entangled. Every check is still applied
+    exactly once, so the round looks perfect and measures nothing.
+    """
+
+    @staticmethod
+    def _pair(inverted: set[int]) -> stim.Circuit:
+        """X-check and Z-check on qubits 0,2,4,6, with ancillas 7 and 10.
+
+        ``inverted`` names the shared qubits where the Z-check goes first.
+        """
+        circ = stim.Circuit()
+        circ.append("R", [7, 10])
+        circ.append("H", [7])
+        for q in (0, 2, 4, 6):
+            if q in inverted:
+                circ.append("CX", [q, 10])
+                circ.append("CX", [7, q])
+            else:
+                circ.append("CX", [7, q])
+                circ.append("CX", [q, 10])
+        circ.append("H", [7])
+        circ.append("M", [7, 10])
+        return circ
+
+    _H_PAIR = np.vstack(
+        [
+            np.hstack([STEANE_CHECKS[:1], _Z[:1]]),
+            np.hstack([_Z[:1], STEANE_CHECKS[:1]]),
+        ]
+    )
+
+    def test_consistent_order_passes(self):
+        assert validate_syndrome_extraction_h(self._pair(set()), self._H_PAIR, N) == "passed"
+
+    def test_even_number_of_inversions_still_passes(self):
+        assert validate_syndrome_extraction_h(self._pair({0, 2}), self._H_PAIR, N) == "passed"
+
+    def test_odd_number_of_inversions_measures_nothing(self):
+        outcome = validate_syndrome_extraction_h(self._pair({0}), self._H_PAIR, N)
+        assert outcome.startswith("failed:")
+        assert "rank 0" in outcome
+
+
+def _greedy_schedule() -> list[list[tuple[int, int, str]]]:
+    """Pack Steane's checks into ticks, X-checks first and Z-checks after.
+
+    Earliest-free-tick greedy; separating the two phases sidesteps interleaving
+    entirely, which is what makes this a fixture rather than a subject.
+    """
+    ticks: list[list[tuple[int, int, str]]] = []
+    used: list[set[int]] = []
+    for pauli, base in (("X", 7), ("Z", 10)):
+        floor = len(ticks)
+        for i, row in enumerate(STEANE_CHECKS):
+            for q in np.flatnonzero(row):
+                t = floor
+                while t < len(ticks) and ({int(q), base + i} & used[t]):
+                    t += 1
+                if t == len(ticks):
+                    ticks.append([])
+                    used.append(set())
+                ticks[t].append((int(q), base + i, pauli))
+                used[t] |= {int(q), base + i}
+    return ticks
+
+
+class TestBuildRound:
+    """The emitter: a schedule in, a round out, and the two Hadamard styles must
+    describe the same physics."""
+
+    # A valid parallel schedule for Steane: greedily packed, X-phase then
+    # Z-phase, so no data qubit ever takes an X- and a Z-check in the same tick.
+    _TICKS = _greedy_schedule()
+
+    def test_round_is_valid(self):
+        circ = build_se_round(self._TICKS, N)
+        assert validate_syndrome_extraction_h(circ, STEANE_H, N, logical=STEANE_LOGICAL) == "passed"
+
+    def test_hadamard_styles_are_equivalent(self):
+        """per-check wrapping is the same round with the cancelling H pairs left
+        in; only the single-qubit gate count differs."""
+        basis = build_se_round(self._TICKS, N, hadamards="basis")
+        per_check = build_se_round(self._TICKS, N, hadamards="per-check")
+        assert validate_syndrome_extraction_h(per_check, STEANE_H, N) == "passed"
+        assert basis.num_measurements == per_check.num_measurements
+        assert circuit_properties(str(basis)).two_qubit_gate_count == (
+            circuit_properties(str(per_check)).two_qubit_gate_count
+        )
+        assert circuit_properties(str(basis)).gate_count < (
+            circuit_properties(str(per_check)).gate_count
+        )
+
+    def test_measurement_order_is_ascending_ancilla(self):
+        circ = build_se_round(self._TICKS, N)
+        checks = round_check_matrix(circ, N)
+        # Ancillas 7,8,9 read the X-checks and 10,11,12 the Z-checks, in that order.
+        assert np.array_equal(checks[:3, :N], STEANE_CHECKS)
+        assert not checks[:3, N:].any()
+        assert np.array_equal(checks[3:, N:], STEANE_CHECKS)
+
+    def test_ticks_are_preserved_not_repacked(self):
+        """The tick assignment is the whole content of a scheduling result, so
+        the emitter must not compress it."""
+        spread = [[(0, 7, "Z")], [], [(1, 7, "Z")]]
+        assert str(build_se_round(spread, N)).count("TICK") == 4  # reset + 3 ticks
+
+    def test_rejects_a_tick_that_reuses_a_qubit(self):
+        with pytest.raises(ValueError, match="parallel"):
+            build_se_round([[(0, 7, "Z"), (0, 8, "Z")]], N)
+
+    def test_rejects_an_ancilla_inside_the_data_range(self):
+        with pytest.raises(ValueError, match="data range"):
+            build_se_round([[(0, 3, "Z")]], N)
+
+    def test_rejects_a_mixed_basis_ancilla(self):
+        with pytest.raises(ValueError, match="both X and Z"):
+            build_se_round([[(0, 7, "X")], [(1, 7, "Z")]], N)
+
+
+class TestRoundCheckMatrix:
+    def test_returns_none_for_a_shape_it_cannot_read(self):
+        """Deliberately narrow: no map is better than a wrong one, and nothing in
+        validation depends on it."""
+        assert round_check_matrix("R 7\nM 7\nR 7\nM 7", N) is None  # reset after measure
+        assert round_check_matrix("H 0", N) is None  # no measurements
+
+    def test_returns_none_when_ancillas_are_entangled(self):
+        """The interleaving failure again: the outcome is not a function of the
+        data, so there is no operator to report."""
+        bad = TestInterleaving._pair({0})
+        assert round_check_matrix(bad, N) is None
+
+
+class TestAnnotatedMemoryExperiment:
+    @staticmethod
+    def _round():
+        return str(build_se_round(TestBuildRound._TICKS, N))
+
+    def test_detectors_are_deterministic(self):
+        ann = build_annotated_se(self._round(), STEANE_H, STEANE_LOGICAL, N, rounds=3)
+        assert validate_annotated(ann) is None
+
+    def test_shape(self):
+        ann = build_annotated_se(self._round(), STEANE_H, STEANE_LOGICAL, N, rounds=3)
+        text = str(ann)
+        assert text.startswith("R 0 1 2 3 4 5 6\n")  # the data, reset to |0...0>
+        assert "REPEAT 2 {" in text  # first round explicit, the rest repeated
+        assert ann.num_observables == 1
+        # 3 first-round Z-checks + 2 x 6 inter-round + 3 terminal
+        assert ann.num_detectors == 3 + 12 + 3
+
+    def test_single_round_has_no_repeat_block(self):
+        ann = build_annotated_se(self._round(), STEANE_H, STEANE_LOGICAL, N, rounds=1)
+        assert "REPEAT" not in str(ann)
+        assert validate_annotated(ann) is None
+
+    def test_detectors_off_view_drops_the_ones_inside_the_repeat(self):
+        """The Detectors switch subtracts from the annotated body, so a detector
+        left inside the REPEAT block would survive being switched off."""
+        ann = build_annotated_se(self._round(), STEANE_H, STEANE_LOGICAL, N, rounds=3)
+        plain = strip_readout(ann)
+        assert plain.num_detectors == 0
+        assert plain.num_observables == 0
+        assert "REPEAT 2 {" in str(plain)  # the rounds themselves stay
+
+    def test_mixed_pauli_checks_get_no_body(self):
+        """A round whose checks mix X and Z on one qubit — the non-CSS case — has
+        no terminal basis, so no readout, no observable and no first-round
+        detector. An experiment with no outcome is not worth emitting."""
+        mixed = "R 7\nH 7\nCY 7 0\nH 7\nM 7"  # reads Y0
+        assert round_check_matrix(mixed, N) is not None  # the map is fine; the basis is not
+        assert build_annotated_se(mixed, STEANE_H, STEANE_LOGICAL, N, rounds=3) is None
+
+    def test_no_map_no_body(self):
+        """A round whose ancillas come out entangled cannot be annotated — and
+        must not be annotated wrongly."""
+        assert (
+            build_annotated_se(str(TestInterleaving._pair({0})), STEANE_H, STEANE_LOGICAL, N, 3)
+            is None
+        )

--- a/scripts/tests/test_validate_circuits.py
+++ b/scripts/tests/test_validate_circuits.py
@@ -197,6 +197,69 @@ def test_logical_basis_skipped_without_tag(tmp_path):
     assert "no logical-state" in check.detail
 
 
+# One syndrome-extraction round for the repetition code: ancilla 3 reads Z0Z1,
+# ancilla 4 reads Z1Z2.
+REPETITION_SE = "R 3 4\nCX 0 3 1 3 1 4 2 4\nM 3 4\n"
+
+
+def test_syndrome_extraction_is_validated_not_skipped(tmp_path):
+    """The gap this closes: before the third branch existed, a circuit tagged
+    syndrome-extraction matched neither `encoding` nor `state-preparation` and
+    was reported as skipped — i.e. published unchecked."""
+    results = _build(tmp_path, REPETITION_SE, code=REPETITION_CODE, tags=("syndrome-extraction",))
+    assert results[0].circuit_type == "syndrome-extraction"
+    assert results[0].is_skipped is False
+    assert _checks(results)["validate_syndrome_extraction"].status == "passed"
+
+
+def test_syndrome_extraction_failure_is_reported(tmp_path):
+    """Dropping the last CNOT leaves ancilla 4 reading a bare Z1, which is not in
+    the stabilizer group."""
+    results = _build(
+        tmp_path,
+        "R 3 4\nCX 0 3 1 3 1 4\nM 3 4\n",
+        code=REPETITION_CODE,
+        tags=("syndrome-extraction",),
+    )
+    check = _checks(results)["validate_syndrome_extraction"]
+    assert check.status == "failed"
+    assert "outside the stabilizer group" in check.detail
+    assert results[0].passed is False
+
+
+def test_syndrome_extraction_reads_a_sparsely_stored_logical(tmp_path):
+    """A big code's `logical` is stored as nonzero column indices, not 0/1 rows.
+    Handing that mapping straight to numpy is a TypeError, and the check reported
+    an error rather than a result — which is how the [[241,121,3]] hypergraph
+    product code's rounds failed the moment its `logical` crossed the threshold.
+    """
+    from scripts.add_circuit.matrix_format import encode
+
+    code = dict(REPETITION_CODE)
+    code["logical"] = encode(REPETITION_CODE["logical"], threshold=1)
+    assert isinstance(code["logical"], dict), "fixture must be stored sparsely"
+
+    results = _build(tmp_path, REPETITION_SE, code=code, tags=("syndrome-extraction",))
+    assert _checks(results)["validate_syndrome_extraction"].status == "passed"
+
+
+def test_syndrome_extraction_measuring_the_logical_is_rejected(tmp_path):
+    """Reading X0X1X2 is a logical measurement, not a syndrome extraction: it
+    collapses the logical state and reads none of the checks.
+
+    (The `L -> L` branch itself is exercised in test_syndrome_extraction.py —
+    reaching it from here would need a round that measures the full stabilizer
+    group and *still* disturbs a logical, which the group check catches first.)
+    """
+    results = _build(
+        tmp_path,
+        "R 3\nH 3\nCX 3 0 3 1 3 2\nH 3\nM 3\n",
+        code=REPETITION_CODE,
+        tags=("syndrome-extraction",),
+    )
+    assert _checks(results)["validate_syndrome_extraction"].status == "failed"
+
+
 def test_all_skipped_checks_count_as_skipped_not_failed():
     """A circuit whose only check is 'skipped' must report is_skipped=True and
     passed=False, so the summary counts it as skipped rather than a failure."""

--- a/scripts/validate_circuits.py
+++ b/scripts/validate_circuits.py
@@ -1,15 +1,19 @@
 """
-Validate encoding and state-prep circuits against stored code check matrices.
+Validate encoding, state-prep and syndrome-extraction circuits against stored
+code check matrices.
 
-Iterates over all circuit YAML files in data_yaml/circuits/, identifies encoding
-and state-preparation circuits (via tags), and verifies correctness against the
-code's symplectic ``h`` — CSS and non-CSS codes alike:
+Iterates over all circuit YAML files in data_yaml/circuits/, identifies the
+circuit type (via tags), and verifies correctness against the code's symplectic
+``h`` — CSS and non-CSS codes alike:
 
   - Encoding: validate_encoding_h (circuit maps |0...0⟩ to the code space)
             + logical_input_count (the encoder has exactly k free inputs)
   - State-prep: validate_state_prep_h (all stabilizers satisfied)
               + logical_basis (prepares the basis its logical-state tag claims;
                 CSS codes only)
+  - Syndrome extraction: validate_syndrome_extraction_h (the round measures
+                exactly the stabilizer group and preserves the code state and
+                its logicals)
 
 Usage:
     uv run python scripts/validate_circuits.py
@@ -35,6 +39,7 @@ from scripts.add_circuit.circuit_validate import (  # noqa: E402
     _widen,
     validate_encoding_h,
     validate_state_prep_h,
+    validate_syndrome_extraction_h,
 )
 from scripts.add_circuit.code_identify import split_h_to_css  # noqa: E402
 from scripts.add_circuit.matrix_format import decode as decode_matrix  # noqa: E402
@@ -54,7 +59,7 @@ class CheckResult:
 @dataclass
 class CircuitResult:
     stem: str
-    circuit_type: str  # "encoding" | "state-preparation" | "skipped"
+    circuit_type: str  # "encoding" | "state-preparation" | "syndrome-extraction" | "skipped"
     checks: list[CheckResult] = field(default_factory=list)
 
     @property
@@ -93,6 +98,8 @@ def validate_all(data_dir: str = "data_yaml") -> list[CircuitResult]:
             circuit_type = "encoding"
         elif "state-preparation" in tags:
             circuit_type = "state-preparation"
+        elif "syndrome-extraction" in tags:
+            circuit_type = "syndrome-extraction"
         else:
             results.append(CircuitResult(stem=stem, circuit_type="skipped"))
             continue
@@ -145,6 +152,17 @@ def validate_all(data_dir: str = "data_yaml") -> list[CircuitResult]:
         elif circuit_type == "state-preparation":
             _check_state_prep(result, circuit_text, h, n)
             _check_logical_basis(result, circuit_text, h, n, code_data.get("d"), tags)
+        elif circuit_type == "syndrome-extraction":
+            # Decoded here, like `h` above: a large code's `logical` is stored
+            # sparsely, and handing the raw mapping to numpy is a TypeError.
+            stored_logical = code_data.get("logical")
+            _check_syndrome_extraction(
+                result,
+                circuit_text,
+                h,
+                n,
+                None if stored_logical is None else decode_matrix(stored_logical),
+            )
 
         results.append(result)
 
@@ -171,6 +189,35 @@ def _check_state_prep(result: CircuitResult, circuit_text: str, h: np.ndarray, n
             result.checks.append(CheckResult("validate_state_prep", "failed", outcome))
     except Exception as e:
         result.checks.append(CheckResult("validate_state_prep", "error", str(e)))
+
+
+def _check_syndrome_extraction(
+    result: CircuitResult,
+    circuit_text: str,
+    h: np.ndarray,
+    n: int,
+    logical: np.ndarray | None,
+) -> None:
+    """A syndrome-extraction round must measure exactly the stabilizer group and
+    leave the encoded state — logicals included — alone.
+
+    Unlike the prep/encoding checks this cannot be a codespace test: the round
+    acts on an already-encoded state, so there is nothing to simulate it on. It
+    is a *flow* check instead; see ``circuit_validate.measured_stabilizers`` for
+    why the ancilla-to-stabilizer correspondence is derived rather than assumed.
+
+    ``codes.logical`` is passed when present so ``L -> L`` is checked too. It is
+    optional data, and its absence weakens the check rather than invalidating it,
+    so a code without it is still checked on the stabilizers.
+    """
+    try:
+        outcome = validate_syndrome_extraction_h(circuit_text, h, n, logical=logical)
+        if outcome == "passed":
+            result.checks.append(CheckResult("validate_syndrome_extraction", "passed"))
+        else:
+            result.checks.append(CheckResult("validate_syndrome_extraction", "failed", outcome))
+    except Exception as e:
+        result.checks.append(CheckResult("validate_syndrome_extraction", "error", str(e)))
 
 
 def _check_logical_basis(

--- a/src/lib/tag-categories.ts
+++ b/src/lib/tag-categories.ts
@@ -25,7 +25,17 @@ export function categorizeTag(name: string): TagCategoryKey {
   if (FT_TAGS.has(name) || name.startsWith("distance:")) return "ft";
   if (HARDWARE_TAGS.has(name) || name.startsWith("connectivity:") || name.startsWith("device:"))
     return "hardware";
-  if (name.startsWith("prep:") || name.startsWith("verification:")) return "method";
+  // `schedule:` and `decoder:` describe how a syndrome-extraction round was
+  // produced. They pair up: a schedule found by search is co-designed with the
+  // decoder it was scored against, so two rounds for one code can differ only
+  // by `decoder:`.
+  if (
+    name.startsWith("prep:") ||
+    name.startsWith("verification:") ||
+    name.startsWith("schedule:") ||
+    name.startsWith("decoder:")
+  )
+    return "method";
   // `tool:<slug>` tags are derived from each circuit's tool at DB-build time.
   if (name.startsWith("tool:")) return "tools";
   return "other";

--- a/uv.lock
+++ b/uv.lock
@@ -829,7 +829,7 @@ wheels = [
 
 [[package]]
 name = "qecirc-website"
-version = "0.7.0"
+version = "0.7.1"
 source = { virtual = "." }
 dependencies = [
     { name = "mqt-qecc" },


### PR DESCRIPTION
Split out of #135 so the circuits that need syndrome-extraction support are not waiting on one dataset's authors. **This is the machinery only** — no circuits, no importer, no `data_yaml/` change at all.

The pipeline could describe an encoder and a state prep. A round of syndrome extraction fits neither, and there was nothing to check one against.

## What it adds

**`validate_syndrome_extraction_h`** — a round must measure exactly the stabilizer group and leave the encoded state, logicals included, alone.

This cannot be a codespace test the way the prep and encoder checks are: a round acts on an *already-encoded* state, so there is nothing to simulate it on. It is a **stabilizer-flow** check instead, and the ancilla-to-check correspondence is derived rather than assumed — assuming it is how you accept a round that measures the right operators with the wrong ancillas.

**`build_se_round`** (`scripts/add_circuit/syndrome_extraction.py`) — ticks of `(data, ancilla, basis)` into one canonical round. It refuses a tick that reuses a qubit, or an ancilla asked to carry both bases.

**`round_check_matrix`** — which operator *each measurement* reads, which is what placing detectors needs. Deliberately narrow, and returns `None` rather than guessing: no map is better than a wrong one, and nothing in validation depends on it.

**A round's `stim-annotated` body is the memory experiment it belongs to** — reset the data, `REPEAT d` of the round, terminal readout, detectors, observable. Unlike a prep or an encoder, a round is *not* reset-free and has no tableau, so none of the derive/fit machinery may be pointed at it. That distinction is now stated in `CLAUDE.md`, because it is the thing most likely to be got wrong later.

**`schedule:` and `decoder:` join the `method` tag category.** They pair up: a schedule found by search is co-designed with the decoder it was scored against, so two rounds for one code can differ only by `decoder:`.

## One thing moved

`find_sigma.py` — the codeword-based permutation matcher — moves from `data-imports/asyndrome/` into `scripts/add_circuit/`. A code can match a stored one on every cheap invariant and still defeat `find_code_permutation`'s search budget; that happens exactly where you would expect, on topological codes with large automorphism groups whose column invariants barely separate anything. Three importers now need it, so it belongs in the shared package rather than inside one of them. The asyndrome CLI that drives it stays with its import.

## Verification

Deliberately checked **with no syndrome-extraction data present**, which is the point of the split:

- 370 tests, including the full `test_syndrome_extraction.py` suite — the round builder, the flow check, the check map and the annotated memory experiment are all exercised on synthetic fixtures, not on stored circuits
- `npm run validate:circuits` — 479 checked, 479 passed
- `npm run annotate_circuits --dry-run` — 479 unchanged
- `npm run validate:yaml`, `npm run db:create`, `npm run lint`, `npm run format:check`

## What is left behind

#135 keeps the AlphaSyndrome import and its 56 circuits, and can land whenever its authors reply. #136 and #137 rebase onto this instead of onto #135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
