### PR TITLE
fix(a11y): raise focus and text contrast, correct heading order, complete the combobox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,47 @@ the source-of-truth `package.json` version.
   open PRs — a debt register with two entries, both now paid. The full project type-checks
   clean: 92 files, 0 errors. The `check-json` exclusion that existed only to parse it went
   with it.
+- **Seven accessibility defects, each measured in a browser rather than inferred from a
+  linter.** They had nothing in common but the failure mode: every one of them looked right
+  to a sighted mouse user, which is exactly why none had been noticed.
+  - **The focus ring was all but invisible.** `focus-visible:ring-blue-500/40` measured
+    1.64:1 against a row in light mode and 1.74:1 in dark — WCAG 1.4.11 asks 3:1 — and,
+    worse, only 1.33:1 and 1.27:1 against the row's own resting border, so "focused" and
+    "not focused" were nearly the same picture. Dropping the alpha leaves solid blue-500:
+    3.76:1 on white, 5.35:1 on gray-950, and 3.04:1 / 3.90:1 against the resting border.
+    `CircuitRow` and `CodeCard` carried the same class and both change.
+  - **`text-amber-600` measured 3.20:1 on white**, under the 4.5:1 body text needs, and
+    neither of the two places that show it — the alpha superscript in the header (14px/600)
+    and the active-sort label (12px/600) — is large enough to claim the 3:1 exception. Now
+    `amber-700`: 5.03:1 in light, and dark mode keeps `amber-400` at 11.69:1. Bumped at all
+    ten call sites at once, because a token that means "this is the sort you asked for"
+    stops meaning it the moment two shades are in play.
+  - **`/codes` skipped from `h1` straight to `h3`** — `CodeCard`'s heading, the only
+    heading-order violation on the site. It is an `h2` now; the class list is unchanged and
+    so is the rendering, since the card sets its own size and weight. `ToolCard` keeps its
+    `h3`, which is correct: `/tools` has a real `h2` above it.
+  - **Three `text-gray-500`s on `/search` had no dark variant**, measuring 4.16:1 against
+    `gray-950`. Every sibling paragraph in the file already had `dark:text-gray-400`, and
+    `global.css` states the pairing as house rule, so these were omissions rather than
+    choices. 7.74:1 now.
+  - **The format tabs said which format was active in colour only** (WCAG 4.1.2) — the
+    server emitted plain buttons and the client rewrote `className` and `display`. They now
+    carry `aria-pressed`, the pattern `CodeMatrices` already uses. The initial state is read
+    off the visible body rather than assumed to be the first tab, because the tabs on code
+    pages are cloned from `CircuitBodiesTemplate` and start with no ARIA of their own.
+  - **The header quick-search was an incomplete combobox.** The input had no
+    `role="combobox"`, `aria-expanded`, `aria-controls` or `aria-autocomplete`, and the
+    results list had no `id` — which made the `aria-activedescendant` the script had been
+    writing all along point at nothing, so no screen reader ever announced the highlighted
+    result. All five are wired up now, and `aria-expanded` tracks the dropdown. They are set
+    from the script, not the markup: without JS there is no dropdown, and an input that
+    claims to own a popup that cannot open is worse than a plain search field.
+  - **`/about` re-documented the keyboard shortcuts and had drifted from them.** It omitted
+    `Home` and `End`, and described `Esc` as collapsing the open row when it also closes the
+    help overlay. Corrected in place. The duplication itself stays: `KeyboardHelp`'s flat
+    17-row table and `/about`'s topic-grouped prose are different shapes, and collapsing
+    them into one source would cost more than it saves.
+
 - **The pre-commit hooks corrupted the repository, and nothing had noticed because nothing
   ran them.** They were never wired into CI, so they only ever fired for someone who had run
   `pre-commit install` — and on this repository a full run rewrites 2476 files and leaves

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,18 +38,29 @@ the source-of-truth `package.json` version.
 - **Seven accessibility defects, each measured in a browser rather than inferred from a
   linter.** They had nothing in common but the failure mode: every one of them looked right
   to a sighted mouse user, which is exactly why none had been noticed.
-  - **The focus ring was all but invisible.** `focus-visible:ring-blue-500/40` measured
-    1.64:1 against a row in light mode and 1.74:1 in dark — WCAG 1.4.11 asks 3:1 — and,
-    worse, only 1.33:1 and 1.27:1 against the row's own resting border, so "focused" and
-    "not focused" were nearly the same picture. Dropping the alpha leaves solid blue-500:
-    3.76:1 on white, 5.35:1 on gray-950, and 3.04:1 / 3.90:1 against the resting border.
-    `CircuitRow` and `CodeCard` carried the same class and both change.
+  - **The focus ring was all but invisible.** `ring-blue-500/40` measured 1.64:1 against a
+    row in light mode and 1.74:1 in dark — WCAG 1.4.11 asks 3:1 — and, worse, only 1.33:1
+    and 1.27:1 against the row's own resting border, so "focused" and "not focused" were
+    nearly the same picture. Dropping the alpha leaves solid blue-500: 3.76:1 on white,
+    5.35:1 on gray-950, and 3.04:1 / 3.90:1 against the resting border. Six call sites, not
+    the two that were first found: `CircuitRow`, `CodeCard`, the `/search` query and filter
+    inputs, the `/` filter input, and the row `favorites` builds client-side. On the inputs
+    the ring also has the field's own `gray-300`/`gray-700` border beside it, and there it
+    goes 1.12:1 → 2.55:1 (light) / 2.74:1 (dark) — short of 3:1 against that one edge, but
+    the ring's other neighbour is the page background, which it clears.
   - **`text-amber-600` measured 3.20:1 on white**, under the 4.5:1 body text needs, and
     neither of the two places that show it — the alpha superscript in the header (14px/600)
     and the active-sort label (12px/600) — is large enough to claim the 3:1 exception. Now
     `amber-700`: 5.03:1 in light, and dark mode keeps `amber-400` at 11.69:1. Bumped at all
     ten call sites at once, because a token that means "this is the sort you asked for"
     stops meaning it the moment two shades are in play.
