### PR TITLE
chore(ci): make the pre-commit hooks safe, then run them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,12 +53,60 @@ jobs:
         with:
           version: "0.11.x"
           python-version: "3.13"
+          enable-cache: true
       - run: uv lock --check
         env:
           UV_NO_CONFIG: "1"
       - run: uv sync
-      - run: uv run ruff check scripts/
-      - run: uv run ruff format --check scripts/
-      - run: uv run pytest --cov=scripts/add_circuit --cov-fail-under=60
+      # data-imports/ too: every importer lives there, and it is where the
+      # ingestion bugs have actually been. It was clean when this was widened,
+      # so the widening costs nothing and stops the next one drifting.
+      - run: uv run ruff check scripts/ data-imports/
+      - run: uv run ruff format --check scripts/ data-imports/
+      # The gate used to measure `scripts/add_circuit` alone at 60%, which left
+      # the four top-level maintainer scripts unmeasured — including
+      # validate_circuits.py, which CI runs as its own step and which was
+      # carrying a live bug. Measuring all five gives 85%, so the bar goes to 80.
+      - run: >
+          uv run pytest
+          --cov=scripts/add_circuit
+          --cov=scripts/validate_circuits.py
+          --cov=scripts/annotate_circuits.py
+          --cov=scripts/measure_circuit_distance.py
+          --cov=scripts/add_paper.py
+          --cov-fail-under=80
       # Same as `npm run validate:circuits`, invoked directly (no node in this job).
       - run: uv run python scripts/validate_circuits.py
+      # A `stim-annotated` body is derived from its circuit, but it is committed
+      # rather than generated at build time — so editing a circuit and not
+      # re-running the annotator ships a memory experiment describing the
+      # previous schedule, and nothing else would notice. The committed tree has
+      # to be a fixed point of the annotator.
+      - name: stim-annotated bodies are up to date
+        run: |
+          out=$(uv run python scripts/annotate_circuits.py --dry-run)
+          echo "$out"
+          if echo "$out" | grep -qE '^ *[0-9]+ +written$'; then
+            echo "::error::stim-annotated bodies are stale. Run: uv run python scripts/annotate_circuits.py"
+            exit 1
+          fi
+
+  # The hooks in .pre-commit-config.yaml only ever ran for contributors who had
+  # run `pre-commit install`, so a fork or a first-time contributor bypassed
+  # every one of them. `typos`, `check-added-large-files` and `uv-lock` are the
+  # ones worth having on every PR.
+  #
+  # `prettier` is skipped: it is the one hook that needs node_modules, and the
+  # `quality` job already runs the same check via `npm run format:check`.
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.11.x"
+          python-version: "3.13"
+          enable-cache: true
+      - run: uvx pre-commit run --all-files --show-diff-on-failure
+        env:
+          SKIP: prettier

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,8 @@ jobs:
       - run: uv run ruff format --check scripts/ data-imports/
       # The gate used to measure `scripts/add_circuit` alone at 60%, which left
       # the four top-level maintainer scripts unmeasured — including
-      # validate_circuits.py, which CI runs as its own step and which was
-      # carrying a live bug. Measuring all five gives 85%, so the bar goes to 80.
+      # validate_circuits.py, which runs in its own job and which was carrying a
+      # live bug. Measuring all five gives 85%, so the bar goes to 80.
       - run: >
           uv run pytest
           --cov=scripts/add_circuit
@@ -75,13 +75,43 @@ jobs:
           --cov=scripts/measure_circuit_distance.py
           --cov=scripts/add_paper.py
           --cov-fail-under=80
-      # Same as `npm run validate:circuits`, invoked directly (no node in this job).
+
+  # The two whole-library sweeps below are their own jobs rather than steps of
+  # `python-tests`, because each one parses all ~970 circuits through stim and
+  # they share nothing but the checkout. Run in sequence they cost 246 s + 236 s
+  # on top of the 78 s test run — 9m35s for the job. In parallel the wall clock
+  # is the slowest of the three (~4m), which is faster than this workflow was
+  # before either check existed. The price is two extra `uv sync` setups, ~8 s
+  # each, on runners that cost nothing to run concurrently.
+
+  # Same as `npm run validate:circuits`, invoked directly (no node in this job).
+  validate-circuits:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.11.x"
+          python-version: "3.13"
+          enable-cache: true
+      - run: uv sync
       - run: uv run python scripts/validate_circuits.py
