### PR TITLE
docs: replace maintained counts and stale paths with rules that cannot drift

### DIFF
--- a/.claude/commands/add-circuit.md
+++ b/.claude/commands/add-circuit.md
@@ -154,7 +154,7 @@ result = add_circuit(
 print(result.summary())
 ```
 
-Report the files written. The output includes original submission files (`*.original.stim` and `*.original.yaml` in `data_yaml/circuits/originals/`) — these are automatically generated and preserve the pre-canonicalization STIM circuit and check matrices for verification purposes. No user action is needed for these.
+Report the files written. The output includes original submission files — `<code-slug>--<circuit-slug>.original.stim` in `data_yaml/circuits/originals/`, and the submitted check matrices in `data_yaml/matrices/<digest>.yaml`, which is content-addressed and shared by every circuit of the code. These are automatically generated and preserve the pre-canonicalization data for verification purposes. No user action is needed for these.
 
 ---
 
@@ -224,7 +224,7 @@ work is enriched too.
 Then confirm it linked. `npm run db:create` prints:
 
 ```
-Papers: 7, linked to 724 circuits.
+Papers: <n>, linked to <m> circuits.
 ```
 
 and lists any source with no paper behind it. The new circuit must not be in that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,50 @@ the source-of-truth `package.json` version.
   worktrees are created under `.claude/worktrees/` — so every worktree showed up as
   untracked in the main checkout. Corrected, narrowly: `.claude/` itself stays tracked,
   because `.claude/agents/` and `.claude/commands/` are committed.
+- **Six documentation defects, five of them the same defect: a maintained count.** CLAUDE.md
+  said "1028 circuit files", "1019 of 1028" and "one paper backs up to 370 circuits"; each
+  was right the day it was written and wrong within days, three times over as imports landed.
+  Updating them would only reset the clock, so the counts are **gone** and the arguments they
+  supported are stated without one — a paper backs "hundreds" of circuits, and widening
+  `toric code` to "any term" matches "all but a handful" because "code" occurs in nearly every
+  circuit's text. Same treatment for the stale counts in code comments
+  (`index.astro`, `CircuitRow.astro`, `add_circuit/annotate.py`) and for the sample
+  `Papers: N, linked to M circuits.` build output quoted in `docs/database.md` and
+  `/add-circuit`.
+- **CLAUDE.md's static/SSR page lists were wrong on the day they were written**, and read as
+  an inventory: `/favorites` was missing from the static list, `/tools` and five `/api/*`
+  routes from the SSR one. Replaced with the rule that actually decides it — a route that
+  reads SQLite is `prerender = false` — plus examples marked as examples and a pointer to
+  `grep -rn "prerender" src/pages/`, which cannot go stale.
+- **The matrices lived in three places at once, on paper.** They moved to content-addressed
+  `data_yaml/matrices/<digest>.yaml` and no `*.original.yaml` has existed since, but
+  `docs/database.md` still omitted the directory from its tree and filed matrices under
+  `circuits/originals/`, `/add-circuit` still named `*.original.yaml`, and
+  `docs/adding-circuits.md` contradicted **itself** — line 444 against its own "Original
+  submission" section. All four now match CLAUDE.md and the pipeline.
+- **"The pipeline always preserves the original" was never true.** The flag gadgets are
+  written directly with the pipeline helpers, so there is nothing earlier to preserve: they
+  have no `circuit_originals` row and no "Original submission" section, which `index.astro`
+  already knew and the docs did not. Corrected in `docs/adding-circuits.md`,
+  `docs/adding-circuits-agent.md`, `docs/database.md` and CLAUDE.md's schema comment.
+- **The QUITS README pointed at a file in an unmerged branch.**
+  `data-imports/autqec/find_sigma.py` does not exist here — that import is still PR #127 —
+  so a reader had no way to reproduce the two BB permutations. The README now says so
+  outright and points at the matcher that _is_ in the repo
+  (`scripts/add_circuit/find_sigma.py`, with `data-imports/qldpc/find_sigma.py` as the
+  worked example of driving it); `sigma_precomputed.json`'s two provenance strings say the
+  same. The permutations themselves are untouched, and `add_circuit` still re-verifies each
+  by row-space equality on every run — which is what makes shipping them acceptable.
+- **The agent doc's "Current tags" table listed about a third of the vocabulary.** It was
+  missing seven code tags (`LDPC`, `topological`, `subsystem`, `bivariate-bicycle-code`, …)
+  and six circuit tags and families (`gadget`, `partial-ft`, `x-type`/`z-type`, `distance:*`,
+  `circuit-distance:*`, …) while telling the agent it may only use tags that already exist.
+  A second copy of a table that imports extend was never going to hold, so it is replaced by
+  the query against `tags`/`taggings` that returns the real vocabulary, plus the shape of it
+  in prose.
+- **`scripts/annotate_circuits.py` described itself as state-prep/encoding-only** though it
+  has dispatched to `build_annotated_se` for syndrome extraction since that landed. Its
+  docstring now covers both branches and why a round cannot be reset-free.
 - **The qLDPC rounds were never measured for circuit-level distance**, and the docs say an
   absent `circuit-distance:` tag means the search ran out of budget. It did not: 26 of the
   28 settle, 20 of them in under a second. `scripts/measure_circuit_distance.py` arrived in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ Circuits also have numeric **metrics** for filtering: `gate_count`, `depth`, `qu
 A circuit taken from a published work also links to a **paper**, which is what makes it
 findable by title, author or arXiv id. The link is **derived, not declared**: `circuits.source`
 already holds the provenance link, so `create_database.mjs` matches it against each paper's
-`url`/`arxiv_id`/`doi` rather than making 1028 circuit files repeat it. Add a paper and every
+`url`/`arxiv_id`/`doi` rather than making every circuit file repeat it. Add a paper and every
 circuit citing it is enriched at the next build; a source with no paper is not an error
 (`source: circuit-synth` names a tool, not a work), it just leaves the circuit searchable by
 URL alone. Both the build and `validate:yaml` report such sources.
@@ -99,10 +99,12 @@ circuit_bodies
 circuit_originals
   id, circuit_id → circuits (UNIQUE),
   original_stim, original_h, original_logical
-  -- pre-canonicalization data as submitted by contributors
+  -- pre-canonicalization data as submitted by contributors — NOT every
+  --   circuit has a row: a circuit written directly by the pipeline helpers
+  --   (the flag gadgets) was never submitted in some other form
   -- matrix fields are JSON-encoded (same format as codes.h / codes.logical)
-  -- original_stim from data_yaml/circuits/originals/ (one per circuit);
-  --   matrices from data_yaml/matrices/<digest>.yaml, shared by every circuit
+  -- original_stim from data_yaml/circuits/originals/, one file per circuit
+  --   that has one; matrices from data_yaml/matrices/<digest>.yaml, shared by every circuit
   --   of a code and referenced by the circuit YAML's `original_matrices`.
   --   create_database.mjs resolves the reference, so this table is unchanged.
 
@@ -178,8 +180,9 @@ A maintainer reviews the issue, then uses the ingestion pipeline to add the circ
 
 **Rendering strategy — Astro v7 (static default, SSR opt-in):**
 
-- Static pages: 404, `/about`, `/contribute`, `/privacy`, `/legal` (pre-rendered at build time)
-- SSR pages (`prerender = false`): the landing page `/`, all `/codes/...` and `/circuits/...` routes, `/search`, `/api/search` (rendered on request, read from SQLite)
+- **The rule: a route that reads SQLite is `prerender = false`; everything else stays static.** `grep -rn "prerender" src/pages/` is the authoritative list — an enumeration here goes stale the day a page is added, so what follows is examples only.
+  - Static (pre-rendered at build time): the prose pages (`/about`, `/contribute`, `/privacy`, `/legal`), `/404`, and `/favorites`, which reads `localStorage` and nothing else.
+  - SSR (`prerender = false`, rendered on request): `/`, `/codes/...`, `/circuits/...`, `/tools`, `/search`, every `/api/*` endpoint, and the machine-facing `sitemap.xml` / `llms.txt` / `robots.txt`.
   - **`/` must stay SSR.** `@astrojs/node` serves pre-rendered pages straight from disk without running middleware, so a static `/` would silently lose the `s-maxage` edge caching (see below). The DB is baked at build time either way, so pre-rendering buys nothing here.
 - **Unknown id/slug → `return notFound()`** (`src/lib/not-found.ts`), which returns a bodiless 404; Astro fills the body with the prerendered /404 page. Never `Astro.rewrite("/404")` from an SSR page — /404 is prerendered, so the rewrite finds no component instance and 500s (`scripts/smoke.sh` guards this).
 - Client-side JS: search bar (debounced fetch), circuit row expand/collapse, format switching, favorites (toggle/filter/export/import), CodeBlock copy/download, lazy-loaded circuit bodies on code pages (fetched from `/api/circuits/[qec_id]/bodies` on first row expand), and filtering/sorting on the listing pages (`list-filter-client.ts` over `data-metrics`/`data-tags` row attributes — the server always renders the canonical full list and ignores filter params; `/api/download` still parses them)
@@ -198,7 +201,7 @@ A maintainer reviews the issue, then uses the ingestion pipeline to add the circ
 
 **Do not "unify" these by pointing the quick-search at the FTS index.** LIKE matches mid-word (`ycle` → Bivariate Bicycle Code), which token-based FTS cannot — that is what makes a type-ahead usable. There is also no FTS index for codes or tools, and pulling `notes` into a 10-item navigation list would surface circuits that merely mention the term. Enter with nothing highlighted hands over to `/search`; that is where the two meet.
 
-**Paper text is `/search`-only, for the same reason.** One paper backs up to 370 circuits, so matching a title in a 10-item navigation dropdown would fill it with near-identical rows and bury the code or tool the user was actually jumping to. A paper is something you _find circuits by_, not something you navigate to — there is no paper page to land on.
+**Paper text is `/search`-only, for the same reason.** A single paper can back hundreds of circuits, so matching a title in a 10-item navigation dropdown would fill it with near-identical rows and bury the code or tool the user was actually jumping to. A paper is something you _find circuits by_, not something you navigate to — there is no paper page to land on.
 
 `/search` ranks by BM25 over the `circuit_search` FTS5 table (migrations `016`–`019`), which `scripts/db/create_database.mjs` repopulates on every build. Its **nine columns** are `circuit_id, name, code_name, aliases, related, tags, code_tags, paper, notes` — and that order is load-bearing (see `BM25_WEIGHTS` below).
 
@@ -223,7 +226,7 @@ What a circuit is findable by, and where each comes from:
    3. any term, `STRICT_COLUMNS` — `partial`
    4. any term, allowing `related`
 
-   (2) precedes (3) deliberately: widening `toric code` to "any term" matches every circuit containing "code" (1019 of 1028), whereas allowing `related` returns the 122 surface codes actually meant.
+   (2) precedes (3) deliberately: widening `toric code` to "any term" matches all but a handful of circuits in the library — "code" occurs in nearly every one's text — whereas allowing `related` returns only the surface codes actually meant.
 
 **Column weights and the strict column set are DERIVED, not restated** (`src/lib/queries/search-schema.ts`). Both used to be hand-maintained constants, and both drifted from the table within a week despite shouty comments. `PRAGMA table_info(circuit_search)` returns the real columns in declaration order — which is exactly what `bm25()` wants — so:
 
@@ -277,7 +280,7 @@ This keeps the site fast and simple while scaling comfortably to thousands of ci
 │   ├── papers/            # One YAML per cited paper (e.g. zen-2024-rl-state-prep.yaml)
 │   ├── codes/             # One YAML per code (e.g. steane-code.yaml)
 │   ├── circuits/          # YAML + body files per circuit (e.g. steane-code--standard-encoding.yaml/.stim)
-│   │   └── originals/     # Original (pre-canonicalization) STIM, one per circuit
+│   │   └── originals/     # Original (pre-canonicalization) STIM, where one was submitted
 │   └── matrices/          # Submitted check matrices, stored once, content-addressed
 ├── .github/
 │   └── ISSUE_TEMPLATE/    # Circuit submission issue template

--- a/data-imports/quits/README.md
+++ b/data-imports/quits/README.md
@@ -141,9 +141,20 @@ BB [[108,8,10]] and [[144,12,12]] already exist in the library under a different
 and the dedup permutation search exceeds its budget on them — these codes have enormous
 automorphism groups. The permutations in [`sigma_precomputed.json`](sigma_precomputed.json) were
 not recomputed here: **QUITS labels these codes exactly as autqec does** — identical X and Z row
-spaces, verified, no X↔Z swap — so the σ derived by `data-imports/autqec/find_sigma.py` applies
-unchanged. `add_circuit` re-verifies each one by row-space equality on every run, so a stale
-entry fails loudly rather than silently.
+spaces, verified, no X↔Z swap — so the σ derived for the autqec import
+([arXiv:2409.18175](https://arxiv.org/abs/2409.18175)) applies unchanged.
+
+That import is **not in this repository** — it is still open as PR #127, and so is the
+`find_sigma.py` driver that produced these two permutations. To recompute them from scratch
+here you need the matcher itself, which _is_ in the repo:
+[`scripts/add_circuit/find_sigma.py`](../../scripts/add_circuit/find_sigma.py), shared with the
+qLDPC and AlphaSyndrome imports. [`data-imports/qldpc/find_sigma.py`](../qldpc/find_sigma.py) is
+the closest worked example of driving it — feed it this code's `Hx`/`Hz` (from `codes.py`) and
+the stored code's, and it returns the same σ or fails.
+
+`add_circuit` re-verifies each entry by row-space equality on every run, so a stale
+entry fails loudly rather than silently — which is what makes shipping a permutation whose
+producer lives in an unmerged branch acceptable rather than merely convenient.
 
 ### Three invariant collisions, all refuted
 

--- a/data-imports/quits/sigma_precomputed.json
+++ b/data-imports/quits/sigma_precomputed.json
@@ -8,7 +8,7 @@
       34, 51, 11, 27, 10, 93, 30, 14, 13, 36, 20, 19, 8, 7, 24
     ],
     "stored_slug": "108-8-10",
-    "provenance": "Derived by data-imports/autqec/find_sigma.py for the autqec import (arXiv:2409.18175). QUITS labels this code identically to autqec (identical X and Z row spaces), so the same permutation applies. add_circuit re-verifies it by row-space equality on every run."
+    "provenance": "Derived for the autqec import (arXiv:2409.18175), whose find_sigma.py driver is not in this repository - it is still open as PR #127. The matcher it calls is scripts/add_circuit/find_sigma.py; see data-imports/qldpc/find_sigma.py for a worked example of driving it. QUITS labels this code identically to autqec (identical X and Z row spaces), so the same permutation applies. add_circuit re-verifies it by row-space equality on every run."
   },
   "bb-144-12-12": {
     "sigma": [
@@ -21,6 +21,6 @@
       29, 3, 39, 116, 16, 35, 12, 122, 41, 19, 24, 25
     ],
     "stored_slug": "144-12-12",
-    "provenance": "Derived by data-imports/autqec/find_sigma.py for the autqec import (arXiv:2409.18175). QUITS labels this code identically to autqec (identical X and Z row spaces), so the same permutation applies. add_circuit re-verifies it by row-space equality on every run."
+    "provenance": "Derived for the autqec import (arXiv:2409.18175), whose find_sigma.py driver is not in this repository - it is still open as PR #127. The matcher it calls is scripts/add_circuit/find_sigma.py; see data-imports/qldpc/find_sigma.py for a worked example of driving it. QUITS labels this code identically to autqec (identical X and Z row spaces), so the same permutation applies. add_circuit re-verifies it by row-space equality on every run."
   }
 }

--- a/docs/adding-circuits-agent.md
+++ b/docs/adding-circuits-agent.md
@@ -60,7 +60,7 @@ The agent then enriches the generated YAML with tags:
 
 The agent shows you the final YAML files. You can request edits. Once you approve, it rebuilds the database with `npm run db:create`.
 
-The pipeline also preserves the original (pre-canonicalization) STIM circuit and check matrices in `data_yaml/circuits/originals/`. These are viewable on the circuit detail page under "Original submission".
+Where you submitted a circuit in some other form, the pipeline also preserves it: the pre-canonicalization STIM in `data_yaml/circuits/originals/`, the check matrices in `data_yaml/matrices/<digest>.yaml` (content-addressed, so every circuit of one code shares one file). Both are viewable on the circuit detail page under "Original submission".
 
 ## What you need to provide
 
@@ -79,11 +79,15 @@ The pipeline also preserves the original (pre-canonicalization) STIM circuit and
 
 ## Tag vocabulary
 
-The agent only uses tags that already exist in the library. Current tags:
+The agent only uses tags that already exist in the library. **The `tags` table is the vocabulary** — reproducing it here would be a second copy to keep in step, and imports add to it faster than a doc gets edited. Ask the database:
 
-| Level   | Tags                                                                                                                                                                                                                         |
-| ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Code    | `CSS`, `stabilizer`, `self-dual`, `color-code`, `surface-code`, `concatenated`                                                                                                                                               |
-| Circuit | `encoding`, `state-preparation`, `syndrome-extraction`, `ft`, `non-ft`, `flag`, `deterministic`, plus structured tags `logical-state:*`, `connectivity:*`, `device:*`, `prep:*`, `verification:*`, `schedule:*`, `decoder:*` |
+```bash
+sqlite3 data/qecirc.db \
+  "SELECT g.taggable_type, t.name, COUNT(*) FROM tags t
+     JOIN taggings g ON g.tag_id = t.id
+    GROUP BY 1, 2 ORDER BY 1, 3 DESC;"
+```
 
-`tool:*` tags are **not** set by hand — they are derived from a circuit's `tool` field when the database is built. If the Zoo or user suggests any other tag not already in the library, the agent will ask before adding it.
+What you will find, in shape rather than in full: **code** tags name what kind of code it is (`CSS`, `LDPC`, `topological`, `self-dual`, `surface-code`, …); **circuit** tags name what the circuit does and how well (`encoding`, `state-preparation`, `syndrome-extraction`, `ft`/`partial-ft`/`non-ft`, `flag`, …); and **structured `key:value` families** carry the parameters — `distance:*` and `circuit-distance:*` (different numbers, see CLAUDE.md), `logical-state:*`, `schedule:*`, `connectivity:*`, `device:*`, `prep:*`, `verification:*`, `decoder:*`.
+
+`tool:*` tags are **not** set by hand — they are derived from a circuit's `tool` field when the database is built. If the Zoo or user suggests any tag the query above does not return, the agent will ask before adding it.

--- a/docs/adding-circuits.md
+++ b/docs/adding-circuits.md
@@ -441,7 +441,7 @@ Each `rebuild_all.py` classifies without writing by default and imports with `--
 - Compact STIM, QASM, and Cirq format conversions
 - Crumble and Quirk visualization URLs
 - **Circuit ID (`qec_id`)**: auto-assigned as `max(existing IDs) + 1` — permanent, never reused
-- **Original submission data**: the pipeline always preserves the original (pre-canonicalization) STIM circuit and the contributor-provided symplectic stabilizer / logical matrices in `data_yaml/circuits/originals/`. These are displayed on the circuit detail page under "Original submission (before canonicalization)"; the Hx/Hz/Lx/Lz view is derived in the UI.
+- **Original submission data**: where a circuit was submitted in some other form, the pipeline preserves the pre-canonicalization STIM in `data_yaml/circuits/originals/` and the contributor's symplectic stabilizer / logical matrices in `data_yaml/matrices/<digest>.yaml` (see [Original submission](#original-submission) below). A circuit written directly with the pipeline helpers — the flag gadgets are — has no original, and the detail page's "Original submission (before canonicalization)" section is simply absent for it. The Hx/Hz/Lx/Lz view is derived in the UI.
 - Dedup: if the code already exists, the pipeline detects qubit ordering differences and relabels the circuit to match. Check `AddCircuitResult.qubit_permutation` to see if relabeling was applied (`None` = no relabeling, `list` = permutation applied)
 - Use `find_existing_code_full()` to check for qubit permutations before generating files
 
@@ -519,10 +519,12 @@ body cannot be: its resets and measurements are the circuit.
 ### Original submission
 
 The pipeline preserves what a circuit was submitted with, before any canonicalization or
-qubit relabeling. It lives in two places, because the two halves have different owners:
+qubit relabeling. There is nothing to preserve for a circuit the pipeline helpers wrote
+themselves — the flag gadgets have no original — but where there is, it lives in two
+places, because the two halves have different owners:
 
 - `data_yaml/circuits/originals/<code-slug>--<circuit-slug>.original.stim` — the STIM
-  circuit as submitted. Per circuit, since every circuit has its own.
+  circuit as submitted. Per circuit, since no two circuits share one.
 - `data_yaml/matrices/<digest>.yaml` — the contributor's symplectic stabilizer / logical
   matrices. **Shared**: every circuit of one code was submitted against the same matrices,
   so they are written once and named by a content digest, and the circuit YAML points at

--- a/docs/database.md
+++ b/docs/database.md
@@ -30,9 +30,16 @@ data_yaml/
 ├── tools/              # one YAML file per tool
 ├── papers/             # one YAML file per cited paper
 ├── codes/              # one YAML file per code
-└── circuits/           # YAML metadata + body files per circuit
-    └── originals/      # original (pre-canonicalization) STIM and matrices
+├── circuits/           # YAML metadata + body files per circuit
+│   └── originals/      # original (pre-canonicalization) STIM, where one was submitted
+└── matrices/           # submitted check matrices, content-addressed and shared
 ```
+
+The two halves of a submission live apart because they have different owners: the
+STIM is per circuit, while the matrices a circuit was submitted against are the same
+for every circuit of one code, so they are written once as
+`data_yaml/matrices/<digest>.yaml` and referenced by the circuit YAML's
+`original_matrices: <digest>`.
 
 To edit existing data, modify the YAML files directly and rebuild:
 
@@ -65,7 +72,7 @@ The build prints how many circuits linked, and lists any link-shaped `source` wi
 behind it:
 
 ```
-Papers: 8, linked to 780 circuits.
+Papers: <n>, linked to <m> circuits.
 ```
 
 Those unlinked circuits still render and still search by URL; they just cannot be found by
@@ -73,7 +80,10 @@ title or author. `npm run validate:yaml` reports the same thing as a warning.
 
 ## Original Circuit Data
 
-The `circuit_originals` table stores pre-canonicalization data for each circuit:
+The `circuit_originals` table stores pre-canonicalization data for the circuits that have
+any. Not every circuit does — one written directly by the pipeline helpers, as the flag
+gadgets are, was never submitted in some other form, and the detail page simply omits the
+section for it.
 
 | Column             | Description                                            |
 | ------------------ | ------------------------------------------------------ |
@@ -82,4 +92,4 @@ The `circuit_originals` table stores pre-canonicalization data for each circuit:
 | `original_h`       | JSON-encoded symplectic stabilizer matrix as submitted |
 | `original_logical` | JSON-encoded symplectic logical operators as submitted |
 
-The Hx/Hz/Lx/Lz CSS view is derived from `original_h` / `original_logical` at render time; it is not stored. This data is populated from `data_yaml/circuits/originals/` during `npm run db:create` and displayed on the circuit detail page (`/circuits/[qec_id]`) under "Original submission (before canonicalization)".
+The Hx/Hz/Lx/Lz CSS view is derived from `original_h` / `original_logical` at render time; it is not stored. `original_stim` is populated from `data_yaml/circuits/originals/` and the matrix columns from `data_yaml/matrices/<digest>.yaml` (resolved through the circuit YAML's `original_matrices` digest) during `npm run db:create`, and both are displayed on the circuit detail page (`/circuits/[qec_id]`) under "Original submission (before canonicalization)".

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qecirc-website",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qecirc-website",
-      "version": "0.7.6",
+      "version": "0.7.7",
       "license": "MIT",
       "dependencies": {
         "@astrojs/node": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qecirc-website",
   "type": "module",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "license": "MIT",
   "scripts": {
     "dev": "astro dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qecirc-website"
-version = "0.7.6"
+version = "0.7.7"
 description = "QECirc — quantum error correction circuit library"
 license = "MIT"
 requires-python = ">=3.13"

--- a/scripts/add_circuit/annotate.py
+++ b/scripts/add_circuit/annotate.py
@@ -2,8 +2,8 @@
 
 The stored ``stim`` body is reset-free and unannotated — ``to_tableau()`` and the
 derive/fit machinery need a circuit with no resets, and it leaves the ``|0...0>``
-input implied. (It is not gate-only: 399 of 834 bodies carry flag or verification
-measurements, which are part of the circuit.) This module builds a *separate*
+input implied. (It is not gate-only: a large share of bodies carry flag or
+verification measurements, which are part of the circuit.) This module builds a *separate*
 ``stim-annotated`` body stating what the stored one leaves out: an explicit reset
 prologue, then the body verbatim, then — where derivable — a terminal readout and
 the deterministic stabilizer outcomes as ``DETECTOR``s.
@@ -474,8 +474,8 @@ def strip_readout(circ: stim.Circuit) -> stim.Circuit:
     leaving it implied.
 
     Only the *added* epilogue goes. Pre-existing mid-circuit measurements are
-    part of the circuit (399 of 834 bodies carry flag/verification measurements)
-    and must survive. :func:`build_annotated` appends exactly one readout
+    part of the circuit — a large share of bodies carry flag/verification
+    measurements — and must survive. :func:`build_annotated` appends exactly one readout
     instruction, last, so after the annotations are dropped it is the final
     instruction — anything earlier belongs to the body.
 

--- a/scripts/annotate_circuits.py
+++ b/scripts/annotate_circuits.py
@@ -1,10 +1,17 @@
 """
-Backfill `stim-annotated` bodies for state-prep and encoding circuits.
+Backfill `stim-annotated` bodies.
 
-Writes `data_yaml/circuits/<stem>.stim-annotated` for every state-prep and
-encoding circuit: a reset prologue stating the `|0...0>` input, then the body,
-then — where a terminal readout basis exists — the readout and its detectors.
-Non-CSS codes get the prologue alone (see `annotate.build_annotated`).
+Writes `data_yaml/circuits/<stem>.stim-annotated`, and what it writes depends on
+what the circuit is:
+
+- **State-prep and encoding** — a reset prologue stating the `|0...0>` input,
+  then the body, then — where a terminal readout basis exists — the readout and
+  its detectors. Non-CSS codes get the prologue alone (see
+  `annotate.build_annotated`).
+- **Syndrome extraction** — the memory experiment the round belongs to: reset
+  the data, `REPEAT d` of the round, terminal readout, detectors, observable
+  (see `annotate.build_annotated_se`). A round is not reset-free and has no
+  tableau, so none of the derive/fit machinery is pointed at it.
 
 Also rewrites both Crumble links in the circuit YAML. `crumble_url` follows what
 the STIM tab shows by default, which now carries the prologue, so leaving it

--- a/src/components/CircuitRow.astro
+++ b/src/components/CircuitRow.astro
@@ -212,9 +212,10 @@ const stimFilename = buildStimFilename({
 
       {circuit.notes && (
         <div class="notes-wrapper">
-          {/* break-words: 311 of the 756 circuits with notes cite a source path
-              of 100+ characters and no spaces, which `normal` overflow-wrap has
-              nowhere to break -- it runs straight out of the column. */}
+          {/* break-words: notes routinely cite a source path dozens of
+              characters long and with no spaces in it, which `normal`
+              overflow-wrap has nowhere to break -- it runs straight out of the
+              column. */}
           <p class="notes-text text-sm text-gray-600 dark:text-gray-400 whitespace-pre-line break-words line-clamp-1">{circuit.notes}</p>
           <button
             class="notes-toggle text-xs text-gray-500 dark:text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 cursor-pointer mt-0.5 hidden"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -102,16 +102,17 @@ const EXAMPLE_CIRCUIT_TAGS = EXAMPLE_CODE
   : [];
 
 // A real circuit for the detail-page preview. Not simply the newest one: the