+  - **Two of those ten are links whose only hover feedback was that colour**, so darkening
+    the resting state flattened the hover step: the header α and "Clear all active filters"
+    went from a 2.22:1 step to 1.41:1. Both now go to `amber-900` on hover — 1.80:1, still
+    a slight step — and, more to the point, underline. Dark mode never had a usable step
+    either (`amber-400` → `amber-200` is 1.38:1) and gains the same underline. A hover
+    affordance that exists only as a colour change is one an awful lot of people cannot
+    see; this is the first of the two that does not depend on hue at all.
   - **`/codes` skipped from `h1` straight to `h3`** — `CodeCard`'s heading, the only
     heading-order violation on the site. It is an `h2` now; the class list is unchanged and
     so is the rendering, since the card sets its own size and weight. `ToolCard` keeps its
@@ -69,12 +80,34 @@ the source-of-truth `package.json` version.
     writing all along point at nothing, so no screen reader ever announced the highlighted
     result. All five are wired up now, and `aria-expanded` tracks the dropdown. They are set
     from the script, not the markup: without JS there is no dropdown, and an input that
-    claims to own a popup that cannot open is worse than a plain search field.
+    claims to own a popup that cannot open is worse than a plain search field. Two
+    consequences of making it a real combobox:
+    - **`aria-live="polite"` came off the results list.** It was there because nothing else
+      announced the results — a reasonable call while `aria-activedescendant` pointed at
+      nothing. Now that the combobox announces the active option, the live region announces
+      the list on top of it, and the user hears everything twice. `role="listbox"` and the
+      label stay.
+    - **Tabbing out left `aria-expanded="true"` on an input nothing was focused on.**
+      `hide()` was reachable from Escape, a click outside, and a query under two characters
+      — not from losing focus. There is a `focusout` handler now, guarded on a non-null
+      `relatedTarget`: the result `<li>`s are not focusable, so pressing the mouse on one
+      blurs the input with a null `relatedTarget`, and hiding there would take the item away
+      between mousedown and the click that navigates.
   - **`/about` re-documented the keyboard shortcuts and had drifted from them.** It omitted
     `Home` and `End`, and described `Esc` as collapsing the open row when it also closes the
     help overlay. Corrected in place. The duplication itself stays: `KeyboardHelp`'s flat
     17-row table and `/about`'s topic-grouped prose are different shapes, and collapsing
     them into one source would cost more than it saves.