-      # A `stim-annotated` body is derived from its circuit, but it is committed
-      # rather than generated at build time — so editing a circuit and not
-      # re-running the annotator ships a memory experiment describing the
-      # previous schedule, and nothing else would notice. The committed tree has
-      # to be a fixed point of the annotator.
+
+  # A `stim-annotated` body is derived from its circuit, but it is committed
+  # rather than generated at build time — so editing a circuit and not
+  # re-running the annotator ships a memory experiment describing the previous
+  # schedule, and nothing else would notice. The committed tree has to be a
+  # fixed point of the annotator.
+  annotated-bodies:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: "0.11.x"
+          python-version: "3.13"
+          enable-cache: true
+      - run: uv sync
       - name: stim-annotated bodies are up to date
         run: |
           out=$(uv run python scripts/annotate_circuits.py --dry-run)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,10 +8,20 @@ repos:
     rev: v6.0.0
     hooks:
       - id: check-merge-conflict
+      # data_yaml/ holds circuit bodies (.stim/.qasm/.cirq) written byte-for-byte
+      # by the ingestion pipeline. These two hooks rewrite them — 2476 files on a
+      # full run — which dirties the whole library to no purpose and puts the
+      # stored body out of step with what the pipeline would emit.
       - id: end-of-file-fixer
+        exclude: ^data_yaml/
       - id: trailing-whitespace
+        exclude: ^data_yaml/
       - id: check-yaml
+      # tsconfig.check.json is JSONC: it carries the comments explaining which
+      # two files it excludes and why. `check-json` is a strict JSON parser and
+      # cannot read it, though TypeScript can.
       - id: check-json
+        exclude: ^tsconfig\.check\.json$
       - id: check-added-large-files
         args: ["--maxkb=500"]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,28 @@ the source-of-truth `package.json` version.
 
 ### Fixed
 
+- **The pre-commit hooks corrupted the repository, and nothing had noticed because nothing
+  ran them.** They were never wired into CI, so they only ever fired for someone who had run
+  `pre-commit install` — and on this repository a full run rewrites 2476 files and leaves
+  Python that does not parse. Three separate causes, each now configured out in `_typos.toml`
+  and `.pre-commit-config.yaml`:
+  - **`typos` rewrites `anc` to `and`.** It is how the importers spell "ancilla", 29 times,
+    and `for row, anc in enumerate(...)` becomes `for row, and in ...` — a syntax error in
+    `circuit_validate.py`, `syndrome_extraction.py` and three of the flag-at-origin drivers.
+    It also translates the German legal pages into English a word at a time (`Sie` → `Size`,
+    `oder` → `order`), which would quietly damage a compliance document, and "corrects" the
+    `ba` inside the content-addressed digest `18ed8bee546ba80f` that 32 circuits reference —
+    breaking `db:create`. Now: the German pages and `data_yaml/` are excluded, and the QEC
+    vocabulary (`anc`, `ket`, `IZ`), the author name `Wille` and the citation `Lond` are
+    named. Not `locale = "en-gb"`, which sounds right for the prose and would rewrite
+    Tailwind's `text-center` and the `/favorites` route: 178 findings become 2233.
+  - **`end-of-file-fixer` and `trailing-whitespace` rewrote 2476 circuit bodies.** `.stim`,
+    `.qasm` and `.cirq` files are emitted byte-for-byte by the pipeline; a hook that edits
+    them puts the stored body out of step with what the pipeline would produce. Excluded
+    from `data_yaml/`.
+  - **`check-json` cannot read `tsconfig.check.json`**, which is JSONC — it carries the
+    comments explaining which two files it excludes and why. Excluded.
+
 - **`/api/search` was cached at the edge for a week, keyed on `?q=`.** `middleware.ts`
   stamps `s-maxage=604800` on any response without its own `Cache-Control`, which is safe
   for a page whose output is fixed at deploy time and not for one whose key space anyone
@@ -190,6 +212,22 @@ the source-of-truth `package.json` version.
 
 ### Added
 
