### PR TITLE
fix(seo): one canonical URL per page, and client code that survives a denied store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -258,39 +258,66 @@ the source-of-truth `package.json` version.
   (`ToolCard` already renders `id={tool.slug}`). Not added to `/search`: it is `Disallow`ed,
   so nothing would ever read it.
 - **Codes whose name already carries their parameters printed them twice** — "Gottesman
-  [[8,3,3]] Code [[8,3,3]]", "[[20,2,6]] Code [[20,2,6]]". Three copies of one guard tested
-  `name === params`, which only catches a name that is _nothing but_ its parameters, on
-  three separate surfaces: `llms.txt`, the header quick-search JSON and the `/search` code
-  filter. All three now test `includes`. Verified on the built server: `llms.txt` has no
-  doubled line left, `/api/search?q=gottesman` returns `params: ""`, and the dropdown and
-  the filter option both read "Gottesman [[8,3,3]] Code" once.
+  [[8,3,3]] Code [[8,3,3]]", "[[20,2,6]] Code [[20,2,6]]". The guard tested
+  `name === params`, which only catches a name that is _nothing but_ its parameters: of the
+  5 codes whose name contains them, 3 are exactly them, so 2 doubled. It had been written
+  out by hand at **eight** call sites — the `<title>`, the `<h1>`, the meta description, two
+  JSON-LD `name` fields, the code cards, `llms.txt`, the quick-search JSON and the `/search`
+  code filter — and correcting them one at a time is how the first pass fixed three and left
+  the page they link to still saying it twice. There is now one predicate,
+  `showCodeParams`/`codeDisplayName` beside `formatCodeParams`, and all eight sites call it.
+  Verified on the built server: all 84 code page titles, `/codes`, its ItemList, `llms.txt`,
+  `/api/search` and the `/search` filter — 0 doubled, with "Steane Code [[7,1,3]]" and the
+  bare "[[16,2,4]]" both still rendering exactly once.
 - **`/search` printed two different empty states, three lines apart** — "No circuits found
   for X" from the result count, then "No circuits match this query." from the empty state
-  proper. The count line is now suppressed when there is nothing to count, leaving the
-  centred block that also knows whether the filters are to blame and offers the way out of
-  them — the same shape `/tools` and `/codes` use for theirs.
+  proper. One empty state now, the centred one, and it carries what the count line used to:
+  the query as actually resolved (a correction rewrites it), whether the filters are to
+  blame, and the way out of each. The three result-set notices are suppressed when there is
+  no result set — "Showing results for steane." sitting directly above "No circuits match"
+  told the user two opposite things — and the escape hatch from a correction moves into the
+  empty state, which is the only thing rendered in that case.
 - **The header quick-search could show results for a query the user had typed past.**
   `doSearch` awaited `fetch` and `res.json()` and wrote `innerHTML` unconditionally: no
   ordering guard, no `res.ok` check, no `catch` — and it is called from a `setTimeout` with
   its promise dropped, so a 5xx (which answers with an HTML error page, making `res.json()`
   reject) threw where nothing could catch it and left the dropdown frozen on stale results.
   A generation counter now discards any response that is not the newest, and a failed
-  request leaves the previous list up for the next keystroke to replace. Verified in the
-  browser by holding responses open and releasing them out of order: the stale response no
-  longer wins, a 500 changes nothing and logs no unhandled rejection, and the next
+  request leaves the previous list up for the next keystroke to replace. **Dismissing counts
+  as newest**: `hide()` bumps the counter too, so a response still in flight cannot reopen a
+  dropdown closed with Escape or an outside click, nor answer a query backspaced below the
+  two-character floor. Verified in the browser by holding responses open and releasing them
+  in a chosen order: the stale response never wins, a dismissed one leaves the list hidden
+  and untouched, a 500 changes nothing and logs no unhandled rejection, and the next
   keystroke recovers.
+- **`aria-activedescendant` outlived the option it named.** Arrowing to the third result and
+  then typing on left the input pointing at `search-result-0-2` after that node had been
+  removed with the rest of the list — the attribute is cleared alongside `activeIndex` now.
 - **Ten unguarded `localStorage` calls, where a denied store throws on _read_.** Chrome's
   "block all cookies" and some embedded webviews make every access raise `SecurityError`,
   so these were not lost preferences but thrown exceptions mid-module. The worst sat in
   `codes/[code].astro`: the favourites-filter read is above the "download all" wiring, so a
   browser that refuses storage lost the download button, the keyboard shortcuts and the tag
-  dropdowns with it. `src/lib/safe-storage.ts` now wraps get/set — a read answers `null`, a
-  write is dropped — and the two `is:inline` scripts that cannot import it (the theme, the
-  search-filter disclosure) inline the same try/catch. Proved by serving the built site
-  through a proxy that makes `localStorage` throw before any page script runs:
-  `/codes/steane-code` renders all 81 rows with zero page errors, the favourites filter,
-  theme toggle and tag-view toggle all still respond, and "Download all" still fetches
-  `/api/download?code=steane-code`.
+  dropdowns with it. `src/lib/safe-storage.ts` now wraps get/set — a read answers `null` —
+  and the two `is:inline` scripts that cannot import it (the theme, the search-filter
+  disclosure) inline the same try/catch. Proved by serving the built site through a proxy
+  that makes `localStorage` throw before any page script runs: `/codes/steane-code` renders
+  all 81 rows with zero page errors, the favourites filter, theme toggle and tag-view
+  toggle all still respond, and "Download all" still fetches `/api/download?code=steane-code`.
+
+  **A write reports whether it landed, and favourites act on that.** Swallowing the failure
+  is right for a theme or a tag view and wrong for the user's own list: `importFavorites`
+  counts a merge it performs in memory, so a dropped write would have toasted
+  "Imported 3 new favorites" and called `location.reload()`, landing the user back on an
+  empty page with nothing to explain it — and a heart would fill for something never stored.
+  `setItem` returns a boolean, favourite writes turn `false` into `StorageBlockedError`, and
+  the message says what actually happened ("this browser is blocking site storage") instead
+  of the file-format error the import's catch-all would have shown. The toast is raised in
+  `favorites-client` rather than at each call site, so the hearts in `CircuitRow.astro`
+  explain themselves too. Verified under denied storage: the import toasts the storage
+  message, does not claim a count and does not reload; the hearts on a code page and on a
+  circuit page stay in their old state. Verified with storage working: the import still
+  stores `[101,102,103]`, reloads, and renders 3 rows, and a heart still round-trips.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -229,6 +229,68 @@ the source-of-truth `package.json` version.
   Corrected, along with how many preserve the code's distance.
 - **`circuit-distance:` fell into the filter's "Other" group** while `distance:` sits under
   Fault tolerance. Same question, different number — they belong together.