+
+- **Writing about a Tailwind class put it back in the stylesheet.** Tailwind v4 finds its
+  own sources, which means it reads every tracked file — including prose that only _names_ a
+  class. The CHANGELOG entry above, explaining that `text-amber-600` had been replaced,
+  regenerated `.text-amber-600{}`; the design plans under `docs/` were keeping
+  `dark:text-amber-300` alive for a component that stopped using it months ago. The wasted
+  bytes are the small half. The large half is that "the class is gone from the built CSS"
+  stops being a way to check that a sweep across call sites was complete — and it fails in
+  the direction that hides a missed one, which is how four `ring-blue-500/40` sites survived
+  the first pass of the fix above. Both paths are now `@source not` in `global.css`.
 
 - **The pre-commit hooks corrupted the repository, and nothing had noticed because nothing
   ran them.** They were never wired into CI, so they only ever fired for someone who had run

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qecirc-website",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qecirc-website",
-      "version": "0.7.13",
+      "version": "0.7.14",
       "license": "MIT",
       "dependencies": {
         "@astrojs/node": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "generate": "uv run python -m scripts.add_circuit.generate",
     "papers:add": "uv run python scripts/add_paper.py",
     "papers:missing": "uv run python scripts/add_paper.py --missing",
-    "typecheck": "astro check --tsconfig ./tsconfig.check.json",
+    "typecheck": "astro check",
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qecirc-website",
   "type": "module",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "license": "MIT",
   "scripts": {
     "dev": "astro dev",
@@ -16,7 +16,7 @@
     "generate": "uv run python -m scripts.add_circuit.generate",
     "papers:add": "uv run python scripts/add_paper.py",
     "papers:missing": "uv run python scripts/add_paper.py --missing",
-    "typecheck": "astro check",
+    "typecheck": "astro check --tsconfig ./tsconfig.check.json",
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qecirc-website"
-version = "0.7.13"
+version = "0.7.14"
 description = "QECirc — quantum error correction circuit library"
 license = "MIT"
 requires-python = ">=3.13"

--- a/src/components/CircuitFilter.astro
+++ b/src/components/CircuitFilter.astro
@@ -29,7 +29,7 @@ function labelInfo(field: CircuitSortField) {
   return {
     arrow: isActive ? "▲" : "",
     cls: isActive
-      ? "text-amber-600 dark:text-amber-400 font-semibold cursor-pointer"
+      ? "text-amber-700 dark:text-amber-400 font-semibold cursor-pointer"
       : "text-gray-600 dark:text-gray-400 font-medium hover:text-gray-900 dark:hover:text-gray-100 cursor-pointer",
   };
 }

--- a/src/components/CircuitRow.astro
+++ b/src/components/CircuitRow.astro
@@ -63,7 +63,7 @@ const stimFilename = buildStimFilename({
   data-tags={rowTags}
 >
   <div
-    class="circuit-toggle w-full text-left px-4 py-3 grid items-center gap-x-1.5 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 focus-visible:ring-inset"
+    class="circuit-toggle w-full text-left px-4 py-3 grid items-center gap-x-1.5 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-inset"
     style="grid-template-columns: var(--circuit-grid);"
     role="button"
     tabindex="0"

--- a/src/components/CodeCard.astro
+++ b/src/components/CodeCard.astro
@@ -24,7 +24,7 @@ const rowTags = JSON.stringify(tags);
 ---
 
 <div
-  class="rounded border border-gray-200 dark:border-gray-800 p-4 hover:border-gray-400 dark:hover:border-gray-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40"
+  class="rounded border border-gray-200 dark:border-gray-800 p-4 hover:border-gray-400 dark:hover:border-gray-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
   tabindex="0"
   data-list-row
   data-filter-row
@@ -34,7 +34,7 @@ const rowTags = JSON.stringify(tags);
 >
   <div class="flex flex-wrap items-baseline gap-x-2 gap-y-1">
     <a href={`/codes/${slug}`} class="flex items-baseline gap-2" data-list-link>
-      <h3 class="font-medium">{name}</h3>
+      <h2 class="font-medium">{name}</h2>
       {showParams && <span class="text-sm text-gray-500 dark:text-gray-400">{params}</span>}
       <span class="text-xs text-gray-500 dark:text-gray-400">{circuit_count} {circuit_count === 1 ? "circuit" : "circuits"}</span>
     </a>

--- a/src/components/CodeFilter.astro
+++ b/src/components/CodeFilter.astro
@@ -28,7 +28,7 @@ function labelInfo(field: CodeSortField) {
   return {
     arrow: isActive ? "▲" : "",
     cls: isActive
-      ? "text-amber-600 dark:text-amber-400 font-semibold cursor-pointer"
+      ? "text-amber-700 dark:text-amber-400 font-semibold cursor-pointer"
       : "text-gray-600 dark:text-gray-400 font-medium hover:text-gray-900 dark:hover:text-gray-100 cursor-pointer",
   };
 }

--- a/src/components/FilterStatus.astro
+++ b/src/components/FilterStatus.astro
@@ -53,7 +53,7 @@ const HINT_TITLE =
   <a
     href={basePath}
     data-clear-filters
-    class="hidden font-medium text-amber-700 dark:text-amber-400 hover:text-amber-800 dark:hover:text-amber-200"
+    class="hidden font-medium text-amber-700 dark:text-amber-400 hover:text-amber-900 dark:hover:text-amber-200 hover:underline"
     title="Clear all active filters"
   >
     <svg

--- a/src/components/FilterStatus.astro
+++ b/src/components/FilterStatus.astro
@@ -53,7 +53,7 @@ const HINT_TITLE =
   <a
     href={basePath}
     data-clear-filters
-    class="hidden font-medium text-amber-600 dark:text-amber-400 hover:text-amber-800 dark:hover:text-amber-200"
+    class="hidden font-medium text-amber-700 dark:text-amber-400 hover:text-amber-800 dark:hover:text-amber-200"
     title="Clear all active filters"
   >
     <svg

--- a/src/components/FormatSwitcher.astro
+++ b/src/components/FormatSwitcher.astro
@@ -60,6 +60,7 @@ const TAB_BASE_CLASS =
           class:list={[TAB_BASE_CLASS, i === 0 ? TAB_ACTIVE_CLASS : TAB_INACTIVE_CLASS]}
           data-format={b.format}
           title={`Switch to ${b.format.toUpperCase()} (${i + 1})`}
+          aria-pressed={i === 0}
         >
           {b.format.toUpperCase()}
           {i < 3 && (

--- a/src/components/Layout.astro
+++ b/src/components/Layout.astro
@@ -129,7 +129,7 @@ const sunIconSvg = `<svg class="w-4 h-4 hidden dark:block" viewBox="0 0 24 24" f
     <header class="border-b border-gray-200 dark:border-gray-800">
       <nav class="mx-auto max-w-4xl px-4 py-4">
         <div class="flex items-center gap-6">
-          <span class="text-lg font-semibold"><a href="/">QECirc</a><a href="/about#alpha" class="text-sm text-amber-700 dark:text-amber-400 hover:text-amber-800 dark:hover:text-amber-200 align-super ml-0.5" title="Alpha — under development">&#945;</a></span>
+          <span class="text-lg font-semibold"><a href="/">QECirc</a><a href="/about#alpha" class="text-sm text-amber-700 dark:text-amber-400 hover:text-amber-900 dark:hover:text-amber-200 hover:underline align-super ml-0.5" title="Alpha — under development">&#945;</a></span>
           {NAV_LINKS.map(({ href, label }) => (
             <a href={href} class="hidden sm:block text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100">{label}</a>
           ))}

--- a/src/components/Layout.astro
+++ b/src/components/Layout.astro
@@ -129,7 +129,7 @@ const sunIconSvg = `<svg class="w-4 h-4 hidden dark:block" viewBox="0 0 24 24" f
     <header class="border-b border-gray-200 dark:border-gray-800">
       <nav class="mx-auto max-w-4xl px-4 py-4">
         <div class="flex items-center gap-6">
-          <span class="text-lg font-semibold"><a href="/">QECirc</a><a href="/about#alpha" class="text-sm text-amber-600 dark:text-amber-400 hover:text-amber-800 dark:hover:text-amber-200 align-super ml-0.5" title="Alpha — under development">&#945;</a></span>
+          <span class="text-lg font-semibold"><a href="/">QECirc</a><a href="/about#alpha" class="text-sm text-amber-700 dark:text-amber-400 hover:text-amber-800 dark:hover:text-amber-200 align-super ml-0.5" title="Alpha — under development">&#945;</a></span>
           {NAV_LINKS.map(({ href, label }) => (
             <a href={href} class="hidden sm:block text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100">{label}</a>
           ))}

--- a/src/components/SearchBar.astro
+++ b/src/components/SearchBar.astro
@@ -13,7 +13,6 @@
   <ul
     class="search-results absolute right-0 top-full mt-1 w-96 rounded border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-lg hidden z-50 max-h-80 overflow-y-auto"
     role="listbox"
-    aria-live="polite"
     aria-label="Search results"
   >
   </ul>
@@ -244,6 +243,17 @@
     } else if (e.key === "Escape") {
       hide();
     }
+  });
+
+  // Tabbing out of the input leaves a dropdown that still reports itself as
+  // expanded on a combobox nothing is focused on. Guarded on a non-null
+  // relatedTarget: the result <li>s are not focusable, so pressing the mouse on
+  // one blurs the input with relatedTarget null, and hiding there would take
+  // the item away between mousedown and the click that navigates. Pointer
+  // dismissal is the document listener below.
+  input.addEventListener("focusout", function (e) {
+    const next = (e as FocusEvent).relatedTarget as Node | null;
+    if (next && !container.contains(next)) hide();
   });
 
   document.addEventListener("click", function (e) {

--- a/src/components/SearchBar.astro
+++ b/src/components/SearchBar.astro
@@ -51,8 +51,20 @@
   let activeIndex = -1;
   let cachedItems: NodeListOf<HTMLLIElement> | HTMLLIElement[] = [];
 
+  // The combobox wiring is applied here rather than in the markup for two
+  // reasons: the dropdown only exists when this script runs (without JS the
+  // input is a plain search field and must not claim to own a popup), and the
+  // layout renders two SearchBars, so the listbox id has to be per-instance --
+  // the same `instance` index the option ids below already use.
+  resultsList.id = `search-results-${instance}`;
+  input.setAttribute("role", "combobox");
+  input.setAttribute("aria-controls", resultsList.id);
+  input.setAttribute("aria-autocomplete", "list");
+  input.setAttribute("aria-expanded", "false");
+
   function show() {
     resultsList.classList.remove("hidden");
+    input.setAttribute("aria-expanded", "true");
   }
 
   function hide() {
@@ -62,6 +74,7 @@
     // the user just closed, or answers a query they have already deleted.
     latestSearch++;
     resultsList.classList.add("hidden");
+    input.setAttribute("aria-expanded", "false");
     activeIndex = -1;
     input.removeAttribute("aria-activedescendant");
   }

--- a/src/lib/format-switcher-client.ts
+++ b/src/lib/format-switcher-client.ts
@@ -24,6 +24,24 @@ export function initFormatSwitchers(root: HTMLElement | Document = document): vo
     }
     syncSwitches((tabs[0] as HTMLElement | undefined)?.dataset.format);
 
+    // The active tab is otherwise signalled by colour alone (WCAG 1.4.1 / 4.1.2).
+    // Same pattern as CodeMatrices.astro. The initial state is read off the
+    // visible body rather than assumed to be the first tab, because the tabs on
+    // code pages are cloned from CircuitBodiesTemplate.astro, which carries no
+    // aria-pressed of its own.
+    function syncPressed(format: string | undefined): void {
+      tabs.forEach(function (t) {
+        (t as HTMLElement).setAttribute(
+          "aria-pressed",
+          (t as HTMLElement).dataset.format === format ? "true" : "false",
+        );
+      });
+    }
+    const shown = Array.from(bodies).find(function (b) {
+      return (b as HTMLElement).style.display !== "none";
+    });
+    syncPressed((shown as HTMLElement | undefined)?.dataset.format);
+
     tabs.forEach(function (tab) {
       tab.addEventListener("click", function () {
         const format = (tab as HTMLElement).dataset.format;
@@ -38,6 +56,7 @@ export function initFormatSwitchers(root: HTMLElement | Document = document): vo
             (b as HTMLElement).dataset.format === format ? "" : "none";
         });
 
+        syncPressed(format);
         syncSwitches(format);
 
         // Formats differ in length, so the row's collapse container has to be

--- a/src/lib/list-filter-client.ts
+++ b/src/lib/list-filter-client.ts
@@ -69,12 +69,12 @@ interface ListState {
 // CircuitFilter.astro / CodeFilter.astro — KEEP THOSE IN SYNC.
 // ---------------------------------------------------------------------------
 
-const SORT_LABEL_ACTIVE = "text-amber-600 dark:text-amber-400 font-semibold cursor-pointer";
+const SORT_LABEL_ACTIVE = "text-amber-700 dark:text-amber-400 font-semibold cursor-pointer";
 const SORT_LABEL_INACTIVE =
   "text-gray-600 dark:text-gray-400 font-medium hover:text-gray-900 dark:hover:text-gray-100 cursor-pointer";
 
 // Column-header links ([data-sort-header]) only toggle the highlight classes.
-const SORT_HEADER_ACTIVE = "text-amber-600 dark:text-amber-400";
+const SORT_HEADER_ACTIVE = "text-amber-700 dark:text-amber-400";
 
 const CHIP_X_ICON =
   '<svg class="w-3 h-3 opacity-70" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 18L18 6M6 6l12 12" /></svg>';

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -33,13 +33,13 @@ const kbdCls =
     </p>
     <ul class="list-disc pl-5 text-gray-600 dark:text-gray-400 mb-6 space-y-1 text-sm">
       <li>
-        <kbd class={kbdCls}>j</kbd> / <kbd class={kbdCls}>k</kbd> or arrow keys to move; <kbd class={kbdCls}>gg</kbd> / <kbd class={kbdCls}>G</kbd> for first / last
+        <kbd class={kbdCls}>j</kbd> / <kbd class={kbdCls}>k</kbd> or arrow keys to move; <kbd class={kbdCls}>gg</kbd> / <kbd class={kbdCls}>Home</kbd> jumps to the first row, <kbd class={kbdCls}>G</kbd> / <kbd class={kbdCls}>End</kbd> to the last
       </li>
       <li>
         <kbd class={kbdCls}>l</kbd> / <kbd class={kbdCls}>→</kbd> or <kbd class={kbdCls}>Space</kbd> toggle a circuit row; <kbd class={kbdCls}>h</kbd> / <kbd class={kbdCls}>←</kbd> collapse; <kbd class={kbdCls}>Enter</kbd> opens the detail page
       </li>
       <li>
-        <kbd class={kbdCls}>f</kbd> to toggle favorite (focused row or current circuit), <kbd class={kbdCls}>⇧F</kbd> to toggle the favorites-only filter; <kbd class={kbdCls}>/</kbd> focuses search; <kbd class={kbdCls}>Esc</kbd> collapses the open row
+        <kbd class={kbdCls}>f</kbd> to toggle favorite (focused row or current circuit), <kbd class={kbdCls}>⇧F</kbd> to toggle the favorites-only filter; <kbd class={kbdCls}>/</kbd> focuses search; <kbd class={kbdCls}>Esc</kbd> collapses the open row, or closes this shortcut reference when it is open
       </li>
       <li>
         <kbd class={kbdCls}>1</kbd> / <kbd class={kbdCls}>2</kbd> / <kbd class={kbdCls}>3</kbd> switch format on the open circuit; <kbd class={kbdCls}>c</kbd> or <kbd class={kbdCls}>y</kbd> copy, <kbd class={kbdCls}>d</kbd> download; <kbd class={kbdCls}>⇧D</kbd> downloads all on the page

--- a/src/pages/codes/[code].astro
+++ b/src/pages/codes/[code].astro
@@ -231,7 +231,7 @@ const jsonLd = [
         <span></span>
         <span></span>
         <a href={sortHref("gate_count")} data-sort-field="gate_count" data-sort-header class="text-center hover:text-gray-900 dark:hover:text-gray-100" title="Gate count — click to sort">G</a>
-        <a href={sortHref("two_qubit_gate_count")} data-sort-field="two_qubit_gate_count" data-sort-header class="text-center hover:text-gray-900 dark:hover:text-gray-100 text-amber-600 dark:text-amber-400" title="Two-qubit gate count — click to sort">2Q</a>
+        <a href={sortHref("two_qubit_gate_count")} data-sort-field="two_qubit_gate_count" data-sort-header class="text-center hover:text-gray-900 dark:hover:text-gray-100 text-amber-700 dark:text-amber-400" title="Two-qubit gate count — click to sort">2Q</a>
         <a href={sortHref("depth")} data-sort-field="depth" data-sort-header class="text-center hover:text-gray-900 dark:hover:text-gray-100" title="Circuit depth — click to sort">D</a>
         <a href={sortHref("qubit_count")} data-sort-field="qubit_count" data-sort-header class="text-center hover:text-gray-900 dark:hover:text-gray-100" title="Qubit count — click to sort">Q</a>
         <span></span>

--- a/src/pages/favorites.astro
+++ b/src/pages/favorites.astro
@@ -161,7 +161,7 @@ import Layout from "../components/Layout.astro";
 
           for (const circuit of codeCircuits) {
             const row = document.createElement("div");
-            row.className = "rounded border border-gray-200 dark:border-gray-800 px-4 py-3 flex items-center gap-3 flex-wrap focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40";
+            row.className = "rounded border border-gray-200 dark:border-gray-800 px-4 py-3 flex items-center gap-3 flex-wrap focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500";
             row.dataset.qecId = String(circuit.qec_id);
             row.tabIndex = 0;
             row.setAttribute("data-list-row", "");

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -159,7 +159,7 @@ const previewCardCls = "rounded border border-gray-200 dark:border-gray-800 p-3 
 const filterBoxCls =
   "inline-flex items-center gap-1 rounded border border-gray-300 dark:border-gray-700 px-1.5 py-0.5 transition-colors";
 const filterFieldCls = "px-1 py-0.5 text-xs font-semibold";
-const filterSortedCls = "text-amber-600 dark:text-amber-400";
+const filterSortedCls = "text-amber-700 dark:text-amber-400";
 const filterPlainCls = "text-gray-600 dark:text-gray-400";
 const filterValueCls = "px-1 py-0.5 text-sm font-mono text-gray-500 dark:text-gray-400";
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -223,7 +223,7 @@ const jsonLd = {
           name="q"
           placeholder="Search circuits by name, notes, tag or #id"
           aria-label="Search circuits"
-          class="flex-1 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-950 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+          class="flex-1 rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-950 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
         />
         <button
           type="submit"

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -115,7 +115,7 @@ Astro.response.headers.set("Cache-Control", "public, max-age=0, s-maxage=600");
       <Fragment>
       <details id="search-filters" open={hasFilters} class="mt-3">
         <summary class="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 cursor-pointer select-none">
-          Filters{hasFilters && <span class="ml-1 text-amber-600 dark:text-amber-400">&#183; active</span>}
+          Filters{hasFilters && <span class="ml-1 text-amber-700 dark:text-amber-400">&#183; active</span>}
         </summary>
 
         <div class="mt-3 space-y-3 rounded border border-gray-200 dark:border-gray-800 p-3">
@@ -135,7 +135,7 @@ Astro.response.headers.set("Cache-Control", "public, max-age=0, s-maxage=600");
               ))}
             </select>
             {hasFilters && (
-              <a href={clearHref} class="text-xs underline text-gray-500 hover:text-gray-900 dark:hover:text-gray-100">
+              <a href={clearHref} class="text-xs underline text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100">
                 Clear
               </a>
             )}
@@ -213,7 +213,7 @@ Astro.response.headers.set("Cache-Control", "public, max-age=0, s-maxage=600");
           blame and offers the way out of them, and two "no results" sentences
           three lines apart read as a rendering fault. */}
       {results.length > 0 && (
-        <p class="text-sm text-gray-500 mb-3">
+        <p class="text-sm text-gray-500 dark:text-gray-400 mb-3">
           {`${truncated ? `Top ${results.length}` : results.length} ${results.length === 1 ? "circuit" : "circuits"}`}
           {" for "}<span class="font-medium text-gray-900 dark:text-gray-100">{resolved?.display ?? q}</span>
         </p>
@@ -265,7 +265,7 @@ Astro.response.headers.set("Cache-Control", "public, max-age=0, s-maxage=600");
             </p>
           )}
           {hasFilters && (
-            <a href={clearHref} class="text-sm underline text-gray-500 hover:text-gray-900 dark:hover:text-gray-100">
+            <a href={clearHref} class="text-sm underline text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100">
               Clear filters
             </a>
           )}
@@ -283,7 +283,7 @@ Astro.response.headers.set("Cache-Control", "public, max-age=0, s-maxage=600");
             <span></span>
             <span></span>
             <span class="text-center" title="Gate count">G</span>
-            <span class="text-center text-amber-600 dark:text-amber-400" title="Two-qubit gate count">2Q</span>
+            <span class="text-center text-amber-700 dark:text-amber-400" title="Two-qubit gate count">2Q</span>
             <span class="text-center" title="Circuit depth">D</span>
             <span class="text-center" title="Qubit count">Q</span>
             <span></span>

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -98,7 +98,7 @@ Astro.response.headers.set("Cache-Control", "public, max-age=0, s-maxage=600");
         autofocus
         placeholder="Search circuits by name, notes, tag or #id"
         aria-label="Search circuits"
-        class="flex-1 rounded border border-gray-300 dark:border-gray-700 px-3 py-2 text-sm bg-transparent focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+        class="flex-1 rounded border border-gray-300 dark:border-gray-700 px-3 py-2 text-sm bg-transparent focus:outline-none focus:ring-2 focus:ring-blue-500"
       />
       <button
         type="submit"
@@ -124,7 +124,7 @@ Astro.response.headers.set("Cache-Control", "public, max-age=0, s-maxage=600");
             <select
               id="code-select"
               name="code"
-              class="rounded border border-gray-300 dark:border-gray-700 px-2 py-1 text-sm bg-transparent focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+              class="rounded border border-gray-300 dark:border-gray-700 px-2 py-1 text-sm bg-transparent focus:outline-none focus:ring-2 focus:ring-blue-500"
             >
               <option value="">Any code ({facets.codes.reduce((s, c) => s + c.count, 0)})</option>
               {staleCode && <option value={codeSlug} selected>No match for this query</option>}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,17 @@
 @import "tailwindcss";
 
+/* Tailwind v4 detects its own sources, which means it scans every tracked file
+   -- including prose that merely *names* a class. A CHANGELOG entry explaining
+   that `text-amber-600` was replaced puts `.text-amber-600{}` back in the
+   stylesheet, and the design plans under docs/ do the same for classes no
+   component has used in months. The dead bytes are the small half of it: the
+   larger cost is that "the class is gone from the built CSS" stops being a way
+   to check that a sweep across call sites was complete, and it fails in the
+   direction that hides a missed one. Neither path renders anything, so neither
+   is a source. Paths resolve relative to this file. */
+@source not "../../CHANGELOG.md";
+@source not "../../docs";
+
 @custom-variant dark (&:where(.dark, .dark *));
 
 .prose-link {

--- a/uv.lock
+++ b/uv.lock
@@ -829,7 +829,7 @@ wheels = [
 
 [[package]]
 name = "qecirc-website"
-version = "0.7.13"
+version = "0.7.14"
 source = { virtual = "." }
 dependencies = [
     { name = "mqt-qecc" },


### PR DESCRIPTION
Accessibility defects, each one reproduced with a measurement in a real browser before and
after the change. They have nothing in common but the failure mode: every one of them looks
correct to a sighted mouse user, which is why none had been caught.

Verified against `npm run build` + `astro preview` (Chrome). Contrast was measured from
freshly-inserted probe elements carrying the identical class list, because `transition-colors`
freezes the computed colour of an existing element when the tab is backgrounded and gives a
stale reading.

> **Second pass.** Review found that the check I used to prove the amber sweep was complete
> was itself broken (see §8), and with it fixed, four more focus-ring sites turned up that the
> first pass had missed. Both are corrected below, along with a hover affordance the first
> pass flattened and two loose ends on the combobox.

## 1. The focus ring failed WCAG 1.4.11 Non-text Contrast

`ring-blue-500/40` composited against the surface it outlines:

| | ring vs background | ring vs the element's own resting border |
| --- | --- | --- |
| before, `blue-500/40` — light | **1.64:1** | **1.33:1** (row) / **1.12:1** (input) |
| before, `blue-500/40` — dark | **1.74:1** | **1.27:1** (row) / **1.12:1** (input) |
| after, solid `blue-500` — light | **3.76:1** | **3.04:1** (row) / **2.55:1** (input) |
| after, solid `blue-500` — dark | **5.35:1** | **3.90:1** (row) / **2.74:1** (input) |

The second column is the real problem: at 1.1–1.3:1 against the border that is already there
when the element is *not* focused, the ring was close to invisible **as a state change**.

**Six call sites, not the two the defect was first reported at** — `CircuitRow`, `CodeCard`,
the `/search` query and filter inputs, the `/` filter input, and the row `favorites` builds
client-side. The four extra ones were found only after fixing §8; they are the same class
doing the same thing.

Residual, stated plainly: on the *inputs* the ring's inner neighbour is the field's own
`gray-300`/`gray-700` border, and 2.55:1 / 2.74:1 there is short of 3:1. Its outer neighbour
is the page background, which it clears at 3.76:1 / 5.35:1. Closing that last edge means
restyling the input borders, which is a visual-design change rather than a contrast fix.

## 2. `text-amber-600` failed 4.5:1 in light mode

**3.20:1 on white.** It is used for the alpha superscript in the header (14px/600) and the
active-sort label (12px/600) — neither is large text, so the 3:1 exception does not apply.
`amber-700` measures **5.03:1**. Dark mode was already fine and is untouched: `amber-400` on
`gray-950` is **11.69:1**.

Bumped at all ten call sites in one go. A token whose whole job is "this is the sort you asked
for" stops doing it the moment two shades of it are in play.

## 3. …which flattened the hover step on two links

Two of those ten are links whose *only* hover feedback was that colour — the header α and
"Clear all active filters". Darkening the resting state narrowed the gap to the hover state:

| | hover step |
| --- | --- |
| original `amber-600` → `amber-800` | 2.22:1 |
| after §2, `amber-700` → `amber-800` | **1.41:1** |
| now, `amber-700` → `amber-900` | 1.80:1 |
| dark, `amber-400` → `amber-200` (unchanged, and always was) | 1.38:1 |

`amber-900` recovers some of it (9.06:1 against white, so still legible), but the substantive
fix is `hover:underline`: a cue that is not a hue. Dark mode never had a usable colour step
either and now gets the same underline, so this ends up better than the state before the PR
rather than merely level with it. Confirmed live under a real pointer hover —
`text-decoration-line: underline`, colour `amber-900`.

## 4. `/codes` skipped a heading level

`CodeCard.astro` emitted an `h3` directly under the page `h1` — the only heading-order
violation on the site. Now `h2`. The class list is unchanged and the rendering is identical,
since the card sets its own size and weight (16px/500/margin 0) rather than inheriting from
the tag. `CodeCard` has one call site. `ToolCard.astro` keeps its `h3` deliberately: `/tools`
has a real `h2` above it.

Confirmed in the browser: `/codes` is now 1 × `h1` + 85 × `h2` and nothing deeper.

## 5. Three `text-gray-500` on `/search` had no dark variant

**4.16:1 on `gray-950`**, under 4.5:1 → **7.74:1** with `dark:text-gray-400`. One paragraph
(the result count) and two "Clear"/"Clear filters" links whose dark colour only applied on
`:hover`. Every sibling paragraph in the file already had the variant and `global.css` states
the pairing as a house rule, so these were omissions rather than choices.

## 6. Format tabs conveyed the active format by colour alone (WCAG 4.1.2)

`FormatSwitcher.astro` emitted plain buttons and `format-switcher-client.ts` rewrote only
`className` and `display`, so nothing in the accessibility tree said which tab was current.
They now carry `aria-pressed`, following `CodeMatrices.astro`, which already uses exactly that
pattern.

Deliberately **not** a full `tablist`/`tab`/`tabpanel`: that needs roving `tabindex` and arrow
keys, and arrow keys collide with the existing row navigation while the 1/2/3 shortcuts
already cover direct selection.

The initial state is read off the visible `.format-body` rather than assumed to be the first
tab. The tabs on **code** pages are cloned from `CircuitBodiesTemplate.astro`, which carries no
ARIA of its own, and deriving the state in `initFormatSwitchers` — which both the
server-rendered and the cloned path call — covers both without editing the template. Verified
on a circuit detail page and on a code page after expanding a row: `aria-pressed` starts
correct and flips on click, including when the 1/2/3 shortcuts drive it, since those dispatch
a real click.

## 7. The header quick-search was an incomplete combobox

`SearchBar.astro`'s input had no `role="combobox"`, `aria-expanded`, `aria-controls` or
`aria-autocomplete`, and the results `<ul>` had no `id` — which meant the
`aria-activedescendant` the script has been writing all along pointed at nothing and was
ignored by assistive tech. So arrowing through the results announced nothing.

All five are wired up. They are applied from the script rather than the markup, for two
reasons: without JS there is no dropdown at all, and an input advertising a popup that can
never open is worse than a plain search field; and the layout renders two `SearchBar`s, so the
listbox `id` has to be per-instance — it reuses the same `instance` index the option ids
already use. The accessibility tree now reads
`combobox … / listbox "Search results" / option ×12`.

Two loose ends, both from the second pass:

- **`aria-live="polite"` came off the list.** It was there because nothing else announced the
  results, which was a fair call while `aria-activedescendant` resolved to nothing. Now that
  the combobox announces the active option, the live region announces the whole list on top of
  it and the user hears it twice. `role="listbox"` and `aria-label` stay.
- **A `focusout` handler.** `hide()` was reachable from Escape, a click outside and a query
  under two characters — not from losing focus, so Tab left `aria-expanded="true"` on an input
  nothing was focused on. It is guarded on a non-null `relatedTarget`: the result `<li>`s are
  not focusable, so pressing the mouse on one blurs the input with a null `relatedTarget`, and
  hiding there would remove the item between mousedown and the click that navigates. Verified
  both ways — a real Tab collapses it, and a real click on a result still lands on
  `/circuits/1254`.

**Follow-up, not done here:** the `<li>`s should be `<a>`s. That is a rewrite of `doSearch` and
`appendAdvanced` plus their click handlers, and it is a different change from wiring up the
ARIA that was already half-written.

## 8. Writing about a Tailwind class put it back in the stylesheet

The first version of this PR claimed "`--color-amber-600` no longer appears in the generated
CSS, confirming none were missed." **That check was wrong.** Tailwind v4 detects its own
sources, which means it reads every tracked file — including prose that merely *names* a class.
The CHANGELOG entry describing the amber bump regenerated `.text-amber-600{}`, and a design
plan under `docs/` was keeping `dark:text-amber-300` alive for a component that stopped using
it months ago.

The dead bytes are the small half. The large half is that it destroys "the class is gone from
the built CSS" as a way to verify a sweep across call sites — and it fails in the direction
that reports a false pass. It did exactly that here: four `ring-blue-500/40` sites survived the
first pass and were only found once this was fixed.

`global.css` now carries `@source not` for both paths. Verified in the built CSS after the
change: `.text-amber-600`, `.dark\:text-amber-300` and every `ring-blue-500\/40` rule are gone,
while `ring-blue-500`, `text-amber-700`, `text-amber-900` and `hover:underline` remain. The
sweep itself is now attested by `grep -rn 'amber-600\|blue-500/40' src/`, which is empty.

## 9. `/about` re-documented the shortcuts and had drifted

`KeyboardHelp.astro` holds `SHORTCUTS` as a module-local const; `/about` hand-writes the same
information as prose bullets. The bullets omitted `Home` and `End`, and described `Esc` as only
collapsing the open row when it also closes the help overlay. Both corrected.

The duplication itself stays. `KeyboardHelp`'s flat 17-row table and `/about`'s topic-grouped
bullets are different shapes — the bullets deliberately merge unrelated rows into one line — so
a shared `SHORTCUTS` module would have to grow a grouping layer to reproduce the prose. That is
a trade for a maintainer to make, not a drive-by refactor.

---

## Reported, not fixed: the main outstanding a11y item

**A circuit row is `role="button"` with `aria-expanded`, but Enter navigates away instead of
toggling** (`CircuitRow.astro`). A screen-reader user hears "button, collapsed", presses Enter
— the one thing that name and state promise will expand it — and lands on the circuit detail
page instead. That is WCAG 4.1.2: the role and state describe a control the element is not.

The honest fix is `role="group"` on the row plus a real toggle button inside it, and that
reaches further than it looks: six `.closest()` guards distinguish "clicked the row" from
"clicked something inside the row", and `expandSelfClick`, `hashAttr` and `expandFromHash` all
key off the row element being the interactive one. Deep-linking (`#qec-190` expanding a row on
load) runs through the same path. It wants its own PR with its own verification pass rather
than being folded into a contrast-and-ARIA sweep.

---

Version bumped to 0.7.12 (`package.json`, `pyproject.toml`, `uv.lock`, `package-lock.json`)
with a CHANGELOG entry. `npm run typecheck`, `npm run lint`, `npm run format:check`,
`npm run build` and `SKIP=prettier uvx pre-commit run --all-files` all pass, the last with 0
files modified. Note that `typecheck` runs against `tsconfig.check.json`, which excludes
`src/pages/search.astro` — one of the files touched here. The edits to it are class strings
only, so nothing is riding on that, but #163 removes the exclusion and is the better guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
