### PR TITLE
fix(a11y): stop the circuit row claiming to be a button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,53 @@ a copy of the database or parsing the YAML will need the columns removed.
 
 ### Fixed
 
+- **A circuit row announced itself as a button that does something else.** It carried
+  `role="button"`, `tabindex="0"` and `aria-expanded="false"`, so a screen reader said
+  "button, collapsed" — and then `Enter` on it navigated to the circuit page. `l`, Space and
+  a mouse click expanded; the one key the announced role promises did not. That is WCAG
+  4.1.2: the name, role and state have to describe what the thing actually does, and here
+  the role described a toggle that only some of the row implements.
+  `role="button"` also carries ARIA's _Children Presentational: True_ — a button's contents
+  are a label, not controls — so the row's eight interactive descendants (the permalink, the
+  favourite toggle, the detail link and five tag links) were stripped of their own roles and
+  folded into the row's accessible name, a 149-character run of
+  `#190G: 112Q: 8D: 3Q: 7Circuit-Synth Zero State Preparation…1D-AODlogical-state:zero…`.
+  Every affordance in the row existed for a mouse and for nobody else.
+  The row now claims nothing it does not do:
+  - **`role="group"` with a name** (`Circuit #190: <name>`), not a bare focusable `div`. It
+    still has to be focusable — `j`/`k` move between rows by focusing them — and something
+    focusable with no role announces as an unnamed container. `group` names it, and, unlike
+    `button`, does not flatten what is inside it: all eight descendants are individually
+    exposed again, and the row's own name is 76 characters that say which circuit it is.
+  - **The chevron is a real `<button>`**, which is the only element here that _is_ a toggle,
+    and it owns `aria-expanded` plus an `aria-controls` pointing at the panel. Its name is
+    fixed ("Circuit #190 details") rather than flipping between "Expand" and "Collapse":
+    `aria-expanded` already carries the state, and a name that repeats it says the same
+    thing twice. It has no click handler of its own — the click bubbles to the row's
+    existing one — so it cannot toggle twice, and there is one implementation, not two.
+  - **No documented keyboard behaviour changed.** `Enter` still navigates, `l`/`h`/Space
+    still expand and collapse, `j`/`k` still move, `f` still favourites, and clicking
+    anywhere on the row still expands it. `Enter` on the chevron toggles instead of
+    navigating, which is what a focused button should do.
+- **Two page scripts selected the open row by its `aria-expanded`, and would have died
+  silently.** `[id] > .circuit-toggle[aria-expanded="true"] + .circuit-detail` is how
+  `/codes/[code]` and `/search` find the row that `1`/`2`/`3`, `c`/`y` and `d` act on, and
+  `circuit-bodies-client` uses the same shape to load bodies for a row already expanded by a
+  `#id` deep link. Moving `aria-expanded` onto the chevron would have left all three
+  matching nothing, with no error and no test to catch it. The row therefore mirrors the
+  state in `data-expanded`, all three selectors read that, and `list-keynav`'s
+  `expandedAttr` is pointed at it on both pages. The split is deliberate rather than
+  incidental: ARIA describes the control to assistive technology, a data attribute is what
+  page scripts are allowed to depend on, and one function (`setExpanded`) writes both plus
+  the chevron rotation so they cannot drift.
+- **Giving the panel an `id` broke the "collapse the other rows" loop**, and only in the
+  state nobody looks at. `aria-controls` needs a target id, and the loop found each other
+  row's header with `panel.closest("[id]")` — which starts at the element itself, so it now
+  returned the panel, found no header under it, and left that row's `data-expanded`,
+  `aria-expanded` and chevron all saying "open" while the panel was visibly shut. Two rows
+  then matched the "open row" selector and `1`/`2`/`3` would have acted on the wrong one. It
+  walks to `previousElementSibling` now. Found by checking the collapsed row's attributes in
+  a browser after the change, not by anything that would have shown on screen.
 - **Every keypress on `/search` threw a `TypeError`.** `initCircuitActions()` was called with
   no argument, so `findActiveContainer()` read `config.activeContainerSelector` off
   `undefined` on any key that reached it. The page still worked: the throw is confined to

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qecirc-website",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qecirc-website",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
         "@astrojs/node": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qecirc-website",
   "type": "module",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "license": "MIT",
   "scripts": {
     "dev": "astro dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qecirc-website"
-version = "0.8.0"
+version = "0.8.1"
 description = "QECirc — quantum error correction circuit library"
 license = "MIT"
 requires-python = ">=3.13"

--- a/src/components/CircuitRow.astro
+++ b/src/components/CircuitRow.astro
@@ -43,6 +43,9 @@ const rowMetrics = JSON.stringify({
 });
 const rowTags = JSON.stringify(circuit.tags);
 const anchorId = String(circuit.qec_id);
+// The expand button's aria-controls target. Distinct from the row's own
+// id (= the bare qec_id, which the URL fragment points at).
+const detailId = `circuit-detail-${anchorId}`;
 
 const stimFilename = buildStimFilename({
   codeSlug: codeSlug,
@@ -62,25 +65,55 @@ const stimFilename = buildStimFilename({
   data-metrics={rowMetrics}
   data-tags={rowTags}
 >
+  {/* role="group", not role="button". The row is focusable (j/k navigate
+      between rows) and clicking it expands, but Enter on it *navigates* to the
+      circuit page — so announcing "button, collapsed" promised a toggle the
+      row does not implement (WCAG 4.1.2). role="button" also carries ARIA's
+      Children Presentational: True, which dropped the semantics of all eight
+      interactive descendants (permalink, favourite, detail link, tag links)
+      and flattened them into one 149-character accessible name. `group` names
+      the row without either claim, and does not flatten its children.
+
+      Expansion state lives in TWO places on purpose: `aria-expanded` on the
+      chevron button, which is the only element that actually claims to be a
+      toggle, and `data-expanded` here, which is what page scripts select the
+      open row by (`[data-expanded="true"] + .circuit-detail`). Selecting on
+      the button's ARIA instead would put a page script's behaviour at the
+      mercy of an accessibility attribute; both are set together in one place,
+      `setExpanded()` below. */}
   <div
     class="circuit-toggle w-full text-left px-4 py-3 grid items-center gap-x-1.5 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-inset"
     style="grid-template-columns: var(--circuit-grid);"
-    role="button"
+    role="group"
+    aria-label={`Circuit ${displayId}: ${circuit.name}`}
     tabindex="0"
     data-qec-id={anchorId}
-    aria-expanded="false"
+    data-expanded="false"
     data-list-row
   >
-    <svg
-      class="chevron w-4 h-4 shrink-0 text-gray-400 transition-transform duration-200"
-      fill="none"
-      stroke="currentColor"
-      stroke-width="2"
-      viewBox="0 0 24 24"
-      aria-hidden="true"
+    {/* The accessible name is fixed and `aria-expanded` carries the state, so
+        a screen reader says "Circuit #190 details, collapsed, button". A name
+        that flipped between "Expand"/"Collapse" would say the same thing
+        twice, and gives one more thing to keep in sync. Sized to the 1rem
+        chevron track (--circuit-grid) so the row layout is unchanged. */}
+    <button
+      type="button"
+      class="circuit-expand-btn w-4 h-4 shrink-0 flex items-center justify-center text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 cursor-pointer rounded-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+      aria-label={`Circuit ${displayId} details`}
+      aria-expanded="false"
+      aria-controls={detailId}
     >
-      <path d="M9 5l7 7-7 7" />
-    </svg>
+      <svg
+        class="chevron w-4 h-4 shrink-0 transition-transform duration-200"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <path d="M9 5l7 7-7 7" />
+      </svg>
+    </button>
 
     <button
       class="circuit-permalink text-gray-500 dark:text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 font-mono text-xs shrink-0 cursor-pointer"
@@ -164,7 +197,7 @@ const stimFilename = buildStimFilename({
        leaves every control inside it tabbable, so a keyboard user tabbing past
        a collapsed row fell into buttons and links they could not see. It must
        be kept in step with max-height by every handler that toggles one. -->
-  <div class="circuit-detail overflow-hidden transition-[max-height] duration-300 ease-in-out" style="max-height: 0px;" data-circuit-scope inert>
+  <div id={detailId} class="circuit-detail overflow-hidden transition-[max-height] duration-300 ease-in-out" style="max-height: 0px;" data-circuit-scope inert>
     <div class="border-t border-gray-200 dark:border-gray-800 px-4 py-4 space-y-3">
       <div class="flex flex-wrap items-center gap-x-6 gap-y-1 text-sm">
         <div>
@@ -251,11 +284,24 @@ const stimFilename = buildStimFilename({
 <script>
   import { copyToClipboard, setFavState } from "../lib/dom-helpers";
 
+  // The single place expansion state is written. `data-expanded` on the row is
+  // what page scripts select the open row by; `aria-expanded` on the chevron
+  // button is what a screen reader reads; the chevron rotation is what everyone
+  // else sees. They must never disagree — see the markup comment above.
+  function setExpanded(toggle: HTMLElement, open: boolean) {
+    toggle.dataset.expanded = String(open);
+    toggle.querySelector(".circuit-expand-btn")?.setAttribute("aria-expanded", String(open));
+    toggle.querySelector(".chevron")?.classList.toggle("rotate-90", open);
+  }
+
   function initCircuitRows() {
     document.querySelectorAll(".circuit-toggle").forEach(function (btn) {
       if ((btn as HTMLElement).dataset.initialized) return;
       (btn as HTMLElement).dataset.initialized = "1";
 
+      // The chevron button is deliberately NOT in the guard list below: it has
+      // no click handler of its own, so its click bubbles to here and toggles
+      // exactly once, through the same code path a click on the row takes.
       btn.addEventListener("click", function (e) {
         if ((e.target as HTMLElement).closest(".circuit-tag")) return;
         if ((e.target as HTMLElement).closest(".circuit-code-link")) return;
@@ -266,7 +312,6 @@ const stimFilename = buildStimFilename({
         const qecId = (btn as HTMLElement).dataset.qecId!;
         const row = btn.closest("[id]") as HTMLElement;
         const detail = row.querySelector(".circuit-detail") as HTMLElement;
-        const chevron = btn.querySelector(".chevron") as HTMLElement;
         const isOpen = detail.style.maxHeight !== "0px";
 
         if (isOpen) {
@@ -274,8 +319,7 @@ const stimFilename = buildStimFilename({
           // Clipped content stays tabbable without this — see the inert note
           // on .circuit-detail in the markup above.
           detail.inert = true;
-          chevron.classList.remove("rotate-90");
-          btn.setAttribute("aria-expanded", "false");
+          setExpanded(btn as HTMLElement, false);
           if (location.hash === "#" + qecId) {
             history.replaceState(null, "", location.pathname + location.search);
           }
@@ -285,17 +329,21 @@ const stimFilename = buildStimFilename({
             if (d !== detail) {
               (d as HTMLElement).style.maxHeight = "0px";
               (d as HTMLElement).inert = true;
-              const otherBtn = (d as HTMLElement).closest("[id]")?.querySelector(".circuit-toggle");
-              if (otherBtn) {
-                otherBtn.querySelector(".chevron")?.classList.remove("rotate-90");
-                otherBtn.setAttribute("aria-expanded", "false");
+              // `previousElementSibling`, not `closest("[id]")`: the panel
+              // carries its own id now (the button's aria-controls target),
+              // and closest() starts at the element itself — so it returned
+              // the panel, found no .circuit-toggle under it, and left the
+              // other row's chevron and data-expanded saying "open" while it
+              // was visibly shut.
+              const otherBtn = (d as HTMLElement).previousElementSibling;
+              if (otherBtn?.classList.contains("circuit-toggle")) {
+                setExpanded(otherBtn as HTMLElement, false);
               }
             }
           });
           detail.inert = false;
           detail.style.maxHeight = detail.scrollHeight + "px";
-          chevron.classList.add("rotate-90");
-          btn.setAttribute("aria-expanded", "true");
+          setExpanded(btn as HTMLElement, true);
           history.replaceState(null, "", "#" + qecId);
           // Signal circuit-bodies-client (code pages) to lazy-load bodies.
           detail.dispatchEvent(new CustomEvent("circuit-expand", { bubbles: true }));
@@ -330,7 +378,7 @@ const stimFilename = buildStimFilename({
     const target = document.getElementById(hash);
     if (!target) return;
     const btn = target.querySelector(".circuit-toggle") as HTMLElement;
-    if (btn && btn.getAttribute("aria-expanded") !== "true") {
+    if (btn && btn.dataset.expanded !== "true") {
       btn.click();
       target.scrollIntoView({ behavior: "smooth", block: "start" });
     }

--- a/src/lib/circuit-actions-client.ts
+++ b/src/lib/circuit-actions-client.ts
@@ -8,7 +8,13 @@
 //
 // "Active" depends on context: on a circuit detail page there is exactly one
 // body; on a code page (with multiple expandable rows) it is the row whose
-// `.circuit-toggle` has `aria-expanded="true"`.
+// `.circuit-toggle` has `data-expanded="true"`. That is deliberately a data
+// attribute and not `aria-expanded`: the row is not the toggle — the chevron
+// button inside it is, and it owns the ARIA — so a page script that selected
+// on the ARIA would break the moment the row's semantics were corrected. It
+// did: `role="button"` + `aria-expanded` on the row announced a toggle that
+// Enter does not perform (Enter navigates), and flattened the row's eight
+// interactive descendants.
 //
 // All bindings reuse the existing click handlers on the underlying buttons,
 // so no copy/download/format logic is duplicated here.

--- a/src/lib/circuit-bodies-client.ts
+++ b/src/lib/circuit-bodies-client.ts
@@ -224,7 +224,7 @@ export function initCircuitBodies(): void {
   // module execution order between component and page scripts isn't
   // guaranteed. Load bodies for any already-expanded row now.
   document
-    .querySelectorAll<HTMLElement>('.circuit-toggle[aria-expanded="true"] + .circuit-detail')
+    .querySelectorAll<HTMLElement>('.circuit-toggle[data-expanded="true"] + .circuit-detail')
     .forEach(function (detail) {
       const container = detail.querySelector<HTMLElement>(".circuit-bodies");
       if (container) void loadBodies(container, template);

--- a/src/lib/list-keynav-client.ts
+++ b/src/lib/list-keynav-client.ts
@@ -23,6 +23,9 @@ export interface ListKeynavConfig {
   expandSelfClick?: boolean;
   expandSelector?: string;
   // Attribute on the row that reflects expansion state. Default: aria-expanded.
+  // `CircuitRow` passes `data-expanded`: there, `aria-expanded` lives on the
+  // chevron button (the only element that claims to be a toggle), and the row
+  // mirrors the state in a data attribute for scripts to read.
   expandedAttr?: string;
   // If true, f triggers a click on `favoriteSelector` inside the focused row.
   favoritable?: boolean;

--- a/src/pages/codes/[code].astro
+++ b/src/pages/codes/[code].astro
@@ -296,13 +296,16 @@ const jsonLd = [
     // toggle, so /codes/foo#42 focuses (and the existing expandFromHash
     // handler expands) the right row.
     hashAttr: "data-qec-id",
+    // The row is not the toggle: `aria-expanded` belongs to the chevron button
+    // inside it, and the row mirrors the state in `data-expanded`.
+    expandedAttr: "data-expanded",
   });
 
   // 1/2/3 + c/y + d target the currently expanded circuit row (if any);
   // Shift+D triggers the page-level "download all visible" button.
   initCircuitActions({
     activeContainerSelector:
-      '[id] > .circuit-toggle[aria-expanded="true"] + .circuit-detail',
+      '[id] > .circuit-toggle[data-expanded="true"] + .circuit-detail',
     downloadAllSelector: "#download-all-btn",
   });
 

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -337,7 +337,7 @@ Astro.response.headers.set("Cache-Control", "public, max-age=0, s-maxage=600");
   // raised a TypeError off `undefined`.
   initCircuitActions({
     activeContainerSelector:
-      '[id] > .circuit-toggle[aria-expanded="true"] + .circuit-detail',
+      '[id] > .circuit-toggle[data-expanded="true"] + .circuit-detail',
   });
 
   // Tags apply the moment they are clicked (they are plain links), so the code
@@ -355,5 +355,7 @@ Astro.response.headers.set("Cache-Control", "public, max-age=0, s-maxage=600");
     favoritable: true,
     favoriteSelector: "[data-list-fav]",
     hashAttr: "data-qec-id",
+    // See the code page: the row mirrors the chevron button's aria-expanded.
+    expandedAttr: "data-expanded",
   });
 </script>

--- a/uv.lock
+++ b/uv.lock
@@ -829,7 +829,7 @@ wheels = [
 
 [[package]]
 name = "qecirc-website"
-version = "0.8.0"
+version = "0.8.1"
 source = { virtual = "." }
 dependencies = [
     { name = "mqt-qecc" },


### PR DESCRIPTION
## The defect

`CircuitRow`'s row element carried `role="button"`, `tabindex="0"` and `aria-expanded="false"`. A screen reader therefore announced **"button, collapsed"** — and then `Enter` on that row *navigates to the circuit page* (`list-keynav`'s `enterSelector`), while `l`, Space and a mouse click expand. The announced role and state promised a toggle the row only partly implements: **WCAG 4.1.2**.

`role="button"` also carries ARIA's *Children Presentational: True* — a button's contents are a label, not controls — so the row's **eight interactive descendants** (permalink, favourite, detail link, five tag links) lost their own roles and were folded into the row's accessible name:

```
before: button, name = "#190G: 112Q: 8D: 3Q: 7Circuit-Synth Zero State Preparation
        (Depth-Optimized, 1D-AOD)1D-AODlogical-state:zeronon-ftstate-preparation
        tool:circuit-synth"                                        (149 characters)
after:  group, name = "Circuit #190: Circuit-Synth Zero State Preparation
        (Depth-Optimized, 1D-AOD)"                                  (76 characters)
          button "Circuit #190 details"  (aria-expanded, aria-controls)
          button "Copy link to circuit"
          button "Toggle favorite"
          link   "/circuits/190"
          link   "1D-AOD" · "logical-state:zero" · "non-ft" · "state-preparation" · "tool:circuit-synth"
```

## The fix

- **The row stops claiming to be a button.** It is `role="group"` with a name (`Circuit #190: <name>`). It has to stay focusable — `j`/`k` navigate by focusing rows — and a focusable element with no role announces as an unnamed container; `group` names it and, unlike `button`, does not flatten what is inside it.
- **The chevron is a real `<button>`** — the only element here that *is* a toggle — owning `aria-expanded` and `aria-controls`. Its name is fixed ("Circuit #190 details") rather than flipping Expand/Collapse: `aria-expanded` already carries the state. It has **no click handler of its own**; the click bubbles to the row's existing handler, so it cannot toggle twice and there is one implementation, not two.
- **No documented keyboard behaviour changes.** `Enter` navigates, `l`/`h`/Space expand and collapse, `j`/`k` move, `f` favourites, clicking anywhere on the row expands. `Enter` on the chevron toggles rather than navigating, which is what a focused button should do.

## The selector trap

`[id] > .circuit-toggle[aria-expanded="true"] + .circuit-detail` is how `/codes/[code]` and `/search` find the row that `1`/`2`/`3`, `c`/`y` and `d` act on, and `circuit-bodies-client` uses the same shape for a row already expanded by a `#id` deep link. Moving `aria-expanded` to the chevron would have left all three matching nothing — silently, with no test to catch it.

The row mirrors the state in **`data-expanded`**; all three selectors read that, and `list-keynav`'s `expandedAttr` is pointed at it on both pages. ARIA describes the control to assistive technology; a data attribute is what page scripts may depend on. One function (`setExpanded`) writes `data-expanded`, `aria-expanded` and the chevron rotation together so they cannot drift.

**A second bug fell out of it:** `aria-controls` needs a target id, and giving the panel one broke the "collapse the other rows" loop, which found each header via `panel.closest("[id]")` — `closest()` starts at the element itself, so it returned the panel, found no header, and left that row's `data-expanded`, `aria-expanded` and chevron all saying "open" while the panel was visibly shut. Two rows then matched the open-row selector. Caught by inspecting the collapsed row's attributes in a browser; nothing on screen showed it. It walks `previousElementSibling` now.

## Verified in a browser (`astro preview`, 127.0.0.1), on `/codes/steane-code` **and** `/search?q=steane`

- Accessibility tree: row is `group` with a 76-char name; the toggle button exposes name + `aria-expanded`; all 8 descendants individually exposed again.
- `Enter` on a focused row navigates to `/circuits/190` and `/circuits/90`. `l`/`h` expand and collapse (so `expandedAttr` is wired — `h` is a no-op unless the row reads as expanded). Space expands and collapses. `j`/`k` move, including from a focused chevron. `f` favourites.
- Clicking the row expands; clicking the chevron expands **exactly once**; tag, permalink, favourite, detail-link and id-copy clicks still do their own thing and do not expand.
- `1`/`2`/`3`, `c`/`y`, `d` act on the open row on both pages (verified by intercepting the resulting `.format-tab` / `.copy-btn` / `.download-btn` click and checking which panel it landed in).
- Collapsed panels stay `inert`: a descendant refuses focus while collapsed and accepts it when expanded. Opening a second row fully resets the first.
- Deep link `/codes/steane-code#88` focuses and expands row #88 and lazy-loads its bodies.

Not verifiable with the available automation: the browser tool emits no native activation for Enter/Space on a focused button (a synthetic keydown arrives, no click follows) and cannot emit a real Space at all. Chevron activation was verified by real mouse click and by `.click()`; row-level Space via a dispatched `keydown`.

## Version

0.8.0 → **0.8.1** (patch: non-breaking UI fix) in `package.json`, `pyproject.toml`, `uv.lock`, `package-lock.json`, plus a CHANGELOG entry.

Gates: `npm test`, `typecheck`, `lint`, `format:check`, `build`, `validate:yaml`, and `SKIP=prettier uvx pre-commit run --all-files` (0 files modified) all pass. No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)