+- **Every page had two indexable URLs, and the prerendered ones canonicalised to the URL
+  the sitemap does not list.** `astro.config.mjs` set no `trailingSlash`, so Astro defaulted
+  to `"ignore"` and `Layout.astro` echoed back whatever path the request carried. `/codes`
+  and `/codes/` both answered 200 and each named _itself_ canonical — one page, two
+  self-canonicalising URLs — while `/about` baked `https://qecirc.com/about/` against a
+  `sitemap.xml` that lists `https://qecirc.com/about`. Now `trailingSlash: "never"`, and the
+  canonical is normalised rather than echoed, so it holds for an SSR page whose request the
+  router did not shape. Crawled before and after on a built server, every route in both
+  forms: each slash-free form answers exactly as it did, and all 16 trailing-slash variants
+  — 12 of which used to answer 200 as a duplicate, 4 the 404 body — now `301` to the
+  slash-free URL with the query string intact
+  (`/search/?q=steane%20code&tag=x` → `/search?q=steane%20code&tag=x`).
+  Canonical, `og:url` and `sitemap.xml` now agree on one URL per page, prerendered and SSR
+  alike.
+- **The site-wide `SearchAction` advertised a path `robots.txt` forbids.** `Layout.astro`
+  told every crawler it could search at `/search?q={search_term_string}`; `robots.txt.ts`
+  disallows `/search` for every agent, and deliberately — the `?q=` key space is unbounded.
+  Both landed in `0abfe8c5`, whose PR justifies the `Disallow` without mentioning the
+  markup it contradicts. Removed rather than reconciled: Google retired the sitelinks
+  searchbox this fed in November 2024, so the four lines were inert as well as wrong.
+- **`/tools` shipped no structured data** though it is the exact sibling of `/codes`, which
+  has carried `CollectionPage` + `ItemList` + `BreadcrumbList` since the JSON-LD went in —
+  and CLAUDE.md asks for matching `jsonLd` when an entity page type is added. It now
+  carries the same graph, enumerating the **unfiltered** 11 tools: `?tag=` filters that page
+  on the server but every variant canonicalises to `/tools`, so the enumeration has to
+  describe that one URL. Tools have no page of their own, so each item links to its anchor
+  (`ToolCard` already renders `id={tool.slug}`). Not added to `/search`: it is `Disallow`ed,
+  so nothing would ever read it.
+- **Codes whose name already carries their parameters printed them twice** — "Gottesman
+  [[8,3,3]] Code [[8,3,3]]", "[[20,2,6]] Code [[20,2,6]]". Three copies of one guard tested
+  `name === params`, which only catches a name that is _nothing but_ its parameters, on
+  three separate surfaces: `llms.txt`, the header quick-search JSON and the `/search` code
+  filter. All three now test `includes`. Verified on the built server: `llms.txt` has no
+  doubled line left, `/api/search?q=gottesman` returns `params: ""`, and the dropdown and
+  the filter option both read "Gottesman [[8,3,3]] Code" once.
+- **`/search` printed two different empty states, three lines apart** — "No circuits found
+  for X" from the result count, then "No circuits match this query." from the empty state
+  proper. The count line is now suppressed when there is nothing to count, leaving the
+  centred block that also knows whether the filters are to blame and offers the way out of
+  them — the same shape `/tools` and `/codes` use for theirs.
+- **The header quick-search could show results for a query the user had typed past.**
+  `doSearch` awaited `fetch` and `res.json()` and wrote `innerHTML` unconditionally: no
+  ordering guard, no `res.ok` check, no `catch` — and it is called from a `setTimeout` with
+  its promise dropped, so a 5xx (which answers with an HTML error page, making `res.json()`
+  reject) threw where nothing could catch it and left the dropdown frozen on stale results.
+  A generation counter now discards any response that is not the newest, and a failed
+  request leaves the previous list up for the next keystroke to replace. Verified in the
+  browser by holding responses open and releasing them out of order: the stale response no
+  longer wins, a 500 changes nothing and logs no unhandled rejection, and the next
+  keystroke recovers.
+- **Ten unguarded `localStorage` calls, where a denied store throws on _read_.** Chrome's
+  "block all cookies" and some embedded webviews make every access raise `SecurityError`,
+  so these were not lost preferences but thrown exceptions mid-module. The worst sat in
+  `codes/[code].astro`: the favourites-filter read is above the "download all" wiring, so a
+  browser that refuses storage lost the download button, the keyboard shortcuts and the tag
+  dropdowns with it. `src/lib/safe-storage.ts` now wraps get/set — a read answers `null`, a
+  write is dropped — and the two `is:inline` scripts that cannot import it (the theme, the
+  search-filter disclosure) inline the same try/catch. Proved by serving the built site
+  through a proxy that makes `localStorage` throw before any page script runs:
+  `/codes/steane-code` renders all 81 rows with zero page errors, the favourites filter,
+  theme toggle and tag-view toggle all still respond, and "Download all" still fetches
+  `/api/download?code=steane-code`.
 
 ### Added
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,11 @@ import tailwindcss from "@tailwindcss/vite";
 
 export default defineConfig({
   site: "https://qecirc.com",
+  // One URL per page. Astro's default ("ignore") served /codes and /codes/ as
+  // two 200s that self-canonicalised differently, while the prerendered pages
+  // baked "/about/" against a sitemap that lists "/about". Layout.astro strips
+  // the trailing slash from the canonical URL for the same reason.
+  trailingSlash: "never",
   adapter: node({ mode: "standalone" }),
   server: { host: "0.0.0.0", port: parseInt(process.env.PORT || "4321") },
   prefetch: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qecirc-website",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qecirc-website",
-      "version": "0.7.12",
+      "version": "0.7.13",
       "license": "MIT",
       "dependencies": {
         "@astrojs/node": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qecirc-website",
   "type": "module",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "license": "MIT",
   "scripts": {
     "dev": "astro dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qecirc-website"
-version = "0.7.12"
+version = "0.7.13"
 description = "QECirc — quantum error correction circuit library"
 license = "MIT"
 requires-python = ">=3.13"

--- a/src/components/CodeCard.astro
+++ b/src/components/CodeCard.astro
@@ -1,7 +1,7 @@
 ---
 import TagList from "./TagList.astro";
 import type { CodeWithMeta } from "../types";
-import { formatCodeParams } from "../lib/queries";
+import { formatCodeParams, showCodeParams } from "../lib/queries";
 
 interface Props {
   code: CodeWithMeta;
@@ -16,7 +16,7 @@ interface Props {
 const { code, basePath, baseUrl, selectedTags } = Astro.props;
 const { name, slug, tags, circuit_count } = code;
 const params = formatCodeParams(code);
-const showParams = params !== "" && name !== params;
+const showParams = showCodeParams(code);
 
 // Row data consumed by list-filter-client.ts (client-side filtering/sorting).
 const rowMetrics = JSON.stringify({ n: code.n, k: code.k, d: code.d ?? null });

--- a/src/components/Layout.astro
+++ b/src/components/Layout.astro
@@ -16,7 +16,13 @@ interface Props {
 
 const DEFAULT_DESCRIPTION = "QECirc — a community-driven library for quantum error correction circuits";
 const { title, description = DEFAULT_DESCRIPTION, jsonLd } = Astro.props;
-const canonicalUrl = new URL(Astro.url.pathname, Astro.site ?? Astro.url.origin).href;
+// Normalised, not echoed: a prerendered page reports its pathname with a
+// trailing slash ("/about/") while sitemap.xml lists "/about", and an SSR page
+// echoes whatever the request asked for. Stripping it here makes canonical,
+// og:url and the sitemap name the same URL on both kinds of page — which is
+// also what `trailingSlash: "never"` (astro.config.mjs) enforces at the router.
+const canonicalPath = Astro.url.pathname.replace(/\/+$/, "") || "/";
+const canonicalUrl = new URL(canonicalPath, Astro.site ?? Astro.url.origin).href;
 const fullTitle = `${title} - QECirc`;
 
 // Site-wide structured data (schema.org), emitted on every page. Entity-level
@@ -42,14 +48,10 @@ const siteGraph = {
       description: DEFAULT_DESCRIPTION,
       inLanguage: "en",
       publisher: { "@id": `${siteUrl}/#organization` },
-      potentialAction: {
-        "@type": "SearchAction",
-        target: {
-          "@type": "EntryPoint",
-          urlTemplate: `${siteUrl}/search?q={search_term_string}`,
-        },
-        "query-input": "required name=search_term_string",
-      },
+      // No `potentialAction`/SearchAction: it advertised /search, which
+      // robots.txt.ts disallows for every agent, so it pointed crawlers at a
+      // path they must not fetch. Google retired the sitelinks searchbox it fed
+      // in November 2024, so there is nothing to un-disallow /search for.
     },
   ],
 };
@@ -105,7 +107,16 @@ const sunIconSvg = `<svg class="w-4 h-4 hidden dark:block" viewBox="0 0 24 24" f
     {extraJsonLd.map((obj) => <script type="application/ld+json" set:html={serializeLd(obj)} />)}
     <script is:inline>
       (function () {
-        const stored = localStorage.getItem("theme");
+        // Inline copy of src/lib/safe-storage.ts: an is:inline script cannot
+        // import. Reading localStorage throws outright where storage is denied
+        // (Chrome "block all cookies", some embedded webviews), and an
+        // exception here would leave the page on its light-mode default.
+        let stored = null;
+        try {
+          stored = localStorage.getItem("theme");
+        } catch {
+          // Storage denied — fall through to the OS preference.
+        }
         const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
         if (stored === "dark" || (!stored && prefersDark)) {
           document.documentElement.classList.add("dark");
@@ -226,7 +237,12 @@ const sunIconSvg = `<svg class="w-4 h-4 hidden dark:block" viewBox="0 0 24 24" f
     <script is:inline>
       function toggleTheme() {
         const dark = document.documentElement.classList.toggle("dark");
-        localStorage.setItem("theme", dark ? "dark" : "light");
+        try {
+          localStorage.setItem("theme", dark ? "dark" : "light");
+        } catch {
+          // Storage denied — the choice applies to this page view only. The
+          // listeners below still get wired up, which is the point of the guard.
+        }
       }
       document.getElementById("theme-toggle").addEventListener("click", toggleTheme);
       const mobileTheme = document.getElementById("theme-toggle-mobile");

--- a/src/components/SearchBar.astro
+++ b/src/components/SearchBar.astro
@@ -26,6 +26,23 @@
   // runs this script once, so each instance is wired up individually.
   document.querySelectorAll<HTMLElement>(".search-bar").forEach(initSearchBar);
 
+  type SearchResult = {
+    type: string;
+    name: string;
+    slug: string;
+    qec_id?: string;
+    params: string;
+    tags: string[];
+    href: string;
+    subtitle?: string;
+  };
+
+  // Only the newest request may write to a dropdown. Responses can arrive out
+  // of order, and a slow one landing last would replace the list with results
+  // for a query the user has already typed past. Shared by both instances --
+  // only one of them is ever visible, so only one is ever being typed into.
+  let latestSearch = 0;
+
   function initSearchBar(container: HTMLElement, instance: number) {
   const input = container.querySelector("input") as HTMLInputElement;
   const resultsList = container.querySelector("ul") as HTMLUListElement;
@@ -72,8 +89,20 @@
       return;
     }
 
-    const res = await fetch("/api/search?q=" + encodeURIComponent(query));
-    const results: { type: string; name: string; slug: string; qec_id?: string; params: string; tags: string[]; href: string; subtitle?: string }[] = await res.json();
+    const seq = ++latestSearch;
+    let results: SearchResult[];
+    try {
+      const res = await fetch("/api/search?q=" + encodeURIComponent(query));
+      // A 5xx answers with an HTML error page, so res.json() rejects. This runs
+      // from a setTimeout with its promise dropped, where that rejection is
+      // unhandled and freezes the dropdown on stale results; leave the previous
+      // list up instead -- the next keystroke retries.
+      if (!res.ok) return;
+      results = await res.json();
+    } catch {
+      return;
+    }
+    if (seq !== latestSearch) return;
 
     resultsList.innerHTML = "";
     activeIndex = -1;

--- a/src/components/SearchBar.astro
+++ b/src/components/SearchBar.astro
@@ -56,6 +56,11 @@
   }
 
   function hide() {
+    // Bump the generation too. Dismissing the dropdown — Escape, an outside
+    // click, or backspacing below the two-character floor, which calls this —
+    // must also abandon whatever is in flight, or that response reopens a list
+    // the user just closed, or answers a query they have already deleted.
+    latestSearch++;
     resultsList.classList.add("hidden");
     activeIndex = -1;
     input.removeAttribute("aria-activedescendant");
@@ -106,6 +111,10 @@
 
     resultsList.innerHTML = "";
     activeIndex = -1;
+    // The active item is about to be removed from the DOM; an
+    // aria-activedescendant naming a node that no longer exists points a
+    // screen reader at nothing.
+    input.removeAttribute("aria-activedescendant");
     cachedItems = [];
 
     if (results.length === 0) {

--- a/src/lib/favorites-client.ts
+++ b/src/lib/favorites-client.ts
@@ -1,6 +1,23 @@
-import { safeStorage } from "./safe-storage";
+import { safeStorage, StorageBlockedError } from "./safe-storage";
+
+// Reads degrade quietly (no favourites is a valid answer); writes do not. A
+// write that vanishes here is the user's own list, and a caller that assumes
+// it landed will report a success that did not happen — so every write throws
+// StorageBlockedError instead of returning as if it had worked.
 
 const STORAGE_KEY = "qecirc-favorites";
+
+/**
+ * Say it here, not at each call site: the hearts in `CircuitRow.astro` have no
+ * error path of their own, and a silent no-op there is exactly the lie this is
+ * meant to prevent. Precedent for a lib module reaching for the toast is
+ * `src/lib/cite-client.ts`.
+ */
+function toastStorageBlocked(): void {
+  if (typeof window !== "undefined" && typeof window.showCiteToast === "function") {
+    window.showCiteToast("Couldn't update favorites — this browser is blocking site storage.");
+  }
+}
 
 export function getFavorites(): number[] {
   try {
@@ -18,7 +35,12 @@ export function isFavorite(qecId: number): boolean {
   return getFavorites().includes(qecId);
 }
 
-/** Toggle a circuit's favorite status. Returns `true` if now favorited. */
+/**
+ * Toggle a circuit's favorite status. Returns `true` if now favorited.
+ *
+ * Toasts and throws `StorageBlockedError` if the new list could not be stored —
+ * the caller must not fill in a heart for something that was never saved.
+ */
 export function toggleFavorite(qecId: number): boolean {
   const favs = getFavorites();
   const idx = favs.indexOf(qecId);
@@ -27,7 +49,10 @@ export function toggleFavorite(qecId: number): boolean {
   } else {
     favs.splice(idx, 1);
   }
-  safeStorage.setItem(STORAGE_KEY, JSON.stringify(favs));
+  if (!safeStorage.setItem(STORAGE_KEY, JSON.stringify(favs))) {
+    toastStorageBlocked();
+    throw new StorageBlockedError();
+  }
   return idx === -1;
 }
 
@@ -39,7 +64,14 @@ export function exportFavorites(): string {
 const MAX_IMPORT_SIZE = 100_000; // 100 KB max file size
 const MAX_FAVORITES = 5_000; // cap total favorites
 
-/** Import favorites from a JSON string. Merges with existing. Returns count of newly added IDs. */
+/**
+ * Import favorites from a JSON string. Merges with existing. Returns count of
+ * newly added IDs.
+ *
+ * The count is computed from an in-memory Set, so it describes an import that
+ * has not been persisted yet: throws `StorageBlockedError` when the write is
+ * refused, rather than reporting "Imported 3" for a list that is still empty.
+ */
 export function importFavorites(json: string): number {
   if (json.length > MAX_IMPORT_SIZE) throw new Error("File too large");
   const parsed = JSON.parse(json);
@@ -55,6 +87,7 @@ export function importFavorites(json: string): number {
     if (existing.size >= MAX_FAVORITES) break;
     existing.add(id);
   }
-  safeStorage.setItem(STORAGE_KEY, JSON.stringify([...existing]));
+  if (!safeStorage.setItem(STORAGE_KEY, JSON.stringify([...existing])))
+    throw new StorageBlockedError();
   return existing.size - before;
 }

--- a/src/lib/favorites-client.ts
+++ b/src/lib/favorites-client.ts
@@ -1,8 +1,10 @@
+import { safeStorage } from "./safe-storage";
+
 const STORAGE_KEY = "qecirc-favorites";
 
 export function getFavorites(): number[] {
   try {
-    const raw = localStorage.getItem(STORAGE_KEY);
+    const raw = safeStorage.getItem(STORAGE_KEY);
     if (!raw) return [];
     const parsed = JSON.parse(raw);
     if (!Array.isArray(parsed)) return [];
@@ -25,7 +27,7 @@ export function toggleFavorite(qecId: number): boolean {
   } else {
     favs.splice(idx, 1);
   }
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(favs));
+  safeStorage.setItem(STORAGE_KEY, JSON.stringify(favs));
   return idx === -1;
 }
 
@@ -53,6 +55,6 @@ export function importFavorites(json: string): number {
     if (existing.size >= MAX_FAVORITES) break;
     existing.add(id);
   }
-  localStorage.setItem(STORAGE_KEY, JSON.stringify([...existing]));
+  safeStorage.setItem(STORAGE_KEY, JSON.stringify([...existing]));
   return existing.size - before;
 }

--- a/src/lib/queries/codes.ts
+++ b/src/lib/queries/codes.ts
@@ -33,6 +33,29 @@ export function formatCodeParams(code: Pick<Code, "n" | "k" | "d">): string {
   return code.d != null ? `[[${code.n},${code.k},${code.d}]]` : `[[${code.n},${code.k}]]`;
 }
 
+/**
+ * Whether `[[n,k,d]]` is worth rendering beside the name.
+ *
+ * `includes`, not `===`: 5 of the 84 codes carry their parameters inside their
+ * name and only 3 of those are *nothing but* the parameters, so an equality
+ * test let "Gottesman [[8,3,3]] Code" and "[[20,2,6]] Code" print theirs twice.
+ *
+ * One predicate for one question. It was written out by hand at eight call
+ * sites — the page title, the `<h1>`, the meta description, two JSON-LD `name`
+ * fields, the code cards, `llms.txt`, the quick-search JSON and the /search
+ * code filter — which is exactly how five of them were missed when the other
+ * three were corrected.
+ */
+export function showCodeParams(code: Pick<Code, "name" | "n" | "k" | "d">): boolean {
+  const params = formatCodeParams(code);
+  return params !== "" && !code.name.includes(params);
+}
+
+/** The code's name, with `[[n,k,d]]` appended unless the name already has it. */
+export function codeDisplayName(code: Pick<Code, "name" | "n" | "k" | "d">): string {
+  return showCodeParams(code) ? `${code.name} ${formatCodeParams(code)}` : code.name;
+}
+
 export function getAllCodes(): CodeWithMeta[] {
   const db = getDb();
   const codes = db

--- a/src/lib/queries/index.ts
+++ b/src/lib/queries/index.ts
@@ -1,5 +1,13 @@
 export { getTagsFor, parseFilterString, hasActiveFilters, getTagsWithCount } from "./shared";
-export { formatCodeParams, getAllCodes, getCodeBySlug, filterCodes, countAllCodes } from "./codes";
+export {
+  formatCodeParams,
+  showCodeParams,
+  codeDisplayName,
+  getAllCodes,
+  getCodeBySlug,
+  filterCodes,
+  countAllCodes,
+} from "./codes";
 export {
   formatCircuitId,
   getCircuitsForCode,

--- a/src/lib/safe-storage.ts
+++ b/src/lib/safe-storage.ts
@@ -7,7 +7,14 @@
  * sits in: the favourites-filter read on a code page sits above the
  * "download all" wiring, so a browser that refuses storage lost the download
  * button too. A missing preference is not an error, so both calls degrade to
- * "nothing stored" / "not persisted" rather than propagating.
+ * "nothing stored" rather than propagating.
+ *
+ * **A write is not silent, though: `setItem` reports whether it landed.** A
+ * dropped preference (theme, tag view) is a shrug; a dropped *favourite* is
+ * data the user thinks they saved. Any caller whose next act is to claim
+ * success must check the return value — see `favorites-client.ts`, which turns
+ * `false` into `StorageBlockedError` rather than reporting an import that
+ * never happened.
  *
  * The two `is:inline` scripts (the theme in Layout.astro, the filter disclosure
  * in search.astro) cannot import a module and inline the same try/catch.
@@ -22,12 +29,23 @@ export const safeStorage = {
     }
   },
 
-  /** Persist a value, silently doing nothing if storage refuses it. */
-  setItem(key: string, value: string): void {
+  /** Persist a value. Returns `false` if storage refused it; never throws. */
+  setItem(key: string, value: string): boolean {
     try {
       localStorage.setItem(key, value);
+      return true;
     } catch {
-      // Storage denied or full — the preference just does not survive the page.
+      // Storage denied or full. The caller decides whether that is worth
+      // saying out loud.
+      return false;
     }
   },
 };
+
+/** Thrown by a write whose failure the user has to be told about. */
+export class StorageBlockedError extends Error {
+  constructor() {
+    super("Browser storage is blocked, so nothing could be saved.");
+    this.name = "StorageBlockedError";
+  }
+}

--- a/src/lib/safe-storage.ts
+++ b/src/lib/safe-storage.ts
@@ -1,0 +1,33 @@
+/**
+ * `localStorage` that cannot throw.
+ *
+ * Where storage is denied — Chrome's "block all cookies", some embedded
+ * webviews, a full quota — *every* access throws a `SecurityError`, reads
+ * included. Unguarded, one preference lookup aborts the rest of the module it
+ * sits in: the favourites-filter read on a code page sits above the
+ * "download all" wiring, so a browser that refuses storage lost the download
+ * button too. A missing preference is not an error, so both calls degrade to
+ * "nothing stored" / "not persisted" rather than propagating.
+ *
+ * The two `is:inline` scripts (the theme in Layout.astro, the filter disclosure
+ * in search.astro) cannot import a module and inline the same try/catch.
+ */
+export const safeStorage = {
+  /** The stored value, or `null` if absent *or* unreadable. */
+  getItem(key: string): string | null {
+    try {
+      return localStorage.getItem(key);
+    } catch {
+      return null;
+    }
+  },
+
+  /** Persist a value, silently doing nothing if storage refuses it. */
+  setItem(key: string, value: string): void {
+    try {
+      localStorage.setItem(key, value);
+    } catch {
+      // Storage denied or full — the preference just does not survive the page.
+    }
+  },
+};

--- a/src/lib/tag-dropdowns-client.ts
+++ b/src/lib/tag-dropdowns-client.ts
@@ -1,3 +1,5 @@
+import { safeStorage } from "./safe-storage";
+
 /**
  * Behavior for a tag filter block rendered by TagFilterDropdowns.astro:
  * one category dropdown open at a time, close on outside click / Escape, and
@@ -55,13 +57,13 @@ export function initTagDropdowns(root: HTMLElement): void {
     cloud!.classList.toggle("hidden", view !== "all");
   }
 
-  const stored = localStorage.getItem(storageKey);
+  const stored = safeStorage.getItem(storageKey);
   applyView(stored === "all" || stored === "grouped" ? stored : defaultView);
 
   toggles.forEach(function (btn) {
     btn.addEventListener("click", function () {
       const view = grouped!.classList.contains("hidden") ? "grouped" : "all";
-      localStorage.setItem(storageKey, view);
+      safeStorage.setItem(storageKey, view);
       applyView(view);
     });
   });

--- a/src/pages/api/search.ts
+++ b/src/pages/api/search.ts
@@ -8,6 +8,7 @@ import {
   correctTokens,
   tokenizeQuery,
   formatCodeParams,
+  showCodeParams,
   formatCircuitId,
   MIN_QUERY_LENGTH,
 } from "../../lib/queries";
@@ -36,15 +37,13 @@ export const GET: APIRoute = ({ url }) => {
   const q = changed ? tokens.join(" ") : raw;
 
   const codes = searchCodes(q).map((c) => {
-    const params = formatCodeParams(c);
     return {
       type: "code" as const,
       name: c.name,
       slug: c.slug,
-      // `includes`, not `===`: the dropdown renders name and params as adjacent
-      // spans, so a name that already carries them ("Gottesman [[8,3,3]] Code")
-      // showed the parameters twice.
-      params: c.name.includes(params) ? "" : params,
+      // The dropdown renders name and params as adjacent spans, so a name that
+      // already carries them ("Gottesman [[8,3,3]] Code") must send none.
+      params: showCodeParams(c) ? formatCodeParams(c) : "",
       tags: c.tags,
       href: `/codes/${c.slug}`,
     };

--- a/src/pages/api/search.ts
+++ b/src/pages/api/search.ts
@@ -41,7 +41,10 @@ export const GET: APIRoute = ({ url }) => {
       type: "code" as const,
       name: c.name,
       slug: c.slug,
-      params: c.name === params ? "" : params,
+      // `includes`, not `===`: the dropdown renders name and params as adjacent
+      // spans, so a name that already carries them ("Gottesman [[8,3,3]] Code")
+      // showed the parameters twice.
+      params: c.name.includes(params) ? "" : params,
       tags: c.tags,
       href: `/codes/${c.slug}`,
     };

--- a/src/pages/circuits/[qec_id].astro
+++ b/src/pages/circuits/[qec_id].astro
@@ -247,7 +247,13 @@ const jsonLd = [
       setFavState(favBtn, isFavorite(qecId));
 
       favBtn.addEventListener("click", function () {
-        setFavState(favBtn, toggleFavorite(qecId));
+        try {
+          setFavState(favBtn, toggleFavorite(qecId));
+        } catch {
+          // Nothing was stored, so the heart must not change: a filled heart
+          // that survives no reload is worse than no heart at all.
+          // toggleFavorite has already told the user why.
+        }
       });
     });
   }

--- a/src/pages/codes/[code].astro
+++ b/src/pages/codes/[code].astro
@@ -14,6 +14,8 @@ import {
   getCodeBySlug,
   getTagsFor,
   formatCodeParams,
+  showCodeParams,
+  codeDisplayName,
   codeHasWeightedCircuits,
   getCircuitTagsForCode,
   getCircuitsForCode,
@@ -63,7 +65,7 @@ const sortHref = (field: CircuitSortField) => `${basePath}?sort=${field}&sort_di
 
 const siteUrl = (Astro.site ?? new URL(Astro.url.origin)).href.replace(/\/$/, "");
 const pageUrl = `${siteUrl}/codes/${codeSlug}`;
-const codeTitle = params && code.name !== params ? `${code.name} ${params}` : code.name;
+const codeTitle = codeDisplayName(code);
 const collection: Record<string, unknown> = {
   "@context": "https://schema.org",
   "@type": "CollectionPage",
@@ -112,7 +114,7 @@ const jsonLd = [
     apart, and the JSON-LD on this page already used it. */}
 <Layout
   title={codeTitle}
-  description={`Circuits for ${code.name}${params && code.name !== params ? ` ${params}` : ""}`}
+  description={`Circuits for ${codeTitle}`}
   jsonLd={jsonLd}
 >
   <a
@@ -136,7 +138,7 @@ const jsonLd = [
         measured 0.00px gap. Same construction as CodeCard.astro. */}
     <h1 class="text-2xl font-bold flex items-baseline flex-wrap gap-x-2">
       <span>{code.name}</span>
-      {params !== "" && code.name !== params && <span class="text-gray-500 dark:text-gray-400 font-normal">{params}</span>}
+      {showCodeParams(code) && <span class="text-gray-500 dark:text-gray-400 font-normal">{params}</span>}
     </h1>
     {code.zoo_url && (
       <a

--- a/src/pages/codes/[code].astro
+++ b/src/pages/codes/[code].astro
@@ -252,6 +252,7 @@ const jsonLd = [
 
 <script>
   import { getFavorites } from "../../lib/favorites-client";
+  import { safeStorage } from "../../lib/safe-storage";
   import { initListKeynav } from "../../lib/list-keynav-client";
   import { initListFilter } from "../../lib/list-filter-client";
   import { initCircuitActions } from "../../lib/circuit-actions-client";
@@ -335,7 +336,7 @@ const jsonLd = [
 
   const favToggle = document.getElementById("fav-filter-toggle");
   if (favToggle) {
-    let active = localStorage.getItem(FAV_FILTER_LS_KEY) === "true";
+    let active = safeStorage.getItem(FAV_FILTER_LS_KEY) === "true";
     if (active) {
       favToggle.setAttribute("aria-pressed", "true");
       applyFavFilter(true);
@@ -343,7 +344,7 @@ const jsonLd = [
     favToggle.addEventListener("click", function () {
       active = !active;
       favToggle.setAttribute("aria-pressed", active ? "true" : "false");
-      localStorage.setItem(FAV_FILTER_LS_KEY, String(active));
+      safeStorage.setItem(FAV_FILTER_LS_KEY, String(active));
       applyFavFilter(active);
     });
   }

--- a/src/pages/codes/index.astro
+++ b/src/pages/codes/index.astro
@@ -4,7 +4,7 @@ export const prerender = false;
 import Layout from "../../components/Layout.astro";
 import CodeCard from "../../components/CodeCard.astro";
 import CodeFilter from "../../components/CodeFilter.astro";
-import { filterCodes, getTagsWithCount, formatCodeParams } from "../../lib/queries";
+import { filterCodes, getTagsWithCount, codeDisplayName } from "../../lib/queries";
 
 // Filtering/sorting happens client-side (list-filter-client.ts): the page
 // always renders the full list in default order and ignores filter params,
@@ -29,15 +29,12 @@ const jsonLd = [
     mainEntity: {
       "@type": "ItemList",
       numberOfItems: totalCount,
-      itemListElement: codes.slice(0, 200).map((code, i) => {
-        const params = formatCodeParams(code);
-        return {
-          "@type": "ListItem",
-          position: i + 1,
-          name: params === "" || code.name === params ? code.name : `${code.name} ${params}`,
-          url: `${siteUrl}/codes/${code.slug}`,
-        };
-      }),
+      itemListElement: codes.slice(0, 200).map((code, i) => ({
+        "@type": "ListItem",
+        position: i + 1,
+        name: codeDisplayName(code),
+        url: `${siteUrl}/codes/${code.slug}`,
+      })),
     },
   },
   {

--- a/src/pages/favorites.astro
+++ b/src/pages/favorites.astro
@@ -174,7 +174,14 @@ import Layout from "../components/Layout.astro";
             unfavBtn.setAttribute("data-list-fav", "");
             unfavBtn.innerHTML = `<svg class="w-3.5 h-3.5" fill="currentColor" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z" /></svg>`;
             unfavBtn.addEventListener("click", function () {
-              toggleFavorite(circuit.qec_id);
+              try {
+                toggleFavorite(circuit.qec_id);
+              } catch {
+                // Storage refused the write, so the circuit is still a
+                // favourite. Removing the row would say otherwise.
+                // toggleFavorite has already told the user why.
+                return;
+              }
               row.remove();
               // Remove section if empty
               if (list.children.length === 0) {
@@ -340,8 +347,18 @@ import Layout from "../components/Layout.astro";
         } else {
           if (toast) toast("All circuits in this list are already in your favorites.");
         }
-      } catch {
-        if (toast) toast("Invalid file format. Expected a QECirc favorites JSON file.");
+      } catch (err) {
+        // A blocked store is not a malformed file, and saying so matters here:
+        // the count comes from an in-memory merge, so reporting success and
+        // reloading would drop the user on the same empty list they started
+        // with, with nothing to explain it.
+        const blocked = err instanceof Error && err.name === "StorageBlockedError";
+        if (toast)
+          toast(
+            blocked
+              ? "Couldn't save — this browser is blocking site storage. Allow cookies/site data for qecirc.com and try again."
+              : "Invalid file format. Expected a QECirc favorites JSON file.",
+          );
       }
       // Reset so the same file can be re-imported
       importFile.value = "";

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from "astro";
-import { getAllCodes, formatCodeParams } from "../lib/queries";
+import { getAllCodes, codeDisplayName } from "../lib/queries";
 
 export const prerender = false;
 
@@ -13,10 +13,7 @@ export const GET: APIRoute = ({ site }) => {
   const totalCircuits = codes.reduce((sum, c) => sum + c.circuit_count, 0);
 
   const codeLines = codes.map((c) => {
-    const params = formatCodeParams(c);
-    // `includes`, not `===`: a name that already carries its parameters
-    // ("[[20,2,6]] Code") would otherwise be listed as "[[20,2,6]] Code [[20,2,6]]".
-    const label = params === "" || c.name.includes(params) ? c.name : `${c.name} ${params}`;
+    const label = codeDisplayName(c);
     const n = c.circuit_count;
     return `- [${label}](${base}/codes/${c.slug}): ${n} circuit${n !== 1 ? "s" : ""}`;
   });

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -14,7 +14,9 @@ export const GET: APIRoute = ({ site }) => {
 
   const codeLines = codes.map((c) => {
     const params = formatCodeParams(c);
-    const label = params === "" || c.name === params ? c.name : `${c.name} ${params}`;
+    // `includes`, not `===`: a name that already carries its parameters
+    // ("[[20,2,6]] Code") would otherwise be listed as "[[20,2,6]] Code [[20,2,6]]".
+    const label = params === "" || c.name.includes(params) ? c.name : `${c.name} ${params}`;
     const n = c.circuit_count;
     return `- [${label}](${base}/codes/${c.slug}): ${n} circuit${n !== 1 ? "s" : ""}`;
   });

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -66,7 +66,10 @@ const tagGroups = TAG_CATEGORIES.map((c) => ({
 const hasFilters = selectedTags.length > 0 || codeSlug !== "";
 const codeLabel = (c: { name: string; n: number; k: number; d: number | null }) => {
   const p = formatCodeParams(c);
-  return p === "" || c.name === p ? c.name : `${c.name} ${p}`;
+  // `includes`, not `===`: a name that already carries its parameters
+  // ("[[20,2,6]] Code", "Gottesman [[8,3,3]] Code") would otherwise print them
+  // twice in the code filter's options.
+  return p === "" || c.name.includes(p) ? c.name : `${c.name} ${p}`;
 };
 const clearHref = `/search?q=${encodeURIComponent(q)}${literal ? "&literal=1" : ""}`;
 // Escape hatch from a correction: same query, spelling left alone.
@@ -173,9 +176,20 @@ Astro.response.headers.set("Cache-Control", "public, max-age=0, s-maxage=600");
           const d = document.getElementById("search-filters");
           if (!d) return;
           const KEY = "qecirc:search-filters-open";
-          if (localStorage.getItem(KEY) === "1") d.open = true;
+          // Inline copy of src/lib/safe-storage.ts: an is:inline script cannot
+          // import. Reading throws where storage is denied, which would leave
+          // the disclosure without its toggle listener as well as its state.
+          try {
+            if (localStorage.getItem(KEY) === "1") d.open = true;
+          } catch {
+            // Storage denied — keep the server-rendered open state.
+          }
           d.addEventListener("toggle", function () {
-            localStorage.setItem(KEY, d.open ? "1" : "0");
+            try {
+              localStorage.setItem(KEY, d.open ? "1" : "0");
+            } catch {
+              // Storage denied — the choice does not survive the page.
+            }
           });
         })();
       </script>
@@ -200,12 +214,16 @@ Astro.response.headers.set("Cache-Control", "public, max-age=0, s-maxage=600");
 
   {hasQuery && (
     <>
-      <p class="text-sm text-gray-500 mb-3">
-        {results.length === 0
-          ? "No circuits found"
-          : `${truncated ? `Top ${results.length}` : results.length} ${results.length === 1 ? "circuit" : "circuits"}`}
-        {" for "}<span class="font-medium text-gray-900 dark:text-gray-100">{resolved?.display ?? q}</span>
-      </p>
+      {/* A count, and only a count: the empty state further down is the single
+          place that says nothing matched. It knows whether filters are to
+          blame and offers the way out of them, and two "no results" sentences
+          three lines apart read as a rendering fault. */}
+      {results.length > 0 && (
+        <p class="text-sm text-gray-500 mb-3">
+          {`${truncated ? `Top ${results.length}` : results.length} ${results.length === 1 ? "circuit" : "circuits"}`}
+          {" for "}<span class="font-medium text-gray-900 dark:text-gray-100">{resolved?.display ?? q}</span>
+        </p>
+      )}
 
       {resolved?.corrected && (
         <p class="text-sm text-gray-500 dark:text-gray-400 mb-3">

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -12,7 +12,7 @@ import {
   resolveQuery,
   getToolsForCircuits,
   getPapersForCircuits,
-  formatCodeParams,
+  codeDisplayName,
   MIN_QUERY_LENGTH,
 } from "../lib/queries";
 import { tagToggleUrl } from "../lib/url";
@@ -64,13 +64,7 @@ const tagGroups = TAG_CATEGORIES.map((c) => ({
 }));
 
 const hasFilters = selectedTags.length > 0 || codeSlug !== "";
-const codeLabel = (c: { name: string; n: number; k: number; d: number | null }) => {
-  const p = formatCodeParams(c);
-  // `includes`, not `===`: a name that already carries its parameters
-  // ("[[20,2,6]] Code", "Gottesman [[8,3,3]] Code") would otherwise print them
-  // twice in the code filter's options.
-  return p === "" || c.name.includes(p) ? c.name : `${c.name} ${p}`;
-};
+const codeLabel = codeDisplayName;
 const clearHref = `/search?q=${encodeURIComponent(q)}${literal ? "&literal=1" : ""}`;
 // Escape hatch from a correction: same query, spelling left alone.
 const literalHref = `/search?q=${encodeURIComponent(q)}&literal=1`;
@@ -225,7 +219,13 @@ Astro.response.headers.set("Cache-Control", "public, max-age=0, s-maxage=600");
         </p>
       )}
 
-      {resolved?.corrected && (
+      {/* All three notices describe a result set ("these are closely related
+          codes", "these match at least one term"), so they are nonsense with
+          nothing to point at: "Showing results for steane." directly above
+          "No circuits match" told the user two opposite things. The escape
+          hatch from a correction is not lost — it moves into the empty state
+          below, which is the only thing rendered in that case. */}
+      {results.length > 0 && resolved?.corrected && (
         <p class="text-sm text-gray-500 dark:text-gray-400 mb-3">
           Showing results for <span class="font-medium text-gray-900 dark:text-gray-100">{resolved.display}</span>.
           {" "}Search instead for{" "}
@@ -233,24 +233,37 @@ Astro.response.headers.set("Cache-Control", "public, max-age=0, s-maxage=600");
         </p>
       )}
 
-      {resolved?.relatedOnly && (
+      {results.length > 0 && resolved?.relatedOnly && (
         <p class="text-sm text-gray-500 dark:text-gray-400 mb-3">
           No code goes by that name here. These are closely related codes that people
           often mean by it &mdash; check the code on each result before relying on it.
         </p>
       )}
 
-      {resolved?.partial && (
+      {results.length > 0 && resolved?.partial && (
         <p class="text-sm text-gray-500 dark:text-gray-400 mb-3">
           No circuit matches every term, so these match at least one.
         </p>
       )}
 
       {results.length === 0 ? (
+        /* The one place a zero-result page speaks, so it has to carry
+           everything the count line above used to: what was actually searched
+           for (which is not always what was typed — a correction rewrites it),
+           whether the filters are to blame, and the way out of each. */
         <div class="text-center py-8">
           <p class="text-gray-500 dark:text-gray-400 mb-2">
-            No circuits match {hasFilters ? "this query and these filters." : "this query."}
+            No circuits match{" "}
+            <span class="font-medium text-gray-900 dark:text-gray-100">{resolved?.display ?? q}</span>
+            {hasFilters ? " with these filters." : "."}
           </p>
+          {resolved?.corrected && (
+            <p class="text-sm text-gray-500 dark:text-gray-400 mb-2">
+              Corrected from <span class="font-medium text-gray-900 dark:text-gray-100">{resolved.raw}</span>.
+              {" "}Search instead for{" "}
+              <a href={`${literalHref}`} class="underline hover:text-gray-900 dark:hover:text-gray-100">{resolved.raw}</a>.
+            </p>
+          )}
           {hasFilters && (
             <a href={clearHref} class="text-sm underline text-gray-500 hover:text-gray-900 dark:hover:text-gray-100">
               Clear filters

--- a/src/pages/tools/index.astro
+++ b/src/pages/tools/index.astro
@@ -19,8 +19,45 @@ const filters: ToolFilters = {
 };
 
 const hasFilters = hasActiveFilters(filters);
-const tools = hasFilters ? filterTools(filters) : getAllTools();
+const allTools = getAllTools();
+const tools = hasFilters ? filterTools(filters) : allTools;
 const allTags = getTagsWithCount("tool");
+
+// Mirrors /codes (src/pages/codes/index.astro): an entity listing page carries
+// a CollectionPage + ItemList and a BreadcrumbList, per CLAUDE.md.
+const siteUrl = (Astro.site ?? new URL(Astro.url.origin)).href.replace(/\/$/, "");
+const pageUrl = `${siteUrl}/tools`;
+const jsonLd = [
+  {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "@id": `${pageUrl}#tools`,
+    url: pageUrl,
+    name: "Tools",
+    description: "Software tools used to create QEC circuits.",
+    isPartOf: { "@id": `${siteUrl}/#website` },
+    // The unfiltered list, not `tools`: ?tag= filters this page on the server
+    // but every variant canonicalises to /tools, so the enumeration has to
+    // describe that one URL. Tools have no page of their own — each item links
+    // to its anchor here (ToolCard renders id={tool.slug}).
+    // Cap the enumeration to bound head size; numberOfItems keeps the true total.
+    mainEntity: {
+      "@type": "ItemList",
+      numberOfItems: allTools.length,
+      itemListElement: allTools.slice(0, 200).map((tool, i) => ({
+        "@type": "ListItem",
+        position: i + 1,
+        name: tool.name,
+        url: `${pageUrl}#${tool.slug}`,
+      })),
+    },
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [{ "@type": "ListItem", position: 1, name: "Tools", item: pageUrl }],
+  },
+];
 
 const contributed = tools.filter((t) => t.circuit_count > 0);
 const others = tools
@@ -28,7 +65,7 @@ const others = tools
   .sort((a, b) => a.name.localeCompare(b.name));
 ---
 
-<Layout title="Tools" description="Software tools used to create QEC circuits">
+<Layout title="Tools" description="Software tools used to create QEC circuits" jsonLd={jsonLd}>
   <h1 class="text-2xl font-bold mb-4">Tools</h1>
 
   <TagList tags={allTags} selectedTags={selectedTags} showCount baseUrl={Astro.url} basePath="/tools" class="mb-6">

--- a/uv.lock
+++ b/uv.lock
@@ -829,7 +829,7 @@ wheels = [
 
 [[package]]
 name = "qecirc-website"
-version = "0.7.12"
+version = "0.7.13"
 source = { virtual = "." }
 dependencies = [
     { name = "mqt-qecc" },


### PR DESCRIPTION
Defects in URL handling, structured data and client-side robustness, each reproduced first. Verified on a built server (`npm run db:create && npm run build` + `astro preview`), not in dev.

> **Second commit** (`8f5a551`) addresses an adversarial review of the first: the display-name guard is now fixed at all eight sites rather than three (§4), a blocked write no longer reports a favourites import that did not happen (§8), dismissing the quick-search abandons its in-flight request (§6), `aria-activedescendant` is cleared (§7), the empty state echoes the query again (§5), and the route table below is corrected. Two pre-existing hazards found while re-verifying are flagged, not fixed.

## 1. Every page had two indexable URLs

`astro.config.mjs` set no `trailingSlash`, so Astro defaulted to `"ignore"` and `Layout.astro` echoed the request path into both `<link rel="canonical">` and `og:url`. Two bugs from that one line: `/codes` and `/codes/` both answered 200 and each named **itself** canonical, and the prerendered pages baked `https://qecirc.com/about/` while `sitemap.xml` lists `https://qecirc.com/about`.

Fixed with `trailingSlash: "never"` **and** a normalised canonical — the config alone does not shape an SSR response's `Astro.url`, and normalising alone would leave the duplicate 200s.

Crawled every route in both forms, before and after:

| Route | before | after |
| --- | --- | --- |
| `/` | 200, canonical `…/` | 200, canonical `…/` (unchanged) |
| `/codes`, `/tools`, `/search`, `/codes/steane-code`, `/circuits/1` | 200, canonical = self | 200, canonical = self (unchanged) |
| `/search?q=steane` | 200, canonical `…/search` — the query is **not** part of the canonical | unchanged (canonical is built from `pathname` only) |
| `/about`, `/contribute`, `/privacy`, `/legal`, `/favorites` | 200, canonical **`…/about/`** ≠ sitemap `…/about` | 200, canonical **`…/about`** = sitemap |
| `/codes/`, `/tools/`, `/search/`, `/codes/steane-code/`, `/circuits/1/` | **200** — duplicate page, canonical `…/codes/` | **301** → `/codes` |
| `/about/`, `/contribute/`, `/privacy/`, `/legal/`, `/favorites/` | 200, canonical `…/about/` | **301** → `/about` |
| `/search/?q=steane`, `/api/search/?q=steane` | 200, canonical `…/search/` | **301** → `/search?q=steane` (query preserved on the redirect) |
| `/sitemap.xml`, `/robots.txt`, `/llms.txt`, `/api/search?q=steane` | 200 | 200 (unchanged) |
| `/sitemap.xml/`, `/robots.txt/`, `/llms.txt/` | 404 | **301** → `/sitemap.xml` |
| `/nope` | 404, canonical `…/404/` | 404, canonical `…/404` |
| `/nope/` | 404 | **301** → `/nope` → 404 |

No route broke. 12 trailing-slash variants that used to serve a duplicate 200 and 4 that used to 404 now all `301` to the slash-free URL with the query string intact (`/search/?q=steane%20code&tag=x` → `/search?q=steane%20code&tag=x`). Canonical, `og:url` and `sitemap.xml` agree on one URL per page, prerendered and SSR alike — the fallback to normalising the canonical string alone was not needed.

## 2. `SearchAction` pointed at a `Disallow`ed path

`Layout.astro` advertised `${siteUrl}/search?q={search_term_string}` while `robots.txt.ts` disallows `/search` for every agent — deliberately: the `?q=` key space is unbounded. Both landed in `0abfe8c5`, whose PR body justifies the `Disallow` and never mentions the markup contradicting it. Removed the `potentialAction` rather than un-disallowing `/search`: Google retired the sitelinks searchbox it fed in November 2024, so it was inert either way.

## 3. `/tools` passed no `jsonLd`

Its exact sibling `/codes` has carried `CollectionPage` + `ItemList` + `BreadcrumbList` since the JSON-LD went in, and CLAUDE.md asks for matching `jsonLd` when an entity page type is added. Mirrored. The `ItemList` enumerates the **unfiltered** 11 tools — `?tag=` filters this page server-side but every variant canonicalises to `/tools` — and each item links to its anchor, since tools have no page of their own (`ToolCard` already renders `id={tool.slug}`). Not added to `/search`, which is `Disallow`ed by policy, so structured data there would never be read.

## 4. Parameters printed twice — now fixed at all eight sites

"Gottesman [[8,3,3]] Code [[8,3,3]]", "[[20,2,6]] Code [[20,2,6]]". The guard tested `name === params`, which only catches a name that is *nothing but* its parameters: of the 5 codes whose name contains them, 3 are exactly them, so 2 doubled.

It had been written out by hand at **eight** call sites, and the first pass of this PR corrected three of them — leaving the dropdown naming a code once and the page it links to naming it twice. There is now one predicate, `showCodeParams` / `codeDisplayName`, beside `formatCodeParams` in `queries/codes.ts`, and all eight call it: the `<title>`, the `<h1>`, the meta description, the two JSON-LD `name` fields (code page + `/codes` ItemList), `CodeCard`, `llms.txt`, `/api/search` and the `/search` code filter.

Verified on the built server: **all 84 code page titles, 0 doubled**; `/codes` and its ItemList, `llms.txt`, `/api/search?q=gottesman` (`"params": ""`) and the `/search` filter option all name it once; and "Steane Code [[7,1,3]]" plus the bare "[[16,2,4]]" still render exactly once, so nothing regressed for the other 82.

## 5. `/search` printed two empty states

"No circuits found for X" from the count line, then "No circuits match this query." three lines below. One empty state now — the centred block, the same shape `/tools` and `/codes` use — and it carries everything the removed line did:

- the query **as resolved** (a spelling correction rewrites it): `No circuits match zzzzqqqqww.`
- whether the filters are to blame: `No circuits match steane with these filters.` + `Clear filters`
- the escape hatch from a correction, which moved here: `Corrected from steene. Search instead for steene.`

The three result-set notices ("Showing results for…", relatedOnly, partial) are suppressed when there is no result set — `/search?q=steene&tag=nonexistent-tag` used to render "Showing results for steane." directly above "No circuits match", telling the user two opposite things. They are unchanged when there *are* results (verified both ways).

## 6. Header quick-search: no sequencing, no error handling

`doSearch` awaited `fetch` and `res.json()` and wrote `innerHTML` unconditionally, called from a `setTimeout` with its promise dropped — so a slow response could overwrite a newer one, and a 5xx (HTML body → `res.json()` rejects) threw where nothing could catch it. Added a module-scope generation counter, an `res.ok` check and a `try`/`catch` — and **`hide()` bumps the counter too**, so dismissing is as final as typing on: an in-flight response cannot reopen a dropdown closed with Escape or an outside click, nor answer a query backspaced below the two-character floor (that path calls `hide()`).

Verified in a browser by holding responses open and releasing them in a chosen order, so nothing depends on timing:

| scenario | result |
| --- | --- |
| older response released last | list still shows the newer query's results |
| Escape while in flight, then the response lands | list stays hidden, contents unchanged |
| `ste` → backspace to `s`, then the `ste` response lands | nothing rendered |
| 500 with an HTML body | previous list kept, **no unhandled rejection** |
| next keystroke after the 500 | recovers |

## 7. `aria-activedescendant` outlived the option it named

Pre-existing, in the function rewritten above: `resultsList.innerHTML = ""` reset `activeIndex` but left the attribute pointing at `search-result-0-2` after that node was gone. Cleared alongside `activeIndex`. Verified: arrow to result 3, then a one-result list arrives → the attribute is absent rather than naming a dead node.

## 8. Ten unguarded `localStorage` calls — and writes that must not lie

Where storage is denied (Chrome "block all cookies", some embedded webviews) every access throws `SecurityError` — **reads included** — so these were thrown exceptions mid-module, not lost preferences. The worst was `codes/[code].astro`, where the favourites-filter read sits above the "download all" wiring.

`src/lib/safe-storage.ts` wraps get/set; the two `is:inline` scripts that cannot import it (the theme, the search-filter disclosure) inline the same try/catch.

**A dropped write is not always harmless, and the first pass of this PR made it look that way.** Swallowing it is right for a theme or a tag view and wrong for the user's own list: `importFavorites` counts a merge it performs in memory, so a swallowed write would have toasted "Imported 3 new favorites" and called `location.reload()`, dropping the user back on an empty page with nothing to explain it — worse than the pre-PR throw. `setItem` now returns a boolean, the favourite writes turn `false` into `StorageBlockedError`, and the import's catch distinguishes that from a malformed file. The toast is raised inside `favorites-client` rather than at each call site, so the hearts in `CircuitRow.astro` explain themselves without that file changing.

Proved by serving the built site through a proxy that makes `localStorage` throw before any page script runs:

- `/codes/steane-code`: 81 rows render, **zero page errors**, favourites filter, theme and tag-view toggles all respond, "Download all" still fetches `/api/download?code=steane-code`.
- `/search`: results render, the filter disclosure keeps its toggle listener.
- `/favorites`: importing a real `File` through the real `<input type=file>` toasts *"Couldn't save — this browser is blocking site storage…"*, claims **no** count, and does **not** reload.
- hearts on `/codes/steane-code` and `/circuits/1`: unchanged markup after the click, with the storage toast shown.

And with storage working, unchanged from `main`: the import stores `[101,102,103]`, reloads, renders 3 rows; a heart round-trips `[190]` → `[]` with no toast.

## Pre-existing hazards found while verifying — flagged, not fixed

- **`HEAD /codes/` answers 308 while `GET /codes/` answers 301.** Adapter behaviour, newly *exposed* by the trailing-slash redirects rather than introduced by them. Both are permanent redirects to the same target, so no crawler is misled; noted in case the asymmetry matters to someone later.
- **`src/pages/index.astro:39`'s `Astro.redirect(…, 301)` is cached for a week.** It sets no `Cache-Control`, so `middleware.ts` stamps `s-maxage=604800` on it — a genuinely sticky cached 301 at the edge (`/?tag=CSS` → `/codes?tag=CSS`, verified). The router redirects this PR adds carry **no** `Cache-Control` at all, so they are not affected. Left alone: it predates this PR and fixing it is a caching-policy decision.
- **Escape does nothing while the dropdown is empty.** The `Escape` branch in `SearchBar`'s keydown handler sits below an `if (items.length === 0) return` guard that predates this PR, so a first-ever query cannot be dismissed mid-flight. Out of scope here (keyboard handling belongs to the search-shortcuts work); the generation counter closes every path that *can* dismiss today.

## Shared files

`Layout.astro`, `search.astro` and `SearchBar.astro` are shared with other agents. The diff in them is strictly the concerns above: the canonical normalisation and the `SearchAction` removal (Layout); the display name, the empty state and the inline storage guards (search.astro); request sequencing, error handling and one stale `aria-activedescendant` (SearchBar).

`CodeCard.astro` and `codes/[code].astro` are touched **only** for the display name (§4) — no ARIA attribute, no colour or contrast class, anywhere in this diff. `CircuitRow.astro`, `FormatSwitcher.astro`, `about.astro`, `data_yaml/`, `scripts/`, `pyproject.toml`'s tooling config, the CIRQ format and `crumble_url`/`quirk_url` are untouched; the hearts in `CircuitRow` pick up the storage message from `favorites-client` without that file changing.

## Checks

`npm run typecheck` (0 errors), `npm run lint`, `npm run format:check`, `npm run build`, `npm run validate:yaml`, and `SKIP=prettier uvx pre-commit run --all-files` — all pass, 0 files modified, re-run after the second commit. Version bumped 0.7.11 → 0.7.13 (`package.json`, `pyproject.toml`, `uv.lock`, `package-lock.json`) with the CHANGELOG entry under Unreleased kept in step. No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