-// step promises Crumble and Quirk, and those links are per-circuit (781 of 1028
-// have them), so a reader clicking through to one without them would find the
-// step had oversold. Prefer a recent circuit that actually has both.
+// step promises Crumble and Quirk, and those links are per-circuit -- a sizeable
+// minority of circuits carry neither -- so a reader clicking through to one
+// without them would find the step had oversold. Prefer a recent circuit that
+// actually has both.
 const EXAMPLE_CIRCUIT = getLatestCircuits(20).find((c) => c.crumble_url && c.quirk_url) ?? latest[0];
 
 // Derived from the example's real bodies through the same splitAnnotated the
 // FormatSwitcher tabs use, so the chips are exactly the tabs the linked page
 // shows -- `stim-annotated` is a view of the STIM body, not a format, and gets
-// no tab. Hardcoding STIM/QASM/Cirq would lie for the ~140 circuits that have
-// no Cirq conversion.
+// no tab. Hardcoding STIM/QASM/Cirq would lie for the several hundred circuits
+// that have no Cirq conversion.
 const EXAMPLE_FORMATS = EXAMPLE_CIRCUIT
   ? splitAnnotated(getBodiesForCircuits([EXAMPLE_CIRCUIT.id]).get(EXAMPLE_CIRCUIT.id) ?? []).tabs.map(
       (b) => b.format.toUpperCase(),

--- a/uv.lock
+++ b/uv.lock
@@ -829,7 +829,7 @@ wheels = [
 
 [[package]]
 name = "qecirc-website"
-version = "0.7.6"
+version = "0.7.7"
 source = { virtual = "." }
 dependencies = [
     { name = "mqt-qecc" },


### PR DESCRIPTION
Seven documentation defects, verified against `data/qecirc.db` rebuilt from `main`
(**972 circuits, 84 codes, 12 papers** at time of writing). No behaviour changes — prose,
comments and two JSON provenance strings only.

Where a count was the defect, it is **removed**, not refreshed. Every one of these was correct
the day it was written.

## 1. Maintained counts in CLAUDE.md

| Line | Said | Actual today | Now says |
| --- | --- | --- | --- |
| `:35` | "1028 circuit files" | **972** | "every circuit file" |
| `:226` | "1019 of 1028" | **963 of 972** (`related:toric` → **122**) | "all but a handful … whereas allowing `related` returns only the surface codes actually meant" |
| `:201` | "One paper backs up to 370 circuits" | max **314** per paper | "A single paper can back hundreds of circuits" |

Each argument is preserved: don't make every circuit file repeat its paper link; widening to
"any term" matches nearly everything whereas `related` returns just the surface codes; a paper
backing hundreds of circuits would flood a 10-item dropdown.

Swept the repo for the same defect. Also fixed: the sample `Papers: 8, linked to 780 circuits.`
in `docs/database.md` and `Papers: 7, linked to 724 circuits.` in `/add-circuit` → `<n>`/`<m>`
(actual build now prints `Papers: 12, linked to 827 circuits.`). **Left alone:** CHANGELOG.md
and `docs/superpowers/` (records of a moment) and the `data-imports/*/README.md` counts, which
describe one import's fixed contents and do not rot.

## 2. Rendering lists read as an inventory and were wrong (`:181-182`)

`grep -rn "prerender" src/pages/` and the build's own prerender output agree: static is exactly
`/404`, `/about`, `/contribute`, `/favorites`, `/legal`, `/privacy`. `favorites.astro` is
`prerender = true` and was **missing from the static list**; `tools/index.astro` is
`prerender = false` and was missing from the SSR list, as were **six** `/api/*` routes
(`circuits`, `circuits/[qec_id]/bodies`, `circuits/[qec_id]/originals`,
`codes/[slug]/matrices`, `download`, `search`).

Restructured so it cannot drift: states the rule (**a route that reads SQLite is
`prerender = false`**), gives both sides as explicitly-marked examples, and points at the grep.

## 3. Matrices documented in three contradictory places

Reality: **137** files in `data_yaml/matrices/`, **0** `*.original.yaml` anywhere.

- `docs/database.md:29-35` omitted `data_yaml/matrices/` from its tree and filed matrices under `circuits/originals/` — tree corrected, plus a sentence on why the two halves live apart.
- `docs/database.md:85` repeated it — corrected.
- `docs/adding-circuits.md:444` contradicted its own "Original submission" section at `:526` — `:444` now defers to it by link.
- Also found and fixed: `docs/adding-circuits-agent.md:63`, and `.claude/commands/add-circuit.md:157`, which named a `*.original.yaml` that has not existed since the move.

`CLAUDE.md:104-106` and `docs/adding-circuits.md:519-534` were already right and were the reference.

## 4. "The pipeline always preserves the original" — false for 298 circuits

**674 of 972** circuits have an original (674 files in `data_yaml/circuits/originals/`); the
**298** flag gadgets have none — they are written directly with the pipeline helpers.
`src/pages/index.astro:121` already had this right.

Fixed `docs/adding-circuits.md:444` and `:526`, and the same overstatement in
`CLAUDE.md:104` / `:280` ("one per circuit") and `docs/database.md`.

## 5. `data-imports/quits/README.md:144` linked to a file in an unmerged branch

`data-imports/autqec/find_sigma.py` **does not exist** — that import is still PR #127. Nor does
`data-imports/quits/find_sigma.py`. What exists: `scripts/add_circuit/find_sigma.py` (the shared
matcher), with `data-imports/qldpc/find_sigma.py` and `data-imports/asyndrome/find_sigma.py` as
drivers.

The honest description, now in the README: the σ were derived for the autqec import, whose
driver is not in this repo, and to recompute them here you drive the shared matcher — with the
qLDPC driver as the worked example. `add_circuit` re-verifying by row-space equality on every
run is what makes shipping them acceptable.

`sigma_precomputed.json`: **only the two `provenance` strings changed** (`git diff --stat`:
2 insertions, 2 deletions). Permutations untouched; re-verified the file parses and both σ are
valid permutations of length 108 and 144.

## 6. Stale comments and an incomplete table

**(a)** `docs/adding-circuits-agent.md:82-88`'s "Current tags" table listed 6 code tags and 7
circuit tags. The DB has **13 code tags** (missing: `LDPC`, `topological`, `subsystem`,
`hamming-code`, `bivariate-bicycle-code`, `triorthogonal`, `no-code`) and **12 unstructured
circuit tags plus 10 `key:value` families** (missing: `gadget`, `partial-ft`, `x-type`,
`z-type`, `1D-AOD`, `distance:*`, `circuit-distance:*`, `tool:*`). Replaced with the
`tags`/`taggings` query that returns the live vocabulary, plus its shape in prose — a second
copy was never going to hold.

**(b)** Stale counts in comments, all reworded to carry none:

| Location | Said | Verified actual |
| --- | --- | --- |
| `src/pages/index.astro:105` | "781 of 1028" have Crumble+Quirk | **725 of 972**; **247** have neither |
| `src/pages/index.astro:113` | "~140 circuits" with no Cirq | **278** |
| `src/components/CircuitRow.astro:215` | "311 of the 756 circuits with notes" cite a 100+ char path | **895** have notes; **375** carry a 40+ char unbroken token, **40** a 100+ one |
| `scripts/add_circuit/annotate.py:5,478` | "399 of 834 bodies" | **359 of 813** prep/encoding bodies carry a measurement |

**(c)** `scripts/annotate_circuits.py`'s docstring called it state-prep/encoding-only though it
dispatches to `build_annotated_se` at `:124`. Now documents both branches and why a syndrome
round cannot be reset-free.

## Validation

- `npm run format` — clean, no reformatting of touched files
- `npm run validate:yaml` — All YAML files valid
- `npm run build` — succeeds; prerendered routes confirm the static list above
- `uv run ruff check scripts/` + `ruff format --check` — pass
- Relative-link/anchor check over all 50 tracked markdown files — **0 broken**, including the new `#original-submission` anchor and the new `../../scripts/add_circuit/find_sigma.py` / `../qldpc/find_sigma.py` links
- `sigma_precomputed.json` re-parsed after edit

## Version

Patch bump `0.7.5` → `0.7.6` per CLAUDE.md's Versioning section (docs updates are a patch):
`package.json`, `pyproject.toml`, `uv.lock`, `package-lock.json`. CHANGELOG entry added under
`## Unreleased`; the rest of the CHANGELOG's structure is untouched.

## Not touched

`src/`, `scripts/`, `data_yaml/`, `.github/`, `.gitignore` are owned elsewhere — the only
edits there are the stale **comments** listed above. `scripts/tests/test_add_paper.py:46`
carries a "109 circuits" count in a test comment; out of scope, flagging it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