+- **Four gaps closed in what CI actually checks.**
+  - **A `pre-commit` job.** The hooks now run on every PR instead of only for contributors
+    who installed them, which is what let the corruption above sit unnoticed. `prettier` is
+    skipped — it is the one hook needing `node_modules`, and `quality` already runs the same
+    check.
+  - **`ruff` covers `data-imports/`.** Every importer lives there, it is where the ingestion
+    bugs have actually been, and it was outside both the lint and format gates. Clean when
+    widened, so it costs nothing now and stops the next drift.
+  - **The coverage gate measures five scripts, not one, and asks for 80% rather than 60%.**
+    It watched `scripts/add_circuit` alone, leaving the four top-level maintainer scripts
+    unmeasured — including `validate_circuits.py`, which CI runs as its own step and which
+    was carrying a live bug. All five together come to 85%.
+  - **`stim-annotated` bodies must be a fixed point of the annotator.** They are derived from
+    their circuit but committed rather than built, so editing a circuit without re-running
+    the annotator ships a memory experiment describing the previous schedule, and nothing
+    else in CI would ever notice.
 - **`npm run typecheck`, because nothing in CI had ever read a TypeScript type.**
   `astro build` transpiles without checking and `eslint.config.mjs` uses the non-type-aware
   `tseslint.configs.recommended`, so all of `src/` was compiled and shipped on trust. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,6 +228,12 @@ the source-of-truth `package.json` version.
     their circuit but committed rather than built, so editing a circuit without re-running
     the annotator ships a memory experiment describing the previous schedule, and nothing
     else in CI would ever notice.
+  - **The two whole-library sweeps now run as their own jobs, in parallel.** Each parses
+    every circuit through stim and they share nothing but the checkout, so as steps of one
+    job they added up: 78 s of tests + 246 s validating circuits + 236 s checking annotated
+    bodies, a 9m35s job. Split, the wall clock is the slowest of the three — about 4
+    minutes, quicker than the workflow was before either check existed — for two extra
+    `uv sync` setups at ~8 s each.
 - **`npm run typecheck`, because nothing in CI had ever read a TypeScript type.**
   `astro build` transpiles without checking and `eslint.config.mjs` uses the non-type-aware
   `tseslint.configs.recommended`, so all of `src/` was compiled and shipped on trust. The

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,60 @@
+# Configuration for the `typos` pre-commit hook.
+#
+# Without this the hook does not merely report — it REWRITES, and on this
+# repository it rewrites working code into syntax errors. `anc` is how the
+# ingestion scripts spell "ancilla", and `typos` is confident it meant `and`:
+#
+#     for row, anc in enumerate(...)   ->   for row, and in enumerate(...)
+#
+# 29 occurrences across data-imports/ and scripts/. It also translates the
+# German legal pages into English one word at a time (`Sie` -> `Size`,
+# `oder` -> `order`, `ist` -> `is`), which would quietly corrupt a compliance
+# document, and Americanises British spellings the prose uses deliberately.
+#
+# So: exclude the German pages, name the vocabulary, and set the locale.
+
+[files]
+extend-exclude = [
+  # Required by German law and written in German. Every word in them is a
+  # "typo" to an English dictionary.
+  "src/pages/legal.astro",
+  "src/pages/privacy.astro",
+  # Generated, content-addressed, and machine-read. A spell-checker has no
+  # business here: 32 circuit files reference a matrices digest such as
+  # `18ed8bee546ba80f`, and `typos` reads the `ba` in it as a misspelt `by`.
+  # "Correcting" one breaks the reference and fails `npm run db:create`.
+  # Circuit bodies and check matrices are data, not prose.
+  "data_yaml/",
+  # The changelog quotes what the code and data contain — including, in the
+  # entry that added this file, the German words and the digest above. A record
+  # of a spelling problem trips the spell-checker by construction, and it will
+  # keep doing so every time an entry quotes a literal.
+  "CHANGELOG.md",
+]
+
+# No `locale` is set on purpose. The obvious move is `en-gb`, since the prose
+# is British — and it is wrong: identifiers here are American by necessity
+# (Tailwind's `text-center`, the `/favorites` route, "Color Code" as a code's
+# actual name), so `en-gb` turns 178 findings into 2233 and wants to rewrite
+# class names. The default locale accepts both for `colour`/`canonicalisation`;
+# `uncatalogued` is the one word it does not, and it is listed below.
+
+[default.extend-words]
+uncatalogued = "uncatalogued"
+
+# QEC and quantum-computing vocabulary.
+anc = "anc"     # ancilla, throughout the importers and add_circuit
+ANC = "ANC"
+ket = "ket"     # |psi>, as in "ket notation"
+IZ = "IZ"       # a two-qubit Pauli string; likewise XZ, ZI, ...
+iz = "iz"
+
+# Fragments that are correct in context.
+prepar = "prepar" # the FTS5 prefix query `prepar*` in migration 016
+mis = "mis"       # "mis-ranking", hyphenated
+PN = "PN"
+
+[default.extend-identifiers]
+# Author and citation names, in data_yaml/papers/.
+Wille = "Wille" # Robert Wille
+Lond = "Lond"   # Proc. R. Soc. Lond., the Steane 1996 citation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qecirc-website",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qecirc-website",
-      "version": "0.7.10",
+      "version": "0.7.11",
       "license": "MIT",
       "dependencies": {
         "@astrojs/node": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qecirc-website",
   "type": "module",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "license": "MIT",
   "scripts": {
     "dev": "astro dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qecirc-website"
-version = "0.7.10"
+version = "0.7.11"
 description = "QECirc — quantum error correction circuit library"
 license = "MIT"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -829,7 +829,7 @@ wheels = [
 
 [[package]]
 name = "qecirc-website"
-version = "0.7.10"
+version = "0.7.11"
 source = { virtual = "." }
 dependencies = [
     { name = "mqt-qecc" },


### PR DESCRIPTION
Follows the CI review. The headline is not the four new checks — it is that **the existing hooks corrupt the repository**, and nothing had noticed because nothing ran them.

## The hooks were unsafe

They are not wired into CI, so they only ever fire for a contributor who ran `pre-commit install`. Running `pre-commit run --all-files` on `main` today **rewrites 2476 files and leaves Python that does not parse**. Three independent causes:

**`typos` auto-fixes, and it is wrong about this codebase.**

| what it rewrites | count | consequence |
| --- | --- | --- |
| `anc` → `and` | 29 | `for row, anc in enumerate(...)` → `for row, and in ...`; syntax errors in `circuit_validate.py`, `syndrome_extraction.py` and three flag-at-origin drivers |
| German → English (`Sie` → `Size`, `oder` → `order`, `ist` → `is`) | ~100 | silently damages `/legal` and `/privacy`, which are compliance documents |
| the `ba` in digest `18ed8bee546ba80f` | 32 | breaks the `original_matrices` reference; `npm run db:create` fails |
| `Wille` → `Will`, `Lond` → `Long` | 6 | an author's name and a journal abbreviation in `data_yaml/papers/` |

Fixed by `_typos.toml`: the German pages, `data_yaml/` and `CHANGELOG.md` are excluded, and the QEC vocabulary (`anc`, `ket`, `IZ`) plus `Wille`/`Lond` are named.

**Not** `locale = "en-gb"`, which is the obvious move for British prose and is wrong: identifiers here are American by necessity (Tailwind's `text-center`, the `/favorites` route, "Color Code" as a code's real name), so it turns 178 findings into **2233** and wants to rewrite class names. Only `uncatalogued` needed listing.

**`end-of-file-fixer` / `trailing-whitespace` rewrote 2476 circuit bodies.** `.stim`/`.qasm`/`.cirq` are emitted byte-for-byte by the pipeline; a hook editing them puts the stored body out of step with what the pipeline would produce. Excluded from `data_yaml/`.

**`check-json` cannot read `tsconfig.check.json`** — it is JSONC, carrying the comments that explain its two exclusions. Excluded.

## Then the four gaps

- **`pre-commit` job** — hooks now run on every PR, so a fork no longer bypasses `typos`, `check-added-large-files` and `uv-lock`. `prettier` is skipped: it is the only hook needing `node_modules`, and `quality` already runs the same check.
- **`ruff` covers `data-imports/`** — every importer lives there, it is where the ingestion bugs have actually been, and it was outside both gates. Clean when widened.
- **Coverage: five scripts at 80%, was one at 60%** — it watched `scripts/add_circuit` alone, leaving out `validate_circuits.py`, which CI runs as its own step and which was carrying a live bug. All five measure 85%, so 80 has headroom.
- **`stim-annotated` bodies must be a fixed point of the annotator** — they are derived but committed, so editing a circuit without re-running it ships a memory experiment describing the previous schedule. Nothing else would notice.

Plus `enable-cache: true` on both `setup-uv` steps.

## Verification

`SKIP=prettier pre-commit run --all-files` → **12 hooks pass, 0 files modified** (before this PR: 2476 modified, 2 hooks failing). `ruff check`/`format --check` clean over `scripts/ data-imports/` (66 files). Coverage 85% over the five. Annotator dry-run: `674 unchanged`. Workflow YAML parses; 4 jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)